### PR TITLE
(WPF) Fixes for use in templates

### DIFF
--- a/src/LiveChartsCore/LineSeries.cs
+++ b/src/LiveChartsCore/LineSeries.cs
@@ -358,6 +358,7 @@ namespace LiveChartsCore
                     visual.Geometry.Y = y - hgs;
                     visual.Geometry.Width = gs;
                     visual.Geometry.Height = gs;
+                    visual.Geometry.RemoveOnCompleted = false;
 
                     data.TargetPoint.Context.HoverArea = new RectangleHoverArea().SetDimensions(x - hgs, y - hgs + 2 * sw, gs, gs + 2 * sw);
 

--- a/src/LiveChartsCore/Measure/Scaler.cs
+++ b/src/LiveChartsCore/Measure/Scaler.cs
@@ -54,6 +54,32 @@ namespace LiveChartsCore.Measure
 
             if (actualBounds == null || actualVisibleBounds == null) throw new Exception("bounds not found");
 
+            if (double.IsInfinity(actualBounds.Delta) || double.IsInfinity(actualVisibleBounds.Delta))
+            {
+                _maxVal = 0;
+                _minVal = 0;
+                _deltaVal = 0;
+
+
+                if (axis.Orientation == AxisOrientation.X)
+                {
+                    _minPx = drawMaringLocation.X;
+                    _maxPx = drawMaringLocation.X + drawMarginSize.Width;
+                    _deltaPx = _maxPx - _minPx;
+                }
+                else
+                {
+                    _minPx = drawMaringLocation.Y;
+                    _maxPx = drawMaringLocation.Y + drawMarginSize.Height;
+                    _deltaPx = _maxPx - _minPx;
+                }
+
+                _m = 0;
+                _mInv = 0;
+
+                return;
+            }
+
             if (axis.Orientation == AxisOrientation.X)
             {
                 _minPx = drawMaringLocation.X;
@@ -114,7 +140,7 @@ namespace LiveChartsCore.Measure
             _m = _deltaPx / _deltaVal;
             _mInv = 1 / _m;
 
-            if (!double.IsNaN(_m)) return;
+            if (!double.IsNaN(_m) && !double.IsInfinity(_m)) return;
             _m = 0;
             _mInv = 0;
         }

--- a/src/LiveChartsCore/RowSeries.cs
+++ b/src/LiveChartsCore/RowSeries.cs
@@ -165,6 +165,7 @@ namespace LiveChartsCore
                 sizedGeometry.Height = uw;
                 sizedGeometry.Rx = rx;
                 sizedGeometry.Ry = ry;
+                sizedGeometry.RemoveOnCompleted = true;
 
                 point.Context.HoverArea = new RectangleHoverArea().SetDimensions(primary, secondary - uwm + cp, b, uw);
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/CartesianChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/CartesianChart.cs
@@ -62,9 +62,9 @@ namespace LiveChartsCore.SkiaSharpView.WPF
             _xObserver = new CollectionDeepObserver<IAxis>(OnDeepCollectionChanged, OnDeepCollectionPropertyChanged, true);
             _yObserver = new CollectionDeepObserver<IAxis>(OnDeepCollectionChanged, OnDeepCollectionPropertyChanged, true);
 
-            XAxes = new List<IAxis>() { new Axis() };
-            YAxes = new List<IAxis>() { new Axis() };
-            Series = new ObservableCollection<ISeries>();
+            SetCurrentValue(XAxesProperty, new List<IAxis>() { new Axis() });
+            SetCurrentValue(YAxesProperty, new List<IAxis>() { new Axis() });
+            SetCurrentValue(SeriesProperty, new ObservableCollection<ISeries>());
 
             MouseWheel += OnMouseWheel;
             MouseDown += OnMouseDown;
@@ -90,6 +90,10 @@ namespace LiveChartsCore.SkiaSharpView.WPF
                         seriesObserver.Initialize((IEnumerable<ISeries>)args.NewValue);
                         if (chart.core == null) return;
                         Application.Current.Dispatcher.Invoke(() => chart.core.Update());
+                    },
+                    (DependencyObject o, object value) =>
+                    {
+                        return value is IEnumerable<ISeries> ? value : new ObservableCollection<ISeries>();
                     }));
 
         /// <summary>
@@ -106,6 +110,10 @@ namespace LiveChartsCore.SkiaSharpView.WPF
                         observer.Initialize((IEnumerable<IAxis>)args.NewValue);
                         if (chart.core == null) return;
                         Application.Current.Dispatcher.Invoke(() => chart.core.Update());
+                    },
+                    (DependencyObject o, object value) =>
+                    {
+                        return value is IEnumerable<IAxis> ? value : new List<IAxis>() { new Axis() };
                     }));
 
         /// <summary>
@@ -122,6 +130,10 @@ namespace LiveChartsCore.SkiaSharpView.WPF
                         observer.Initialize((IEnumerable<IAxis>)args.NewValue);
                         if (chart.core == null) return;
                         Application.Current.Dispatcher.Invoke(() => chart.core.Update());
+                    },
+                    (DependencyObject o, object value) =>
+                    {
+                        return value is IEnumerable<IAxis> ? value : new List<IAxis>() { new Axis() };
                     }));
 
         /// <summary>

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/CartesianChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/CartesianChart.cs
@@ -187,11 +187,23 @@ namespace LiveChartsCore.SkiaSharpView.WPF
             set => SetValue(ZoomModeProperty, value);
         }
 
+        ZoomAndPanMode ICartesianChartView<SkiaSharpDrawingContext>.ZoomMode
+        {
+            get => ZoomMode;
+            set => SetValueOrCurrentValue(ZoomModeProperty, value);
+        }
+
         /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.ZoomingSpeed" />
         public double ZoomingSpeed
         {
             get => (double)GetValue(ZoomingSpeedProperty);
             set => SetValue(ZoomingSpeedProperty, value);
+        }
+
+        double ICartesianChartView<SkiaSharpDrawingContext>.ZoomingSpeed
+        {
+            get => ZoomingSpeed;
+            set => SetValueOrCurrentValue(ZoomingSpeedProperty, value);
         }
 
         #endregion

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/Chart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/Chart.cs
@@ -276,7 +276,7 @@ namespace LiveChartsCore.SkiaSharpView.WPF
             get => Background is not SolidColorBrush b
                     ? new System.Drawing.Color()
                     : System.Drawing.Color.FromArgb(b.Color.A, b.Color.R, b.Color.G, b.Color.B);
-            set => Background = new SolidColorBrush(System.Windows.Media.Color.FromArgb(value.A, value.R, value.G, value.B));
+            set => SetValueOrCurrentValue(BackgroundProperty, new SolidColorBrush(System.Windows.Media.Color.FromArgb(value.A, value.R, value.G, value.B)));
         }
 
         /// <inheritdoc cref="IChartView.DrawMargin" />
@@ -285,6 +285,13 @@ namespace LiveChartsCore.SkiaSharpView.WPF
             get => (Margin)GetValue(DrawMarginProperty);
             set => SetValue(DrawMarginProperty, value);
         }
+
+        Margin? IChartView.DrawMargin
+        {
+            get => DrawMargin;
+            set => SetValueOrCurrentValue(DrawMarginProperty, value);
+        }
+
         SizeF IChartView.ControlSize => canvas == null
                     ? throw new Exception("Canvas not found")
                     : (new() { Width = (float)canvas.ActualWidth, Height = (float)canvas.ActualHeight });
@@ -299,11 +306,23 @@ namespace LiveChartsCore.SkiaSharpView.WPF
             set => SetValue(AnimationsSpeedProperty, value);
         }
 
+        TimeSpan IChartView.AnimationsSpeed
+        {
+            get => AnimationsSpeed;
+            set => SetValueOrCurrentValue(AnimationsSpeedProperty, value);
+        }
+
         /// <inheritdoc cref="IChartView.EasingFunction" />
         public Func<float, float> EasingFunction
         {
             get => (Func<float, float>)GetValue(EasingFunctionProperty);
             set => SetValue(EasingFunctionProperty, value);
+        }
+
+        Func<float, float> IChartView.EasingFunction
+        {
+            get => EasingFunction;
+            set => SetValueOrCurrentValue(EasingFunctionProperty, value);
         }
 
         /// <inheritdoc cref="IChartView.LegendPosition" />
@@ -313,11 +332,23 @@ namespace LiveChartsCore.SkiaSharpView.WPF
             set => SetValue(LegendPositionProperty, value);
         }
 
+        LegendPosition IChartView.LegendPosition
+        {
+            get => LegendPosition;
+            set => SetValueOrCurrentValue(LegendPositionProperty, value);
+        }
+
         /// <inheritdoc cref="IChartView.LegendOrientation" />
         public LegendOrientation LegendOrientation
         {
             get => (LegendOrientation)GetValue(LegendOrientationProperty);
             set => SetValue(LegendOrientationProperty, value);
+        }
+
+        LegendOrientation IChartView.LegendOrientation
+        {
+            get => LegendOrientation;
+            set => SetValueOrCurrentValue(LegendOrientationProperty, value);
         }
 
         /// <inheritdoc cref="IChartView.TooltipPosition" />
@@ -327,11 +358,23 @@ namespace LiveChartsCore.SkiaSharpView.WPF
             set => SetValue(TooltipPositionProperty, value);
         }
 
+        TooltipPosition IChartView.TooltipPosition
+        {
+            get => TooltipPosition;
+            set => SetValueOrCurrentValue(TooltipPositionProperty, value);
+        }
+
         /// <inheritdoc cref="IChartView.TooltipFindingStrategy" />
         public TooltipFindingStrategy TooltipFindingStrategy
         {
             get => (TooltipFindingStrategy)GetValue(TooltipFindingStrategyProperty);
             set => SetValue(TooltipFindingStrategyProperty, value);
+        }
+
+        TooltipFindingStrategy IChartView.TooltipFindingStrategy
+        {
+            get => TooltipFindingStrategy;
+            set => SetValueOrCurrentValue(TooltipFindingStrategyProperty, value);
         }
 
         /// <summary>
@@ -598,6 +641,20 @@ namespace LiveChartsCore.SkiaSharpView.WPF
         private void OnCoreMeasuring(IChartView<SkiaSharpDrawingContext> chart)
         {
             Measuring?.Invoke(this);
+        }
+
+        /// <summary>
+        /// Sets the local value of a dependency property, specified by its dependency property identifier.
+        /// If the object has not yet finished initializing, does so without changing its value source.
+        /// </summary>
+        /// <param name="dp">The identifier of the dependency property to set.</param>
+        /// <param name="value">The new local value.</param>
+        protected void SetValueOrCurrentValue(DependencyProperty dp, object value)
+        {
+            if (IsInitialized)
+                SetValue(dp, value);
+            else
+                SetCurrentValue(dp, value);
         }
     }
 }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/DefaultTooltip.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/DefaultTooltip.xaml.cs
@@ -44,8 +44,8 @@ namespace LiveChartsCore.SkiaSharpView.WPF
         public DefaultTooltip()
         {
             InitializeComponent();
-            PopupAnimation = PopupAnimation.Fade;
-            Placement = PlacementMode.Relative;
+            SetCurrentValue(PopupAnimationProperty, PopupAnimation.Fade);
+            SetCurrentValue(PlacementProperty, PlacementMode.Relative);
             _defaultTempalte = (DataTemplate)FindResource("defaultTemplate");
         }
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/PieChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/PieChart.cs
@@ -58,7 +58,7 @@ namespace LiveChartsCore.SkiaSharpView.WPF
                     Application.Current.Dispatcher.Invoke(() => core.Update());
                 });
 
-            Series = new ObservableCollection<ISeries>();
+            SetCurrentValue(SeriesProperty, new ObservableCollection<ISeries>());
         }
 
         /// <summary>
@@ -75,6 +75,10 @@ namespace LiveChartsCore.SkiaSharpView.WPF
                         seriesObserver.Initialize((IEnumerable<ISeries>)args.NewValue);
                         if (chart.core == null) return;
                         Application.Current.Dispatcher.Invoke(() => chart.core.Update());
+                    },
+                    (DependencyObject o, object value) =>
+                    {
+                        return value is IEnumerable<ISeries> ? value : new ObservableCollection<ISeries>();
                     }));
 
         PieChart<SkiaSharpDrawingContext> IPieChartView<SkiaSharpDrawingContext>.Core => core == null ? throw new Exception("core not found") : (PieChart<SkiaSharpDrawingContext>)core;


### PR DESCRIPTION
Use of SetValue during initialization prevented templates from setting their own values on those properties.
Replaced property assignments with calls to SetCurrentValue, and added explicit interface implementations that use SetCurrentValue during initialization.

Added CoerceValueCallback to the Series and Axes properties to ensure they are not set to null.