### PR TITLE
Clean up

### DIFF
--- a/samples/AvaloniaSample/App.axaml.cs
+++ b/samples/AvaloniaSample/App.axaml.cs
@@ -1,4 +1,3 @@
-
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;

--- a/samples/AvaloniaSample/Bars/AutoUpdate/View.axaml.cs
+++ b/samples/AvaloniaSample/Bars/AutoUpdate/View.axaml.cs
@@ -17,9 +17,9 @@ namespace AvaloniaSample.Bars.AutoUpdate
         private async void ButtonClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
         {
             var vm = (ViewModel?)DataContext;
-            if (vm == null) return;
+            if (vm is null) return;
 
-            isStreaming = isStreaming == null ? true : !isStreaming;
+            isStreaming = isStreaming is null ? true : !isStreaming;
 
             while (isStreaming.Value)
             {

--- a/samples/AvaloniaSample/Bars/Race/View.axaml.cs
+++ b/samples/AvaloniaSample/Bars/Race/View.axaml.cs
@@ -17,7 +17,7 @@ namespace AvaloniaSample.Bars.Race
         public async void Update()
         {
             var vm = (ViewModel?)DataContext;
-            if (vm == null) return;
+            if (vm is null) return;
             while (true)
             {
                 await Dispatcher.UIThread.InvokeAsync(vm.RandomIncrement, DispatcherPriority.Background);

--- a/samples/AvaloniaSample/Lines/AutoUpdate/View.axaml.cs
+++ b/samples/AvaloniaSample/Lines/AutoUpdate/View.axaml.cs
@@ -17,9 +17,9 @@ namespace AvaloniaSample.Lines.AutoUpdate
         private async void ButtonClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
         {
             var vm = (ViewModel?)DataContext;
-            if (vm == null) return;
+            if (vm is null) return;
 
-            isStreaming = isStreaming == null ? true : !isStreaming;
+            isStreaming = isStreaming is null ? true : !isStreaming;
 
             while (isStreaming.Value)
             {

--- a/samples/AvaloniaSample/MainWindow.axaml.cs
+++ b/samples/AvaloniaSample/MainWindow.axaml.cs
@@ -1,8 +1,6 @@
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
-using LiveChartsCore;
-using LiveChartsCore.SkiaSharpView;
 using System;
 
 namespace AvaloniaSample

--- a/samples/AvaloniaSample/Maps/World/View.axaml.cs
+++ b/samples/AvaloniaSample/Maps/World/View.axaml.cs
@@ -20,7 +20,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 

--- a/samples/AvaloniaSample/Pies/AutoUpdate/View.axaml.cs
+++ b/samples/AvaloniaSample/Pies/AutoUpdate/View.axaml.cs
@@ -17,9 +17,9 @@ namespace AvaloniaSample.Pies.AutoUpdate
         private async void ButtonClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
         {
             var vm = (ViewModel?)DataContext;
-            if (vm == null) return;
+            if (vm is null) return;
 
-            isStreaming = isStreaming == null ? true : !isStreaming;
+            isStreaming = isStreaming is null ? true : !isStreaming;
 
             while (isStreaming.Value)
             {

--- a/samples/AvaloniaSample/Scatter/AutoUpdate/View.axaml.cs
+++ b/samples/AvaloniaSample/Scatter/AutoUpdate/View.axaml.cs
@@ -17,9 +17,9 @@ namespace AvaloniaSample.Scatter.AutoUpdate
         private async void ButtonClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
         {
             var vm = (ViewModel?)DataContext;
-            if (vm == null) return;
+            if (vm is null) return;
 
-            isStreaming = isStreaming == null ? true : !isStreaming;
+            isStreaming = isStreaming is null ? true : !isStreaming;
 
             while (isStreaming.Value)
             {

--- a/samples/AvaloniaSample/StepLines/AutoUpdate/View.axaml.cs
+++ b/samples/AvaloniaSample/StepLines/AutoUpdate/View.axaml.cs
@@ -17,9 +17,9 @@ namespace AvaloniaSample.StepLines.AutoUpdate
         private async void ButtonClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
         {
             var vm = (ViewModel?)DataContext;
-            if (vm == null) return;
+            if (vm is null) return;
 
-            isStreaming = isStreaming == null ? true : !isStreaming;
+            isStreaming = isStreaming is null ? true : !isStreaming;
 
             while (isStreaming.Value)
             {

--- a/samples/ViewModelsSamples/General/UserDefinedTypes/ViewModel.cs
+++ b/samples/ViewModelsSamples/General/UserDefinedTypes/ViewModel.cs
@@ -1,6 +1,5 @@
 ﻿using LiveChartsCore;
 using LiveChartsCore.SkiaSharpView;
-using System.Collections.Generic;
 
 namespace ViewModelsSamples.General.UserDefinedTypes
 {

--- a/samples/WPFSample/Bars/AutoUpdate/View.xaml.cs
+++ b/samples/WPFSample/Bars/AutoUpdate/View.xaml.cs
@@ -19,7 +19,7 @@ namespace WPFSample.Bars.AutoUpdate
         private async void Button_Click(object sender, System.Windows.RoutedEventArgs e)
         {
             var vm = (ViewModel)DataContext;
-            isStreaming = isStreaming == null ? true : !isStreaming;
+            isStreaming = isStreaming is null ? true : !isStreaming;
 
             while (isStreaming.Value)
             {

--- a/samples/WPFSample/Lines/AutoUpdate/View.xaml.cs
+++ b/samples/WPFSample/Lines/AutoUpdate/View.xaml.cs
@@ -19,7 +19,7 @@ namespace WPFSample.Lines.AutoUpdate
         private async void Button_Click(object sender, System.Windows.RoutedEventArgs e)
         {
             var vm = (ViewModel)DataContext;
-            isStreaming = isStreaming == null ? true : !isStreaming;
+            isStreaming = isStreaming is null ? true : !isStreaming;
 
             while (isStreaming.Value)
             {

--- a/samples/WPFSample/MainWindow.xaml.cs
+++ b/samples/WPFSample/MainWindow.xaml.cs
@@ -21,7 +21,7 @@ namespace WPFSample
         private void Border_MouseDown(object sender, MouseButtonEventArgs e)
         {
             var ctx = (sender as FrameworkElement).DataContext as string;
-            if (ctx == null) throw new Exception("Sample not found");
+            if (ctx is null) throw new Exception("Sample not found");
             content.Content = Activator.CreateInstance(null, $"WPFSample.{ctx.Replace('/', '.')}.View").Unwrap();
         }
     }

--- a/samples/WPFSample/Pies/AutoUpdate/View.xaml.cs
+++ b/samples/WPFSample/Pies/AutoUpdate/View.xaml.cs
@@ -19,7 +19,7 @@ namespace WPFSample.Pies.AutoUpdate
         private async void Button_Click(object sender, System.Windows.RoutedEventArgs e)
         {
             var vm = (ViewModel)DataContext;
-            isStreaming = isStreaming == null ? true : !isStreaming;
+            isStreaming = isStreaming is null ? true : !isStreaming;
 
             while (isStreaming.Value)
             {

--- a/samples/WPFSample/Scatter/AutoUpdate/View.xaml.cs
+++ b/samples/WPFSample/Scatter/AutoUpdate/View.xaml.cs
@@ -19,7 +19,7 @@ namespace WPFSample.Scatter.AutoUpdate
         private async void Button_Click(object sender, System.Windows.RoutedEventArgs e)
         {
             var vm = (ViewModel)DataContext;
-            isStreaming = isStreaming == null ? true : !isStreaming;
+            isStreaming = isStreaming is null ? true : !isStreaming;
 
             while (isStreaming.Value)
             {

--- a/samples/WPFSample/StepLines/AutoUpdate/View.xaml.cs
+++ b/samples/WPFSample/StepLines/AutoUpdate/View.xaml.cs
@@ -19,7 +19,7 @@ namespace WPFSample.StepLines.AutoUpdate
         private async void Button_Click(object sender, System.Windows.RoutedEventArgs e)
         {
             var vm = (ViewModel)DataContext;
-            isStreaming = isStreaming == null ? true : !isStreaming;
+            isStreaming = isStreaming is null ? true : !isStreaming;
 
             while (isStreaming.Value)
             {

--- a/samples/WinFormsSample/Bars/AutoUpdate/View.cs
+++ b/samples/WinFormsSample/Bars/AutoUpdate/View.cs
@@ -1,5 +1,4 @@
 ﻿using LiveChartsCore.SkiaSharpView.WinForms;
-using System;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using ViewModelsSamples.Bars.AutoUpdate;

--- a/samples/WinFormsSample/Bars/AutoUpdate/View.cs
+++ b/samples/WinFormsSample/Bars/AutoUpdate/View.cs
@@ -57,7 +57,7 @@ namespace WinFormsSample.Bars.AutoUpdate
 
         private async void OnConstantChangesClick(object sender, System.EventArgs e)
         {
-            isStreaming = isStreaming == null ? true : !isStreaming;
+            isStreaming = isStreaming is null ? true : !isStreaming;
 
             while (isStreaming.Value)
             {

--- a/samples/WinFormsSample/Bars/Basic/View.cs
+++ b/samples/WinFormsSample/Bars/Basic/View.cs
@@ -1,7 +1,4 @@
-﻿using LiveChartsCore;
-using LiveChartsCore.SkiaSharpView;
-using LiveChartsCore.SkiaSharpView.WinForms;
-using System;
+﻿using LiveChartsCore.SkiaSharpView.WinForms;
 using System.Windows.Forms;
 using ViewModelsSamples.Bars.Basic;
 

--- a/samples/WinFormsSample/Form1.cs
+++ b/samples/WinFormsSample/Form1.cs
@@ -22,7 +22,7 @@ namespace WinFormsSample
 
         private void listBox1_SelectedIndexChanged(object sender, EventArgs e)
         {
-            if (activeControl != null)
+            if (activeControl is not null)
             {
                 Controls.Remove(activeControl);
                 activeControl.Dispose();

--- a/samples/WinFormsSample/General/TemplatedTooltips/CustomTooltip.cs
+++ b/samples/WinFormsSample/General/TemplatedTooltips/CustomTooltip.cs
@@ -122,7 +122,7 @@ namespace WinFormsSample.General.TemplatedTooltips
 
         protected override void Dispose(bool disposing)
         {
-            if (disposing && (components != null))
+            if (disposing && (components is not null))
             {
                 components.Dispose();
             }

--- a/samples/WinFormsSample/Lines/AutoUpdate/View.cs
+++ b/samples/WinFormsSample/Lines/AutoUpdate/View.cs
@@ -57,7 +57,7 @@ namespace WinFormsSample.Lines.AutoUpdate
 
         private async void OnConstantChangesClick(object sender, System.EventArgs e)
         {
-            isStreaming = isStreaming == null ? true : !isStreaming;
+            isStreaming = isStreaming is null ? true : !isStreaming;
 
             while (isStreaming.Value)
             {

--- a/samples/WinFormsSample/Pies/AutoUpdate/View.cs
+++ b/samples/WinFormsSample/Pies/AutoUpdate/View.cs
@@ -49,7 +49,7 @@ namespace WinFormsSample.Pies.AutoUpdate
 
         private async void OnConstantChangesClick(object sender, System.EventArgs e)
         {
-            isStreaming = isStreaming == null ? true : !isStreaming;
+            isStreaming = isStreaming is null ? true : !isStreaming;
 
             while (isStreaming.Value)
             {

--- a/samples/WinFormsSample/Scatter/AutoUpdate/View.cs
+++ b/samples/WinFormsSample/Scatter/AutoUpdate/View.cs
@@ -57,7 +57,7 @@ namespace WinFormsSample.Scatter.AutoUpdate
 
         private async void OnConstantChangesClick(object sender, System.EventArgs e)
         {
-            isStreaming = isStreaming == null ? true : !isStreaming;
+            isStreaming = isStreaming is null ? true : !isStreaming;
 
             while (isStreaming.Value)
             {

--- a/samples/WinFormsSample/StepLines/AutoUpdate/View.cs
+++ b/samples/WinFormsSample/StepLines/AutoUpdate/View.cs
@@ -57,7 +57,7 @@ namespace WinFormsSample.StepLines.AutoUpdate
 
         private async void OnConstantChangesClick(object sender, System.EventArgs e)
         {
-            isStreaming = isStreaming == null ? true : !isStreaming;
+            isStreaming = isStreaming is null ? true : !isStreaming;
 
             while (isStreaming.Value)
             {

--- a/samples/XamarinSample/XamarinSample/XamarinSample.Android/MainActivity.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample.Android/MainActivity.cs
@@ -1,5 +1,4 @@
-﻿
-using Android.App;
+﻿using Android.App;
 using Android.Content.PM;
 using Android.Runtime;
 using Android.OS;

--- a/samples/XamarinSample/XamarinSample/XamarinSample.UWP/App.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample.UWP/App.xaml.cs
@@ -40,7 +40,7 @@ namespace XamarinSample.UWP
 
             // Do not repeat app initialization when the Window already has content,
             // just ensure that the window is active
-            if (rootFrame == null)
+            if (rootFrame is null)
             {
                 // Create a Frame to act as the navigation context and navigate to the first page
                 rootFrame = new Frame();
@@ -58,7 +58,7 @@ namespace XamarinSample.UWP
                 Window.Current.Content = rootFrame;
             }
 
-            if (rootFrame.Content == null)
+            if (rootFrame.Content is null)
             {
                 // When the navigation stack isn't restored navigate to the first page,
                 // configuring the new page by passing required information as a navigation

--- a/samples/XamarinSample/XamarinSample/XamarinSample.iOS/AppDelegate.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample.iOS/AppDelegate.cs
@@ -1,5 +1,4 @@
-﻿
-using Foundation;
+﻿using Foundation;
 using UIKit;
 
 namespace XamarinSample.iOS

--- a/samples/XamarinSample/XamarinSample/XamarinSample/Axes/ColorsAndPositions/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/Axes/ColorsAndPositions/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace XamarinSample.Axes.ColorsAndPosition

--- a/samples/XamarinSample/XamarinSample/XamarinSample/Axes/DateTimeScaled/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/Axes/DateTimeScaled/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace XamarinSample.Axes.DateTimeScaled

--- a/samples/XamarinSample/XamarinSample/XamarinSample/Axes/LabelsFormat/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/Axes/LabelsFormat/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace XamarinSample.Axes.LabelsFormat

--- a/samples/XamarinSample/XamarinSample/XamarinSample/Axes/LabelsRotation/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/Axes/LabelsRotation/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace XamarinSample.Axes.LabelsRotation

--- a/samples/XamarinSample/XamarinSample/XamarinSample/Axes/Logaritmic/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/Axes/Logaritmic/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace XamarinSample.Axes.Logaritmic

--- a/samples/XamarinSample/XamarinSample/XamarinSample/Axes/Multiple/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/Axes/Multiple/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace XamarinSample.Axes.Multiple

--- a/samples/XamarinSample/XamarinSample/XamarinSample/Axes/NamedLabels/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/Axes/NamedLabels/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace XamarinSample.Axes.NamedLabels

--- a/samples/XamarinSample/XamarinSample/XamarinSample/Axes/Shared/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/Axes/Shared/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace XamarinSample.Axes.Shared

--- a/samples/XamarinSample/XamarinSample/XamarinSample/Bars/AutoUpdate/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/Bars/AutoUpdate/View.xaml.cs
@@ -19,7 +19,7 @@ namespace XamarinSample.Bars.AutoUpdate
         {
             var vm = (ViewModel)BindingContext;
 
-            isStreaming = isStreaming == null ? true : !isStreaming;
+            isStreaming = isStreaming is null ? true : !isStreaming;
 
             while (isStreaming.Value)
             {

--- a/samples/XamarinSample/XamarinSample/XamarinSample/Bars/AutoUpdate/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/Bars/AutoUpdate/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using ViewModelsSamples.Bars.AutoUpdate;
 using Xamarin.Forms;
 using Xamarin.Forms.Xaml;

--- a/samples/XamarinSample/XamarinSample/XamarinSample/Bars/Basic/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/Bars/Basic/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace XamarinSample.Bars.Basic

--- a/samples/XamarinSample/XamarinSample/XamarinSample/Bars/Custom/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/Bars/Custom/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace XamarinSample.Bars.Custom

--- a/samples/XamarinSample/XamarinSample/XamarinSample/Bars/DelayedAnimation/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/Bars/DelayedAnimation/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace XamarinSample.Bars.DelayedAnimation

--- a/samples/XamarinSample/XamarinSample/XamarinSample/Bars/Layered/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/Bars/Layered/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace XamarinSample.Bars.Layered

--- a/samples/XamarinSample/XamarinSample/XamarinSample/Bars/Race/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/Bars/Race/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using ViewModelsSamples.Bars.Race;
 using Xamarin.Forms;
 using Xamarin.Forms.Xaml;

--- a/samples/XamarinSample/XamarinSample/XamarinSample/Bars/RowsWithLabels/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/Bars/RowsWithLabels/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace XamarinSample.Bars.RowsWithLabels

--- a/samples/XamarinSample/XamarinSample/XamarinSample/Bars/States/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/Bars/States/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace XamarinSample.Bars.States

--- a/samples/XamarinSample/XamarinSample/XamarinSample/Bars/WithBackground/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/Bars/WithBackground/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace XamarinSample.Bars.WithBackground

--- a/samples/XamarinSample/XamarinSample/XamarinSample/Design/LinearGradients/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/Design/LinearGradients/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace XamarinSample.Design.LinearGradients

--- a/samples/XamarinSample/XamarinSample/XamarinSample/Design/RadialGradients/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/Design/RadialGradients/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace XamarinSample.Design.RadialGradients

--- a/samples/XamarinSample/XamarinSample/XamarinSample/Design/StrokeDashArray/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/Design/StrokeDashArray/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace XamarinSample.Design.StrokeDashArray

--- a/samples/XamarinSample/XamarinSample/XamarinSample/Financial/Basic/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/Financial/Basic/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace XamarinSample.Financial.BasicCandlesticks

--- a/samples/XamarinSample/XamarinSample/XamarinSample/General/Animations/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/General/Animations/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace XamarinSample.General.Animations

--- a/samples/XamarinSample/XamarinSample/XamarinSample/General/Legends/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/General/Legends/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace XamarinSample.General.Legends

--- a/samples/XamarinSample/XamarinSample/XamarinSample/General/NullPoints/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/General/NullPoints/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace XamarinSample.General.NullPoints

--- a/samples/XamarinSample/XamarinSample/XamarinSample/General/Sections/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/General/Sections/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace XamarinSample.General.Sections

--- a/samples/XamarinSample/XamarinSample/XamarinSample/General/TemplatedLegends/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/General/TemplatedLegends/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace XamarinSample.General.TemplatedLegends

--- a/samples/XamarinSample/XamarinSample/XamarinSample/General/TemplatedTooltips/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/General/TemplatedTooltips/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace XamarinSample.General.TemplatedTooltips

--- a/samples/XamarinSample/XamarinSample/XamarinSample/General/Tooltips/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/General/Tooltips/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace XamarinSample.General.Tooltips

--- a/samples/XamarinSample/XamarinSample/XamarinSample/General/UserDefinedTypes/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/General/UserDefinedTypes/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace XamarinSample.General.UserDefinedTypes

--- a/samples/XamarinSample/XamarinSample/XamarinSample/Heat/Basic/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/Heat/Basic/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace XamarinSample.Heat.Basic

--- a/samples/XamarinSample/XamarinSample/XamarinSample/Lines/Area/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/Lines/Area/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace XamarinSample.Lines.Area

--- a/samples/XamarinSample/XamarinSample/XamarinSample/Lines/AutoUpdate/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/Lines/AutoUpdate/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using ViewModelsSamples.Lines.AutoUpdate;
 using Xamarin.Forms;
 using Xamarin.Forms.Xaml;

--- a/samples/XamarinSample/XamarinSample/XamarinSample/Lines/AutoUpdate/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/Lines/AutoUpdate/View.xaml.cs
@@ -19,7 +19,7 @@ namespace XamarinSample.Lines.AutoUpdate
         {
             var vm = (ViewModel)BindingContext;
 
-            isStreaming = isStreaming == null ? true : !isStreaming;
+            isStreaming = isStreaming is null ? true : !isStreaming;
 
             while (isStreaming.Value)
             {

--- a/samples/XamarinSample/XamarinSample/XamarinSample/Lines/Basic/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/Lines/Basic/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace XamarinSample.Lines.Basic

--- a/samples/XamarinSample/XamarinSample/XamarinSample/Lines/Custom/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/Lines/Custom/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace XamarinSample.Lines.Custom

--- a/samples/XamarinSample/XamarinSample/XamarinSample/Lines/Properties/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/Lines/Properties/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace XamarinSample.Lines.Properties

--- a/samples/XamarinSample/XamarinSample/XamarinSample/Lines/Straight/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/Lines/Straight/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace XamarinSample.Lines.Straight

--- a/samples/XamarinSample/XamarinSample/XamarinSample/Lines/Zoom/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/Lines/Zoom/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace XamarinSample.Lines.Zoom

--- a/samples/XamarinSample/XamarinSample/XamarinSample/Maps/World/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/Maps/World/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace XamarinSample.Maps.World

--- a/samples/XamarinSample/XamarinSample/XamarinSample/Pies/AutoUpdate/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/Pies/AutoUpdate/View.xaml.cs
@@ -19,7 +19,7 @@ namespace XamarinSample.Pies.AutoUpdate
         {
             var vm = (ViewModel)BindingContext;
 
-            isStreaming = isStreaming == null ? true : !isStreaming;
+            isStreaming = isStreaming is null ? true : !isStreaming;
 
             while (isStreaming.Value)
             {

--- a/samples/XamarinSample/XamarinSample/XamarinSample/Pies/AutoUpdate/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/Pies/AutoUpdate/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using ViewModelsSamples.Pies.AutoUpdate;
 using Xamarin.Forms;
 using Xamarin.Forms.Xaml;

--- a/samples/XamarinSample/XamarinSample/XamarinSample/Pies/Basic/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/Pies/Basic/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace XamarinSample.Pies.Basic

--- a/samples/XamarinSample/XamarinSample/XamarinSample/Pies/Custom/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/Pies/Custom/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace XamarinSample.Pies.Custom

--- a/samples/XamarinSample/XamarinSample/XamarinSample/Pies/Doughnut/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/Pies/Doughnut/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace XamarinSample.Pies.Doughnut

--- a/samples/XamarinSample/XamarinSample/XamarinSample/Pies/Gauges/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/Pies/Gauges/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace XamarinSample.Pies.Gauges

--- a/samples/XamarinSample/XamarinSample/XamarinSample/Pies/NightingaleRose/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/Pies/NightingaleRose/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace XamarinSample.Pies.NightingaleRose

--- a/samples/XamarinSample/XamarinSample/XamarinSample/Pies/Processing/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/Pies/Processing/View.xaml.cs
@@ -21,7 +21,7 @@ namespace XamarinSample.Pies.Processing
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
             var enumerable = value as IEnumerable;
-            if (value == null) return null;
+            if (value is null) return null;
 
             var enumerator = enumerable.GetEnumerator();
             enumerator.MoveNext();

--- a/samples/XamarinSample/XamarinSample/XamarinSample/Pies/Pushout/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/Pies/Pushout/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace XamarinSample.Pies.Pushout

--- a/samples/XamarinSample/XamarinSample/XamarinSample/Scatter/AutoUpdate/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/Scatter/AutoUpdate/View.xaml.cs
@@ -19,7 +19,7 @@ namespace XamarinSample.Scatter.AutoUpdate
         {
             var vm = (ViewModel)BindingContext;
 
-            isStreaming = isStreaming == null ? true : !isStreaming;
+            isStreaming = isStreaming is null ? true : !isStreaming;
 
             while (isStreaming.Value)
             {

--- a/samples/XamarinSample/XamarinSample/XamarinSample/Scatter/AutoUpdate/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/Scatter/AutoUpdate/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using ViewModelsSamples.Scatter.AutoUpdate;
 using Xamarin.Forms;
 using Xamarin.Forms.Xaml;

--- a/samples/XamarinSample/XamarinSample/XamarinSample/Scatter/Basic/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/Scatter/Basic/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace XamarinSample.Scatter.Basic

--- a/samples/XamarinSample/XamarinSample/XamarinSample/Scatter/Bubbles/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/Scatter/Bubbles/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace XamarinSample.Scatter.Bubbles

--- a/samples/XamarinSample/XamarinSample/XamarinSample/Scatter/Custom/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/Scatter/Custom/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace XamarinSample.Scatter.Custom

--- a/samples/XamarinSample/XamarinSample/XamarinSample/StackedArea/Basic/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/StackedArea/Basic/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace XamarinSample.StackedArea.Basic

--- a/samples/XamarinSample/XamarinSample/XamarinSample/StackedArea/StepArea/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/StackedArea/StepArea/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace XamarinSample.StackedArea.StepArea

--- a/samples/XamarinSample/XamarinSample/XamarinSample/StackedBars/Basic/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/StackedBars/Basic/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace XamarinSample.StackedBars.Basic

--- a/samples/XamarinSample/XamarinSample/XamarinSample/StackedBars/Groups/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/StackedBars/Groups/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace XamarinSample.StackedBars.Groups

--- a/samples/XamarinSample/XamarinSample/XamarinSample/StepLines/Area/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/StepLines/Area/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace XamarinSample.StepLines.Area

--- a/samples/XamarinSample/XamarinSample/XamarinSample/StepLines/AutoUpdate/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/StepLines/AutoUpdate/View.xaml.cs
@@ -19,7 +19,7 @@ namespace XamarinSample.StepLines.AutoUpdate
         {
             var vm = (ViewModel)BindingContext;
 
-            isStreaming = isStreaming == null ? true : !isStreaming;
+            isStreaming = isStreaming is null ? true : !isStreaming;
 
             while (isStreaming.Value)
             {

--- a/samples/XamarinSample/XamarinSample/XamarinSample/StepLines/AutoUpdate/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/StepLines/AutoUpdate/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using ViewModelsSamples.Lines.AutoUpdate;
 using Xamarin.Forms;
 using Xamarin.Forms.Xaml;

--- a/samples/XamarinSample/XamarinSample/XamarinSample/StepLines/Basic/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/StepLines/Basic/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace XamarinSample.StepLines.Basic

--- a/samples/XamarinSample/XamarinSample/XamarinSample/StepLines/Custom/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/StepLines/Custom/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace XamarinSample.StepLines.Custom

--- a/samples/XamarinSample/XamarinSample/XamarinSample/StepLines/Properties/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/StepLines/Properties/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace XamarinSample.StepLines.Properties

--- a/samples/XamarinSample/XamarinSample/XamarinSample/StepLines/Zoom/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/StepLines/Zoom/View.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace XamarinSample.StepLines.Zoom

--- a/src/LiveChartsCore/Axis.cs
+++ b/src/LiveChartsCore/Axis.cs
@@ -179,20 +179,20 @@ namespace LiveChartsCore
         {
             var cartesianChart = (CartesianChart<TDrawingContext>)chart;
 
-            if (_dataBounds == null) throw new Exception("DataBounds not found");
+            if (_dataBounds is null) throw new Exception("DataBounds not found");
 
             var controlSize = cartesianChart.ControlSize;
             var drawLocation = cartesianChart.DrawMarginLocation;
             var drawMarginSize = cartesianChart.DrawMarginSize;
 
             var scale = new Scaler(drawLocation, drawMarginSize, this);
-            var previousSacale = ((IAxis)this).PreviousDataBounds == null
+            var previousSacale = ((IAxis)this).PreviousDataBounds is null
                 ? null
                 : new Scaler(drawLocation, drawMarginSize, this, true);
             var axisTick = this.GetTick(drawMarginSize);
 
             var labeler = Labeler;
-            if (Labels != null)
+            if (Labels is not null)
             {
                 labeler = Labelers.BuildNamedLabeler(Labels).Function;
                 _minStep = 1;
@@ -201,12 +201,12 @@ namespace LiveChartsCore
             var s = axisTick.Value;
             if (s < _minStep) s = _minStep;
 
-            if (LabelsPaint != null)
+            if (LabelsPaint is not null)
             {
                 LabelsPaint.ZIndex = -1;
                 cartesianChart.Canvas.AddDrawableTask(LabelsPaint);
             }
-            if (SeparatorsPaint != null)
+            if (SeparatorsPaint is not null)
             {
                 SeparatorsPaint.ZIndex = -1;
                 SeparatorsPaint.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
@@ -237,8 +237,8 @@ namespace LiveChartsCore
             var r = (float)_labelsRotation;
             var hasRotation = Math.Abs(r) > 0.01f;
 
-            var max = MaxLimit == null ? (_visibleDataBounds ?? _dataBounds).Max : MaxLimit.Value;
-            var min = MinLimit == null ? (_visibleDataBounds ?? _dataBounds).Min : MinLimit.Value;
+            var max = MaxLimit is null ? (_visibleDataBounds ?? _dataBounds).Max : MaxLimit.Value;
+            var min = MinLimit is null ? (_visibleDataBounds ?? _dataBounds).Min : MinLimit.Value;
 
             var start = Math.Truncate(min / s) * s;
             if (!activeSeparators.TryGetValue(cartesianChart, out var separators))
@@ -270,7 +270,7 @@ namespace LiveChartsCore
                 {
                     visualSeparator = new AxisVisualSeprator<TDrawingContext>() { Value = (float)i };
 
-                    if (LabelsPaint != null)
+                    if (LabelsPaint is not null)
                     {
                         var textGeometry = new TTextGeometry { TextSize = size };
                         visualSeparator.Text = textGeometry;
@@ -286,7 +286,7 @@ namespace LiveChartsCore
                                     .WithDuration(AnimationsSpeed ?? cartesianChart.AnimationsSpeed)
                                     .WithEasingFunction(EasingFunction ?? cartesianChart.EasingFunction));
 
-                        if (previousSacale != null)
+                        if (previousSacale is not null)
                         {
                             float xi, yi;
 
@@ -307,7 +307,7 @@ namespace LiveChartsCore
                         }
                     }
 
-                    if (SeparatorsPaint != null && ShowSeparatorLines)
+                    if (SeparatorsPaint is not null && ShowSeparatorLines)
                     {
                         var lineGeometry = new TLineGeometry();
 
@@ -323,7 +323,7 @@ namespace LiveChartsCore
                                     .WithDuration(AnimationsSpeed ?? cartesianChart.AnimationsSpeed)
                                     .WithEasingFunction(EasingFunction ?? cartesianChart.EasingFunction));
 
-                        if (previousSacale != null)
+                        if (previousSacale is not null)
                         {
                             float xi, yi;
 
@@ -360,12 +360,12 @@ namespace LiveChartsCore
                     separators.Add(label, visualSeparator);
                 }
 
-                if (LabelsPaint != null && visualSeparator.Text != null)
+                if (LabelsPaint is not null && visualSeparator.Text is not null)
                     LabelsPaint.AddGeometryToPaintTask(cartesianChart.Canvas, visualSeparator.Text);
-                if (SeparatorsPaint != null && ShowSeparatorLines && visualSeparator.Line != null)
+                if (SeparatorsPaint is not null && ShowSeparatorLines && visualSeparator.Line is not null)
                     SeparatorsPaint.AddGeometryToPaintTask(cartesianChart.Canvas, visualSeparator.Line);
 
-                if (visualSeparator.Text != null)
+                if (visualSeparator.Text is not null)
                 {
                     visualSeparator.Text.Text = label;
                     visualSeparator.Text.Padding = _padding;
@@ -373,10 +373,10 @@ namespace LiveChartsCore
                     visualSeparator.Text.Y = y;
                     if (hasRotation) visualSeparator.Text.Rotation = r;
 
-                    if (((IAxis)this).PreviousDataBounds == null) visualSeparator.Text.CompleteAllTransitions();
+                    if (((IAxis)this).PreviousDataBounds is null) visualSeparator.Text.CompleteAllTransitions();
                 }
 
-                if (visualSeparator.Line != null)
+                if (visualSeparator.Line is not null)
                 {
                     if (_orientation == AxisOrientation.X)
                     {
@@ -393,10 +393,10 @@ namespace LiveChartsCore
                         visualSeparator.Line.Y1 = y;
                     }
 
-                    if (((IAxis)this).PreviousDataBounds == null) visualSeparator.Line.CompleteAllTransitions();
+                    if (((IAxis)this).PreviousDataBounds is null) visualSeparator.Line.CompleteAllTransitions();
                 }
 
-                if (visualSeparator.Text != null || visualSeparator.Line != null) _ = measured.Add(visualSeparator);
+                if (visualSeparator.Text is not null || visualSeparator.Line is not null) _ = measured.Add(visualSeparator);
             }
 
             foreach (var separator in separators.ToArray())
@@ -412,13 +412,13 @@ namespace LiveChartsCore
         /// <inheritdoc cref="IAxis{TDrawingContext}.GetPossibleSize(CartesianChart{TDrawingContext})"/>
         public SizeF GetPossibleSize(CartesianChart<TDrawingContext> chart)
         {
-            if (_dataBounds == null) throw new Exception("DataBounds not found");
-            if (LabelsPaint == null) return new SizeF(0f, 0f);
+            if (_dataBounds is null) throw new Exception("DataBounds not found");
+            if (LabelsPaint is null) return new SizeF(0f, 0f);
 
             var ts = (float)TextSize;
             var labeler = Labeler;
 
-            if (Labels != null)
+            if (Labels is not null)
             {
                 labeler = Labelers.BuildNamedLabeler(Labels).Function;
                 _minStep = 1;
@@ -428,8 +428,8 @@ namespace LiveChartsCore
             var s = axisTick.Value;
             if (s < _minStep) s = _minStep;
 
-            var max = MaxLimit == null ? (_visibleDataBounds ?? _dataBounds).Max : MaxLimit.Value;
-            var min = MinLimit == null ? (_visibleDataBounds ?? _dataBounds).Min : MinLimit.Value;
+            var max = MaxLimit is null ? (_visibleDataBounds ?? _dataBounds).Max : MaxLimit.Value;
+            var min = MinLimit is null ? (_visibleDataBounds ?? _dataBounds).Min : MinLimit.Value;
 
             var start = Math.Truncate(min / s) * s;
 
@@ -470,12 +470,12 @@ namespace LiveChartsCore
         public virtual void Delete(Chart<TDrawingContext> chart)
         {
 
-            if (_labelsPaint != null)
+            if (_labelsPaint is not null)
             {
                 chart.Canvas.RemovePaintTask(_labelsPaint);
                 _labelsPaint.ClearGeometriesFromPaintTask(chart.Canvas);
             }
-            if (_separatorsPaint != null)
+            if (_separatorsPaint is not null)
             {
                 chart.Canvas.RemovePaintTask(_separatorsPaint);
                 _separatorsPaint.ClearGeometriesFromPaintTask(chart.Canvas);
@@ -550,7 +550,7 @@ namespace LiveChartsCore
                 y = scale.ToPixels((float)separator.Value);
             }
 
-            if (separator.Line != null)
+            if (separator.Line is not null)
             {
                 if (_orientation == AxisOrientation.X)
                 {
@@ -571,7 +571,7 @@ namespace LiveChartsCore
                 separator.Line.RemoveOnCompleted = true;
             }
 
-            if (separator.Text != null)
+            if (separator.Text is not null)
             {
                 separator.Text.X = x;
                 separator.Text.Y = y;

--- a/src/LiveChartsCore/BarSeries.cs
+++ b/src/LiveChartsCore/BarSeries.cs
@@ -45,7 +45,7 @@ namespace LiveChartsCore
         /// Initializes a new instance of the <see cref="BarSeries{TModel, TVisual, TLabel, TDrawingContext}"/> class.
         /// </summary>
         /// <param name="properties">The properties.</param>
-        public BarSeries(SeriesProperties properties)
+        protected BarSeries(SeriesProperties properties)
             : base(properties)
         {
             HoverState = LiveCharts.BarSeriesHoverKey;

--- a/src/LiveChartsCore/BarSeries.cs
+++ b/src/LiveChartsCore/BarSeries.cs
@@ -74,7 +74,7 @@ namespace LiveChartsCore
             var context = new CanvasSchedule<TDrawingContext>();
             var w = LegendShapeSize;
             var sh = 0f;
-            if (Stroke != null)
+            if (Stroke is not null)
             {
                 var strokeClone = Stroke.CloneTask();
                 var visual = new TVisual
@@ -90,7 +90,7 @@ namespace LiveChartsCore
                 context.PaintSchedules.Add(new PaintSchedule<TDrawingContext>(strokeClone, visual));
             }
 
-            if (Fill != null)
+            if (Fill is not null)
             {
                 var fillClone = Fill.CloneTask();
                 var visual = new TVisual { X = sh, Y = sh, Height = (float)LegendShapeSize, Width = (float)LegendShapeSize };

--- a/src/LiveChartsCore/CartesianChart.cs
+++ b/src/LiveChartsCore/CartesianChart.cs
@@ -65,12 +65,12 @@ namespace LiveChartsCore
             view.PointStates.Chart = this;
             foreach (var item in view.PointStates.GetStates())
             {
-                if (item.Fill != null)
+                if (item.Fill is not null)
                 {
                     item.Fill.ZIndex += 1000000;
                     canvas.AddDrawableTask(item.Fill);
                 }
-                if (item.Stroke != null)
+                if (item.Stroke is not null)
                 {
                     item.Stroke.ZIndex += 1000000;
                     canvas.AddDrawableTask(item.Stroke);
@@ -137,7 +137,7 @@ namespace LiveChartsCore
         /// <inheritdoc cref="IChart.Update(ChartUpdateParams?)" />
         public override void Update(ChartUpdateParams? chartUpdateParams = null)
         {
-            if (chartUpdateParams == null) chartUpdateParams = new ChartUpdateParams();
+            if (chartUpdateParams is null) chartUpdateParams = new ChartUpdateParams();
             if (chartUpdateParams.IsAutomaticUpdate && !View.AutoUpdateEnaled) return;
             if (!chartUpdateParams.Throttling)
             {
@@ -201,7 +201,7 @@ namespace LiveChartsCore
         /// <returns></returns>
         public void Zoom(PointF pivot, ZoomDirection direction)
         {
-            if (YAxes == null || XAxes == null) return;
+            if (YAxes is null || XAxes is null) return;
 
             var speed = _zoomingSpeed < 0.1 ? 0.1 : (_zoomingSpeed > 0.95 ? 0.95 : _zoomingSpeed);
             var m = direction == ZoomDirection.ZoomIn ? speed : 1 / speed;
@@ -213,8 +213,8 @@ namespace LiveChartsCore
                     var xi = XAxes[index];
                     var px = new Scaler(DrawMarginLocation, drawMarginSize, xi).ToChartValues(pivot.X);
 
-                    var max = xi.MaxLimit == null ? xi.DataBounds.Max : xi.MaxLimit.Value;
-                    var min = xi.MinLimit == null ? xi.DataBounds.Min : xi.MinLimit.Value;
+                    var max = xi.MaxLimit is null ? xi.DataBounds.Max : xi.MaxLimit.Value;
+                    var min = xi.MinLimit is null ? xi.DataBounds.Min : xi.MinLimit.Value;
 
                     var l = max - min;
 
@@ -242,8 +242,8 @@ namespace LiveChartsCore
                     var yi = YAxes[index];
                     var px = new Scaler(DrawMarginLocation, drawMarginSize, yi).ToChartValues(pivot.Y);
 
-                    var max = yi.MaxLimit == null ? yi.DataBounds.Max : yi.MaxLimit.Value;
-                    var min = yi.MinLimit == null ? yi.DataBounds.Min : yi.MinLimit.Value;
+                    var max = yi.MaxLimit is null ? yi.DataBounds.Max : yi.MaxLimit.Value;
+                    var min = yi.MinLimit is null ? yi.DataBounds.Min : yi.MinLimit.Value;
 
                     var l = max - min;
 
@@ -282,8 +282,8 @@ namespace LiveChartsCore
                     var scale = new Scaler(DrawMarginLocation, drawMarginSize, xi);
                     var dx = scale.ToChartValues(-delta.X) - scale.ToChartValues(0);
 
-                    var max = xi.MaxLimit == null ? xi.DataBounds.Max : xi.MaxLimit.Value;
-                    var min = xi.MinLimit == null ? xi.DataBounds.Min : xi.MinLimit.Value;
+                    var max = xi.MaxLimit is null ? xi.DataBounds.Max : xi.MaxLimit.Value;
+                    var min = xi.MinLimit is null ? xi.DataBounds.Min : xi.MinLimit.Value;
 
                     if (max + dx > xi.DataBounds.Max)
                     {
@@ -312,8 +312,8 @@ namespace LiveChartsCore
                     var scale = new Scaler(DrawMarginLocation, drawMarginSize, yi);
                     var dy = -(scale.ToChartValues(delta.Y) - scale.ToChartValues(0));
 
-                    var max = yi.MaxLimit == null ? yi.DataBounds.Max : yi.MaxLimit.Value;
-                    var min = yi.MinLimit == null ? yi.DataBounds.Min : yi.MinLimit.Value;
+                    var max = yi.MaxLimit is null ? yi.DataBounds.Max : yi.MaxLimit.Value;
+                    var min = yi.MinLimit is null ? yi.DataBounds.Min : yi.MinLimit.Value;
 
                     if (max + dy > yi.DataBounds.Max)
                     {
@@ -367,7 +367,7 @@ namespace LiveChartsCore
                 _zoomMode = _chartView.ZoomMode;
 
                 var theme = LiveCharts.CurrentSettings.GetTheme<TDrawingContext>();
-                if (theme.CurrentColors == null || theme.CurrentColors.Length == 0)
+                if (theme.CurrentColors is null || theme.CurrentColors.Length == 0)
                     throw new Exception("Default colors are not valid");
                 var forceApply = ThemeId != LiveCharts.CurrentSettings.ThemeId && !IsFirstDraw;
 
@@ -438,7 +438,7 @@ namespace LiveChartsCore
                     series.IsNotifyingChanges = true;
                 }
 
-                if (legend != null && SeriesMiniatureChanged(Series, LegendPosition))
+                if (legend is not null && SeriesMiniatureChanged(Series, LegendPosition))
                 {
                     legend.Draw(this);
                     Update();
@@ -446,7 +446,7 @@ namespace LiveChartsCore
                 }
 
                 // calculate draw margin
-                if (viewDrawMargin == null)
+                if (viewDrawMargin is null)
                 {
                     var m = viewDrawMargin ?? new Margin();
                     float ts = 0f, bs = 0f, ls = 0f, rs = 0f;
@@ -548,12 +548,12 @@ namespace LiveChartsCore
                     _ = toDeleteSeries.Remove(series);
                 }
 
-                if (_previousDrawMarginFrame != null && _chartView.DrawMarginFrame != _previousDrawMarginFrame)
+                if (_previousDrawMarginFrame is not null && _chartView.DrawMarginFrame != _previousDrawMarginFrame)
                 {
                     _previousDrawMarginFrame.RemoveFromUI(this);
                     _previousDrawMarginFrame = null;
                 }
-                if (_chartView.DrawMarginFrame != null)
+                if (_chartView.DrawMarginFrame is not null)
                 {
                     _chartView.DrawMarginFrame.Measure(this);
                     _chartView.DrawMarginFrame.RemoveOldPaints(View);

--- a/src/LiveChartsCore/CartesianChart.cs
+++ b/src/LiveChartsCore/CartesianChart.cs
@@ -137,7 +137,7 @@ namespace LiveChartsCore
         /// <inheritdoc cref="IChart.Update(ChartUpdateParams?)" />
         public override void Update(ChartUpdateParams? chartUpdateParams = null)
         {
-            if (chartUpdateParams is null) chartUpdateParams = new ChartUpdateParams();
+            chartUpdateParams ??= new ChartUpdateParams();
             if (chartUpdateParams.IsAutomaticUpdate && !View.AutoUpdateEnaled) return;
             if (!chartUpdateParams.Throttling)
             {

--- a/src/LiveChartsCore/CartesianSeries.cs
+++ b/src/LiveChartsCore/CartesianSeries.cs
@@ -24,7 +24,6 @@ using LiveChartsCore.Kernel;
 using LiveChartsCore.Drawing;
 using System;
 using LiveChartsCore.Measure;
-using System.Collections.Generic;
 using System.Drawing;
 using LiveChartsCore.Kernel.Sketches;
 using LiveChartsCore.Kernel.Data;

--- a/src/LiveChartsCore/CartesianSeries.cs
+++ b/src/LiveChartsCore/CartesianSeries.cs
@@ -69,7 +69,7 @@ namespace LiveChartsCore
         public virtual SeriesBounds GetBounds(
             CartesianChart<TDrawingContext> chart, IAxis<TDrawingContext> x, IAxis<TDrawingContext> y)
         {
-            return dataProvider == null
+            return dataProvider is null
                 ? throw new Exception("A data provider is required")
                 : dataProvider.GetCartesianBounds(chart, this, x, y);
         }

--- a/src/LiveChartsCore/CartesianSeries.cs
+++ b/src/LiveChartsCore/CartesianSeries.cs
@@ -54,7 +54,7 @@ namespace LiveChartsCore
         /// Initializes a new instance of the <see cref="CartesianSeries{TModel, TVisual, TLabel, TDrawingContext}"/> class.
         /// </summary>
         /// <param name="properties">The series properties.</param>
-        public CartesianSeries(SeriesProperties properties) : base(properties) { }
+        protected CartesianSeries(SeriesProperties properties) : base(properties) { }
 
         /// <inheritdoc cref="ICartesianSeries{TDrawingContext}.ScalesXAt"/>
         public int ScalesXAt { get => _scalesXAt; set { _scalesXAt = value; OnPropertyChanged(); } }

--- a/src/LiveChartsCore/Chart.cs
+++ b/src/LiveChartsCore/Chart.cs
@@ -164,7 +164,7 @@ namespace LiveChartsCore
 
         private void TooltipThrottlerUnlocked()
         {
-            if (tooltip == null || TooltipPosition == TooltipPosition.Hidden) return;
+            if (tooltip is null || TooltipPosition == TooltipPosition.Hidden) return;
             tooltip.Show(FindPointsNearTo(_pointerPosition), this);
         }
 
@@ -190,7 +190,7 @@ namespace LiveChartsCore
         {
             _pointerPosition = pointerPosition;
 
-            if (tooltip != null && TooltipPosition != TooltipPosition.Hidden) _tooltipThrottler.Call();
+            if (tooltip is not null && TooltipPosition != TooltipPosition.Hidden) _tooltipThrottler.Call();
             if (!_isPanning) return;
             _pointerPanningPosition = pointerPosition;
             _panningThrottler.Call();

--- a/src/LiveChartsCore/Chart.cs
+++ b/src/LiveChartsCore/Chart.cs
@@ -146,7 +146,7 @@ namespace LiveChartsCore
         /// </summary>
         /// <param name="canvas">The canvas.</param>
         /// <param name="defaultPlatformConfig">The default platform configuration.</param>
-        public Chart(MotionCanvas<TDrawingContext> canvas, Action<LiveChartsSettings> defaultPlatformConfig)
+        protected Chart(MotionCanvas<TDrawingContext> canvas, Action<LiveChartsSettings> defaultPlatformConfig)
         {
             this.canvas = canvas;
             canvas.Validated += OnCanvasValidated;

--- a/src/LiveChartsCore/ChartSeries.cs
+++ b/src/LiveChartsCore/ChartSeries.cs
@@ -107,7 +107,7 @@ namespace LiveChartsCore
         {
             var stylesBuilder = LiveCharts.CurrentSettings.GetTheme<TDrawingContext>();
             var initializer = stylesBuilder.GetVisualsInitializer();
-            if (stylesBuilder.CurrentColors == null || stylesBuilder.CurrentColors.Length == 0)
+            if (stylesBuilder.CurrentColors is null || stylesBuilder.CurrentColors.Length == 0)
                 throw new Exception("Default colors are not valid");
 
             initializer.ApplyStyleToSeries(this);

--- a/src/LiveChartsCore/ChartSeries.cs
+++ b/src/LiveChartsCore/ChartSeries.cs
@@ -57,7 +57,7 @@ namespace LiveChartsCore
         /// Initializes a new instance of the <see cref="ChartSeries{TModel, TVisual, TLabel, TDrawingContext}"/> class.
         /// </summary>
         /// <param name="properties">The properties.</param>
-        public ChartSeries(SeriesProperties properties) : base(properties) { }
+        protected ChartSeries(SeriesProperties properties) : base(properties) { }
 
         /// <inheritdoc cref="IChartSeries{TDrawingContext}.DataLabelsPaint"/>
         public IPaintTask<TDrawingContext>? DataLabelsPaint

--- a/src/LiveChartsCore/Collections/RangeObservableCollection.cs
+++ b/src/LiveChartsCore/Collections/RangeObservableCollection.cs
@@ -137,7 +137,7 @@ namespace LiveChartsCore.Collections // we use this namespace, because .Net migh
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="index"/> is not in the collection range.</exception>
         public void InsertRange(int index, IEnumerable<T> collection)
         {
-            if (collection == null)
+            if (collection is null)
                 throw new ArgumentNullException(nameof(collection));
             if (index < 0)
                 throw new ArgumentOutOfRangeException(nameof(index));
@@ -181,7 +181,7 @@ namespace LiveChartsCore.Collections // we use this namespace, because .Net migh
         /// <exception cref="ArgumentNullException"><paramref name="collection"/> is null.</exception>
         public void RemoveRange(IEnumerable<T> collection)
         {
-            if (collection == null)
+            if (collection is null)
                 throw new ArgumentNullException(nameof(collection));
 
             if (Count == 0)
@@ -214,7 +214,7 @@ namespace LiveChartsCore.Collections // we use this namespace, because .Net migh
 
                 Items.RemoveAt(index);
 
-                if (lastIndex == index && lastCluster != null)
+                if (lastIndex == index && lastCluster is not null)
                     lastCluster.Add(item);
                 else
                     clusters[lastIndex = index] = lastCluster = new List<T> { item };
@@ -261,7 +261,7 @@ namespace LiveChartsCore.Collections // we use this namespace, because .Net migh
                 throw new ArgumentOutOfRangeException(nameof(count));
             if (index + count > Count)
                 throw new ArgumentOutOfRangeException(nameof(index));
-            if (match == null)
+            if (match is null)
                 throw new ArgumentNullException(nameof(match));
 
             if (Count == 0)
@@ -284,7 +284,7 @@ namespace LiveChartsCore.Collections // we use this namespace, because .Net migh
 
                         if (clusterIndex == index)
                         {
-                            Debug.Assert(cluster != null);
+                            Debug.Assert(cluster is not null);
                             cluster!.Add(item);
                         }
                         else
@@ -382,7 +382,7 @@ namespace LiveChartsCore.Collections // we use this namespace, because .Net migh
             if (index + count > Count)
                 throw new ArgumentOutOfRangeException(nameof(index));
 
-            if (collection == null)
+            if (collection is null)
                 throw new ArgumentNullException(nameof(collection));
 
             if (!AllowDuplicates)
@@ -440,9 +440,9 @@ namespace LiveChartsCore.Collections // we use this namespace, because .Net migh
                     {
                         Items[i] = @new;
 
-                        if (newCluster == null)
+                        if (newCluster is null)
                         {
-                            Debug.Assert(oldCluster == null);
+                            Debug.Assert(oldCluster is null);
                             newCluster = new List<T> { @new };
                             oldCluster = new List<T> { old };
                         }
@@ -557,7 +557,7 @@ namespace LiveChartsCore.Collections // we use this namespace, because .Net migh
         /// </remarks>
         protected override void OnCollectionChanged(NotifyCollectionChangedEventArgs e)
         {
-            if (_deferredEvents != null)
+            if (_deferredEvents is not null)
             {
                 _deferredEvents.Add(e);
                 return;
@@ -628,9 +628,9 @@ namespace LiveChartsCore.Collections // we use this namespace, because .Net migh
         //move when supported language version updated.
         void OnRangeReplaced(int followingItemIndex, ICollection<T> newCluster, ICollection<T> oldCluster)
         {
-            if (oldCluster == null || oldCluster.Count == 0)
+            if (oldCluster is null || oldCluster.Count == 0)
             {
-                Debug.Assert(newCluster == null || newCluster.Count == 0);
+                Debug.Assert(newCluster is null || newCluster.Count == 0);
                 return;
             }
 
@@ -659,9 +659,9 @@ namespace LiveChartsCore.Collections // we use this namespace, because .Net migh
             readonly RangeObservableCollection<T> _collection;
             public DeferredEventsCollection(RangeObservableCollection<T> collection)
             {
-                Debug.Assert(collection != null);
+                Debug.Assert(collection is not null);
 #pragma warning disable CS8602 // Dereference of a possibly null reference.
-                Debug.Assert(collection._deferredEvents == null);
+                Debug.Assert(collection._deferredEvents is null);
 #pragma warning restore CS8602 // Dereference of a possibly null reference.
                 _collection = collection;
                 _collection._deferredEvents = this;

--- a/src/LiveChartsCore/ColumnSeries.cs
+++ b/src/LiveChartsCore/ColumnSeries.cs
@@ -70,12 +70,12 @@ namespace LiveChartsCore
             var secondaryScale = new Scaler(drawLocation, drawMarginSize, secondaryAxis);
             var primaryScale = new Scaler(drawLocation, drawMarginSize, primaryAxis);
             var previousPrimaryScale =
-                primaryAxis.PreviousDataBounds == null ? null : new Scaler(drawLocation, drawMarginSize, primaryAxis, true);
+                primaryAxis.PreviousDataBounds is null ? null : new Scaler(drawLocation, drawMarginSize, primaryAxis, true);
             var previousSecondaryScale =
-                secondaryAxis.PreviousDataBounds == null ? null : new Scaler(drawLocation, drawMarginSize, secondaryAxis, true);
+                secondaryAxis.PreviousDataBounds is null ? null : new Scaler(drawLocation, drawMarginSize, secondaryAxis, true);
 
             var uw = secondaryScale.ToPixels((float)secondaryAxis.UnitWidth) - secondaryScale.ToPixels(0f);
-            var puw = previousSecondaryScale == null ? 0 : previousSecondaryScale.ToPixels((float)secondaryAxis.UnitWidth) - previousSecondaryScale.ToPixels(0f);
+            var puw = previousSecondaryScale is null ? 0 : previousSecondaryScale.ToPixels((float)secondaryAxis.UnitWidth) - previousSecondaryScale.ToPixels(0f);
 
             uw -= (float)GroupPadding;
             puw -= (float)GroupPadding;
@@ -104,19 +104,19 @@ namespace LiveChartsCore
             var p = primaryScale.ToPixels(pivot);
 
             var actualZIndex = ZIndex == 0 ? ((ISeries)this).SeriesId : ZIndex;
-            if (Fill != null)
+            if (Fill is not null)
             {
                 Fill.ZIndex = actualZIndex + 0.1;
                 Fill.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
                 cartesianChart.Canvas.AddDrawableTask(Fill);
             }
-            if (Stroke != null)
+            if (Stroke is not null)
             {
                 Stroke.ZIndex = actualZIndex + 0.2;
                 Stroke.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
                 cartesianChart.Canvas.AddDrawableTask(Stroke);
             }
-            if (DataLabelsPaint != null)
+            if (DataLabelsPaint is not null)
             {
                 DataLabelsPaint.ZIndex = actualZIndex + 0.3;
                 DataLabelsPaint.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
@@ -138,7 +138,7 @@ namespace LiveChartsCore
 
                 if (point.IsNull)
                 {
-                    if (visual != null)
+                    if (visual is not null)
                     {
                         visual.X = secondary - uwm + cp;
                         visual.Y = p;
@@ -150,14 +150,14 @@ namespace LiveChartsCore
                     continue;
                 }
 
-                if (visual == null)
+                if (visual is null)
                 {
                     var xi = secondary - uwm + cp;
                     var pi = p;
                     var uwi = uw;
                     var hi = 0f;
 
-                    if (previousSecondaryScale != null && previousPrimaryScale != null)
+                    if (previousSecondaryScale is not null && previousPrimaryScale is not null)
                     {
                         var previousP = previousPrimaryScale.ToPixels(pivot);
                         var previousPrimary = previousPrimaryScale.ToPixels(point.PrimaryValue);
@@ -193,8 +193,8 @@ namespace LiveChartsCore
                     _ = everFetched.Add(point);
                 }
 
-                if (Fill != null) Fill.AddGeometryToPaintTask(cartesianChart.Canvas, visual);
-                if (Stroke != null) Stroke.AddGeometryToPaintTask(cartesianChart.Canvas, visual);
+                if (Fill is not null) Fill.AddGeometryToPaintTask(cartesianChart.Canvas, visual);
+                if (Stroke is not null) Stroke.AddGeometryToPaintTask(cartesianChart.Canvas, visual);
 
                 var cy = point.PrimaryValue > pivot ? primary : primary - b;
                 var x = secondary - uwm + cp;
@@ -217,11 +217,11 @@ namespace LiveChartsCore
                 OnPointMeasured(point);
                 _ = toDeletePoints.Remove(point);
 
-                if (DataLabelsPaint != null)
+                if (DataLabelsPaint is not null)
                 {
                     var label = (TLabel?)point.Context.Label;
 
-                    if (label == null)
+                    if (label is null)
                     {
                         var l = new TLabel { X = secondary - uwm + cp, Y = p };
 
@@ -335,7 +335,7 @@ namespace LiveChartsCore
         protected override void SoftDeletePoint(ChartPoint point, Scaler primaryScale, Scaler secondaryScale)
         {
             var visual = (TVisual?)point.Context.Visual;
-            if (visual == null) return;
+            if (visual is null) return;
 
             var chartView = (ICartesianChartView<TDrawingContext>)point.Context.Chart;
             if (chartView.Core.IsZoomingOrPanning)
@@ -353,11 +353,11 @@ namespace LiveChartsCore
             visual.Height = 0;
             visual.RemoveOnCompleted = true;
 
-            if (dataProvider == null) throw new Exception("Data provider not found");
+            if (dataProvider is null) throw new Exception("Data provider not found");
             dataProvider.DisposePoint(point);
 
             var label = (TLabel?)point.Context.Label;
-            if (label == null) return;
+            if (label is null) return;
 
             label.TextSize = 1;
             label.RemoveOnCompleted = true;

--- a/src/LiveChartsCore/ColumnSeries.cs
+++ b/src/LiveChartsCore/ColumnSeries.cs
@@ -49,7 +49,7 @@ namespace LiveChartsCore
         /// <summary>
         /// Initializes a new instance of the <see cref="ColumnSeries{TModel, TVisual, TLabel, TDrawingContext}"/> class.
         /// </summary>
-        public ColumnSeries()
+        protected ColumnSeries()
             : base(
                   SeriesProperties.Bar | SeriesProperties.PrimaryAxisVerticalOrientation |
                   SeriesProperties.Solid | SeriesProperties.PrefersXStrategyTooltips)

--- a/src/LiveChartsCore/DrawMarginFrame.cs
+++ b/src/LiveChartsCore/DrawMarginFrame.cs
@@ -117,11 +117,11 @@ namespace LiveChartsCore
             var drawLocation = chart.DrawMarginLocation;
             var drawMarginSize = chart.DrawMarginSize;
 
-            if (Fill != null)
+            if (Fill is not null)
             {
                 Fill.ZIndex = -3;
 
-                if (_fillSizedGeometry == null) _fillSizedGeometry = new TSizedGeometry();
+                if (_fillSizedGeometry is null) _fillSizedGeometry = new TSizedGeometry();
 
                 _fillSizedGeometry.X = drawLocation.X;
                 _fillSizedGeometry.Y = drawLocation.Y;
@@ -132,11 +132,11 @@ namespace LiveChartsCore
                 chart.Canvas.AddDrawableTask(Fill);
             }
 
-            if (Stroke != null)
+            if (Stroke is not null)
             {
                 Stroke.ZIndex = -2;
 
-                if (_strokeSizedGeometry == null) _strokeSizedGeometry = new TSizedGeometry();
+                if (_strokeSizedGeometry is null) _strokeSizedGeometry = new TSizedGeometry();
 
                 _strokeSizedGeometry.X = drawLocation.X;
                 _strokeSizedGeometry.Y = drawLocation.Y;

--- a/src/LiveChartsCore/DrawMarginFrame.cs
+++ b/src/LiveChartsCore/DrawMarginFrame.cs
@@ -121,7 +121,7 @@ namespace LiveChartsCore
             {
                 Fill.ZIndex = -3;
 
-                if (_fillSizedGeometry is null) _fillSizedGeometry = new TSizedGeometry();
+                _fillSizedGeometry ??= new TSizedGeometry();
 
                 _fillSizedGeometry.X = drawLocation.X;
                 _fillSizedGeometry.Y = drawLocation.Y;
@@ -136,7 +136,7 @@ namespace LiveChartsCore
             {
                 Stroke.ZIndex = -2;
 
-                if (_strokeSizedGeometry is null) _strokeSizedGeometry = new TSizedGeometry();
+                _strokeSizedGeometry ??= new TSizedGeometry();
 
                 _strokeSizedGeometry.X = drawLocation.X;
                 _strokeSizedGeometry.Y = drawLocation.Y;

--- a/src/LiveChartsCore/Drawing/Animatable.cs
+++ b/src/LiveChartsCore/Drawing/Animatable.cs
@@ -41,7 +41,7 @@ namespace LiveChartsCore.Drawing.Common
         /// <summary>
         /// Initializes a new instance of the <see cref="Animatable"/> class.
         /// </summary>
-        public Animatable() { }
+        protected Animatable() { }
 
         /// <inheritdoc cref="IAnimatable.IsValid" />
         bool IAnimatable.IsValid { get => _isCompleted; set => _isCompleted = value; }

--- a/src/LiveChartsCore/Drawing/Animatable.cs
+++ b/src/LiveChartsCore/Drawing/Animatable.cs
@@ -90,7 +90,7 @@ namespace LiveChartsCore.Drawing.Common
         /// <inheritdoc cref="IAnimatable.CompleteTransitions(string[])" />
         public void CompleteTransitions(params string[] propertyNames)
         {
-            if (propertyNames == null || propertyNames.Length == 0)
+            if (propertyNames is null || propertyNames.Length == 0)
                 throw new Exception(
                     $"At least one property is required to call {nameof(CompleteTransitions)}.");
 
@@ -100,7 +100,7 @@ namespace LiveChartsCore.Drawing.Common
                     throw new Exception(
                         $"The property {property} is not a transition property of this instance.");
 
-                if (transitionProperty.Animation == null) continue;
+                if (transitionProperty.Animation is null) continue;
                 transitionProperty.IsCompleted = true;
             }
         }

--- a/src/LiveChartsCore/Drawing/IPathGeometry.cs
+++ b/src/LiveChartsCore/Drawing/IPathGeometry.cs
@@ -20,8 +20,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Collections.Generic;
-
 namespace LiveChartsCore.Drawing
 {
     /// <summary>

--- a/src/LiveChartsCore/Drawing/ISizedVisualChartPoint.cs
+++ b/src/LiveChartsCore/Drawing/ISizedVisualChartPoint.cs
@@ -20,8 +20,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Drawing;
-
 namespace LiveChartsCore.Drawing
 {
     /// <summary>

--- a/src/LiveChartsCore/Drawing/MotionCanvas.cs
+++ b/src/LiveChartsCore/Drawing/MotionCanvas.cs
@@ -94,7 +94,7 @@ namespace LiveChartsCore.Drawing
 
                     foreach (var geometry in task.GetGeometries(this))
                     {
-                        if (geometry == null) continue;
+                        if (geometry is null) continue;
 
                         geometry.IsValid = true;
                         geometry.CurrentTime = frameTime;

--- a/src/LiveChartsCore/FinancialSeries.cs
+++ b/src/LiveChartsCore/FinancialSeries.cs
@@ -55,7 +55,7 @@ namespace LiveChartsCore
         /// <summary>
         /// Initializes a new instance of the <see cref="FinancialSeries{TModel, TVisual, TLabel, TDrawingContext}"/> class.
         /// </summary>
-        public FinancialSeries()
+        protected FinancialSeries()
             : base(
                  SeriesProperties.Financial | SeriesProperties.PrimaryAxisVerticalOrientation |
                  SeriesProperties.Solid | SeriesProperties.PrefersXStrategyTooltips)

--- a/src/LiveChartsCore/FinancialSeries.cs
+++ b/src/LiveChartsCore/FinancialSeries.cs
@@ -107,12 +107,12 @@ namespace LiveChartsCore
             var secondaryScale = new Scaler(drawLocation, drawMarginSize, secondaryAxis);
             var primaryScale = new Scaler(drawLocation, drawMarginSize, primaryAxis);
             var previousPrimaryScale =
-                primaryAxis.PreviousDataBounds == null ? null : new Scaler(drawLocation, drawMarginSize, primaryAxis, true);
+                primaryAxis.PreviousDataBounds is null ? null : new Scaler(drawLocation, drawMarginSize, primaryAxis, true);
             var previousSecondaryScale =
-                secondaryAxis.PreviousDataBounds == null ? null : new Scaler(drawLocation, drawMarginSize, secondaryAxis, true);
+                secondaryAxis.PreviousDataBounds is null ? null : new Scaler(drawLocation, drawMarginSize, secondaryAxis, true);
 
             var uw = secondaryScale.ToPixels((float)secondaryAxis.UnitWidth) - secondaryScale.ToPixels(0f);
-            var puw = previousSecondaryScale == null ? 0 : previousSecondaryScale.ToPixels((float)secondaryAxis.UnitWidth) - previousSecondaryScale.ToPixels(0f);
+            var puw = previousSecondaryScale is null ? 0 : previousSecondaryScale.ToPixels((float)secondaryAxis.UnitWidth) - previousSecondaryScale.ToPixels(0f);
             var uwm = 0.5f * uw;
 
             if (uw > MaxBarWidth)
@@ -124,31 +124,31 @@ namespace LiveChartsCore
 
             var actualZIndex = ZIndex == 0 ? ((ISeries)this).SeriesId : ZIndex;
 
-            if (UpFill != null)
+            if (UpFill is not null)
             {
                 UpFill.ZIndex = actualZIndex + 0.1;
                 UpFill.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
                 cartesianChart.Canvas.AddDrawableTask(UpFill);
             }
-            if (DownFill != null)
+            if (DownFill is not null)
             {
                 DownFill.ZIndex = actualZIndex + 0.1;
                 DownFill.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
                 cartesianChart.Canvas.AddDrawableTask(DownFill);
             }
-            if (UpStroke != null)
+            if (UpStroke is not null)
             {
                 UpStroke.ZIndex = actualZIndex + 0.2;
                 UpStroke.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
                 cartesianChart.Canvas.AddDrawableTask(UpStroke);
             }
-            if (DownStroke != null)
+            if (DownStroke is not null)
             {
                 DownStroke.ZIndex = actualZIndex + 0.2;
                 DownStroke.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
                 cartesianChart.Canvas.AddDrawableTask(DownStroke);
             }
-            if (DataLabelsPaint != null)
+            if (DataLabelsPaint is not null)
             {
                 DataLabelsPaint.ZIndex = actualZIndex + 0.3;
                 DataLabelsPaint.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
@@ -171,7 +171,7 @@ namespace LiveChartsCore
 
                 if (point.IsNull)
                 {
-                    if (visual != null)
+                    if (visual is not null)
                     {
                         visual.X = secondary - uwm;
                         visual.Width = uw;
@@ -185,13 +185,13 @@ namespace LiveChartsCore
                     continue;
                 }
 
-                if (visual == null)
+                if (visual is null)
                 {
                     var xi = secondary - uwm;
                     var uwi = uw;
                     var hi = 0f;
 
-                    if (previousSecondaryScale != null && previousPrimaryScale != null)
+                    if (previousSecondaryScale is not null && previousPrimaryScale is not null)
                     {
                         var previousP = previousPrimaryScale.ToPixels(pivot);
                         var previousPrimary = previousPrimaryScale.ToPixels(point.PrimaryValue);
@@ -223,17 +223,17 @@ namespace LiveChartsCore
 
                 if (open > close)
                 {
-                    if (UpFill != null) UpFill.AddGeometryToPaintTask(cartesianChart.Canvas, visual);
-                    if (UpStroke != null) UpStroke.AddGeometryToPaintTask(cartesianChart.Canvas, visual);
-                    if (DownFill != null) DownFill.RemoveGeometryFromPainTask(cartesianChart.Canvas, visual);
-                    if (DownStroke != null) DownStroke.RemoveGeometryFromPainTask(cartesianChart.Canvas, visual);
+                    if (UpFill is not null) UpFill.AddGeometryToPaintTask(cartesianChart.Canvas, visual);
+                    if (UpStroke is not null) UpStroke.AddGeometryToPaintTask(cartesianChart.Canvas, visual);
+                    if (DownFill is not null) DownFill.RemoveGeometryFromPainTask(cartesianChart.Canvas, visual);
+                    if (DownStroke is not null) DownStroke.RemoveGeometryFromPainTask(cartesianChart.Canvas, visual);
                 }
                 else
                 {
-                    if (DownFill != null) DownFill.AddGeometryToPaintTask(cartesianChart.Canvas, visual);
-                    if (DownStroke != null) DownStroke.AddGeometryToPaintTask(cartesianChart.Canvas, visual);
-                    if (UpFill != null) UpFill.RemoveGeometryFromPainTask(cartesianChart.Canvas, visual);
-                    if (UpStroke != null) UpStroke.RemoveGeometryFromPainTask(cartesianChart.Canvas, visual);
+                    if (DownFill is not null) DownFill.AddGeometryToPaintTask(cartesianChart.Canvas, visual);
+                    if (DownStroke is not null) DownStroke.AddGeometryToPaintTask(cartesianChart.Canvas, visual);
+                    if (UpFill is not null) UpFill.RemoveGeometryFromPainTask(cartesianChart.Canvas, visual);
+                    if (UpStroke is not null) UpStroke.RemoveGeometryFromPainTask(cartesianChart.Canvas, visual);
                 }
 
                 var x = secondary - uwm;
@@ -252,11 +252,11 @@ namespace LiveChartsCore
                 OnPointMeasured(point);
                 _ = toDeletePoints.Remove(point);
 
-                if (DataLabelsPaint != null)
+                if (DataLabelsPaint is not null)
                 {
                     var label = (TLabel?)point.Context.Label;
 
-                    if (label == null)
+                    if (label is null)
                     {
                         var l = new TLabel { X = secondary - uwm, Y = high };
 
@@ -296,7 +296,7 @@ namespace LiveChartsCore
         public override SeriesBounds GetBounds(
             CartesianChart<TDrawingContext> chart, IAxis<TDrawingContext> secondaryAxis, IAxis<TDrawingContext> primaryAxis)
         {
-            if (dataProvider == null) throw new Exception("A data provider is required");
+            if (dataProvider is null) throw new Exception("A data provider is required");
 
             var baseSeriesBounds = dataProvider.GetFinancialBounds(chart, this, secondaryAxis, primaryAxis);
             if (baseSeriesBounds.IsPrevious) return baseSeriesBounds;
@@ -375,7 +375,7 @@ namespace LiveChartsCore
         protected override void SoftDeletePoint(ChartPoint point, Scaler primaryScale, Scaler secondaryScale)
         {
             var visual = (TVisual?)point.Context.Visual;
-            if (visual == null) return;
+            if (visual is null) return;
 
             var chartView = (ICartesianChartView<TDrawingContext>)point.Context.Chart;
             if (chartView.Core.IsZoomingOrPanning)
@@ -395,11 +395,11 @@ namespace LiveChartsCore
             visual.Low = p;
             visual.RemoveOnCompleted = true;
 
-            if (dataProvider == null) throw new Exception("Data provider not found");
+            if (dataProvider is null) throw new Exception("Data provider not found");
             dataProvider.DisposePoint(point);
 
             var label = (TLabel?)point.Context.Label;
-            if (label == null) return;
+            if (label is null) return;
 
             label.TextSize = 1;
             label.RemoveOnCompleted = true;
@@ -443,7 +443,7 @@ namespace LiveChartsCore
             var context = new CanvasSchedule<TDrawingContext>();
             var w = LegendShapeSize;
             var sh = 0f;
-            //if (Stroke != null)
+            //if (Stroke is not null)
             //{
             //    var strokeClone = Stroke.CloneTask();
             //    var visual = new TVisual
@@ -459,7 +459,7 @@ namespace LiveChartsCore
             //    context.PaintSchedules.Add(new PaintSchedule<TDrawingContext>(strokeClone, visual));
             //}
 
-            //if (Fill != null)
+            //if (Fill is not null)
             //{
             //    var fillClone = Fill.CloneTask();
             //    var visual = new TVisual { X = sh, Y = sh, Height = (float)LegendShapeSize, Width = (float)LegendShapeSize };
@@ -500,7 +500,7 @@ namespace LiveChartsCore
 
             foreach (var pt in GetPaintTasks())
             {
-                if (pt != null) core.Canvas.RemovePaintTask(pt);
+                if (pt is not null) core.Canvas.RemovePaintTask(pt);
             }
 
             foreach (var item in deleted) _ = everFetched.Remove(item);

--- a/src/LiveChartsCore/Geo/GeoJsonFile.cs
+++ b/src/LiveChartsCore/Geo/GeoJsonFile.cs
@@ -78,11 +78,11 @@ namespace LiveChartsCore.Geo
         {
             var index = new Dictionary<string, GeoJsonFeature>();
 
-            if (Features == null) return index;
+            if (Features is null) return index;
 
             foreach (var feature in Features)
             {
-                if (feature.Geometry == null || feature.Geometry.Coordinates == null) continue;
+                if (feature.Geometry is null || feature.Geometry.Coordinates is null) continue;
 
                 foreach (var geometry in feature.Geometry.Coordinates)
                 {

--- a/src/LiveChartsCore/HeatFunctions.cs
+++ b/src/LiveChartsCore/HeatFunctions.cs
@@ -47,7 +47,7 @@ namespace LiveChartsCore
         {
             if (heatMap.Length < 2) throw new Exception("At least 2 colors are required in a heat map.");
 
-            if (colorStops == null)
+            if (colorStops is null)
             {
                 var s = 1 / (double)(heatMap.Length - 1);
                 colorStops = new double[heatMap.Length];

--- a/src/LiveChartsCore/HeatSeries.cs
+++ b/src/LiveChartsCore/HeatSeries.cs
@@ -79,7 +79,7 @@ namespace LiveChartsCore
         /// <inheritdoc cref="ChartElement{TDrawingContext}.Measure(Chart{TDrawingContext})"/>
         public override void Measure(Chart<TDrawingContext> chart)
         {
-            if (_paintTaks is null) _paintTaks = GetSolidColorPaintTask();
+            _paintTaks ??= GetSolidColorPaintTask();
 
             var cartesianChart = (CartesianChart<TDrawingContext>)chart;
             var primaryAxis = cartesianChart.YAxes[ScalesYAt];

--- a/src/LiveChartsCore/HeatSeries.cs
+++ b/src/LiveChartsCore/HeatSeries.cs
@@ -79,7 +79,7 @@ namespace LiveChartsCore
         /// <inheritdoc cref="ChartElement{TDrawingContext}.Measure(Chart{TDrawingContext})"/>
         public override void Measure(Chart<TDrawingContext> chart)
         {
-            if (_paintTaks == null) _paintTaks = GetSolidColorPaintTask();
+            if (_paintTaks is null) _paintTaks = GetSolidColorPaintTask();
 
             var cartesianChart = (CartesianChart<TDrawingContext>)chart;
             var primaryAxis = cartesianChart.YAxes[ScalesYAt];
@@ -90,21 +90,21 @@ namespace LiveChartsCore
             var secondaryScale = new Scaler(drawLocation, drawMarginSize, secondaryAxis);
             var primaryScale = new Scaler(drawLocation, drawMarginSize, primaryAxis);
             var previousPrimaryScale =
-                primaryAxis.PreviousDataBounds == null ? null : new Scaler(drawLocation, drawMarginSize, primaryAxis, true);
+                primaryAxis.PreviousDataBounds is null ? null : new Scaler(drawLocation, drawMarginSize, primaryAxis, true);
             var previousSecondaryScale =
-                secondaryAxis.PreviousDataBounds == null ? null : new Scaler(drawLocation, drawMarginSize, secondaryAxis, true);
+                secondaryAxis.PreviousDataBounds is null ? null : new Scaler(drawLocation, drawMarginSize, secondaryAxis, true);
 
             var uws = secondaryScale.ToPixels((float)secondaryAxis.UnitWidth) - secondaryScale.ToPixels(0f);
             var uwp = primaryScale.ToPixels(0f) - primaryScale.ToPixels((float)primaryAxis.UnitWidth);
 
             var actualZIndex = ZIndex == 0 ? ((ISeries)this).SeriesId : ZIndex;
-            if (_paintTaks != null)
+            if (_paintTaks is not null)
             {
                 _paintTaks.ZIndex = actualZIndex + 0.2;
                 _paintTaks.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
                 cartesianChart.Canvas.AddDrawableTask(_paintTaks);
             }
-            if (DataLabelsPaint != null)
+            if (DataLabelsPaint is not null)
             {
                 DataLabelsPaint.ZIndex = actualZIndex + 0.3;
                 DataLabelsPaint.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
@@ -133,7 +133,7 @@ namespace LiveChartsCore
 
                 if (point.IsNull)
                 {
-                    if (visual != null)
+                    if (visual is not null)
                     {
                         visual.X = secondary - uws * 0.5f;
                         visual.Y = primary - uwp * 0.5f;
@@ -146,12 +146,12 @@ namespace LiveChartsCore
                     continue;
                 }
 
-                if (visual == null)
+                if (visual is null)
                 {
                     var xi = secondary - uws * 0.5f;
                     var yi = primary - uwp * 0.5f;
 
-                    if (previousSecondaryScale != null && previousPrimaryScale != null)
+                    if (previousSecondaryScale is not null && previousPrimaryScale is not null)
                     {
                         var previousP = previousPrimaryScale.ToPixels(pivot);
                         var previousPrimary = previousPrimaryScale.ToPixels(point.PrimaryValue);
@@ -179,7 +179,7 @@ namespace LiveChartsCore
                     _ = everFetched.Add(point);
                 }
 
-                if (_paintTaks != null) _paintTaks.AddGeometryToPaintTask(cartesianChart.Canvas, visual);
+                if (_paintTaks is not null) _paintTaks.AddGeometryToPaintTask(cartesianChart.Canvas, visual);
 
                 visual.X = secondary - uws * 0.5f + p.Left;
                 visual.Y = primary - uwp * 0.5f + p.Top;
@@ -194,11 +194,11 @@ namespace LiveChartsCore
                 OnPointMeasured(point);
                 _ = toDeletePoints.Remove(point);
 
-                if (DataLabelsPaint != null)
+                if (DataLabelsPaint is not null)
                 {
                     var label = (TLabel?)point.Context.Label;
 
-                    if (label == null)
+                    if (label is null)
                     {
                         var l = new TLabel { X = secondary - uws * 0.5f, Y = primary - uws * 0.5f };
 
@@ -315,7 +315,7 @@ namespace LiveChartsCore
         protected override void SoftDeletePoint(ChartPoint point, Scaler primaryScale, Scaler secondaryScale)
         {
             var visual = (TVisual?)point.Context.Visual;
-            if (visual == null) return;
+            if (visual is null) return;
 
             var chartView = (ICartesianChartView<TDrawingContext>)point.Context.Chart;
             if (chartView.Core.IsZoomingOrPanning)
@@ -328,11 +328,11 @@ namespace LiveChartsCore
             visual.Color = Color.FromArgb(255, visual.Color);
             visual.RemoveOnCompleted = true;
 
-            if (dataProvider == null) throw new Exception("Data provider not found");
+            if (dataProvider is null) throw new Exception("Data provider not found");
             dataProvider.DisposePoint(point);
 
             var label = (TLabel?)point.Context.Label;
-            if (label == null) return;
+            if (label is null) return;
 
             label.TextSize = 1;
             label.RemoveOnCompleted = true;
@@ -352,7 +352,7 @@ namespace LiveChartsCore
             var context = new CanvasSchedule<TDrawingContext>();
             var w = LegendShapeSize;
             var sh = 0f;
-            //if (Stroke != null)
+            //if (Stroke is not null)
             //{
             //    var strokeClone = Stroke.CloneTask();
             //    var visual = new TVisual
@@ -368,7 +368,7 @@ namespace LiveChartsCore
             //    context.PaintSchedules.Add(new PaintSchedule<TDrawingContext>(strokeClone, visual));
             //}
 
-            //if (Fill != null)
+            //if (Fill is not null)
             //{
             //    var fillClone = Fill.CloneTask();
             //    var visual = new TVisual { X = sh, Y = sh, Height = (float)LegendShapeSize, Width = (float)LegendShapeSize };
@@ -420,8 +420,8 @@ namespace LiveChartsCore
                 deleted.Add(point);
             }
 
-            if (_paintTaks != null) core.Canvas.RemovePaintTask(_paintTaks);
-            if (DataLabelsPaint != null) core.Canvas.RemovePaintTask(DataLabelsPaint);
+            if (_paintTaks is not null) core.Canvas.RemovePaintTask(_paintTaks);
+            if (DataLabelsPaint is not null) core.Canvas.RemovePaintTask(DataLabelsPaint);
 
             foreach (var item in deleted) _ = everFetched.Remove(item);
         }

--- a/src/LiveChartsCore/HeatSeries.cs
+++ b/src/LiveChartsCore/HeatSeries.cs
@@ -53,7 +53,7 @@ namespace LiveChartsCore
         /// <summary>
         /// Initializes a new instance of the <see cref="HeatSeries{TModel, TVisual, TLabel, TDrawingContext}"/> class.
         /// </summary>
-        public HeatSeries()
+        protected HeatSeries()
             : base(
                  SeriesProperties.Heat | SeriesProperties.PrimaryAxisVerticalOrientation |
                  SeriesProperties.Solid | SeriesProperties.PrefersXYStrategyTooltips)

--- a/src/LiveChartsCore/Kernel/ChartElement.cs
+++ b/src/LiveChartsCore/Kernel/ChartElement.cs
@@ -57,7 +57,7 @@ namespace LiveChartsCore.Kernel
         {
             foreach (var item in GetPaintTasks())
             {
-                if (item == null) continue;
+                if (item is null) continue;
                 chart.Canvas.RemovePaintTask(item);
                 item.ClearGeometriesFromPaintTask(chart.Canvas);
             }
@@ -77,9 +77,9 @@ namespace LiveChartsCore.Kernel
             bool isStroke = false,
             [CallerMemberName] string? propertyName = null)
         {
-            if (reference != null) ScheduleDeleteFor(reference);
+            if (reference is not null) ScheduleDeleteFor(reference);
             reference = value;
-            if (reference != null)
+            if (reference is not null)
             {
                 reference.IsStroke = isStroke;
                 reference.IsFill = !isStroke; // seems unnecessary ????

--- a/src/LiveChartsCore/Kernel/CollectionDeepObserver.cs
+++ b/src/LiveChartsCore/Kernel/CollectionDeepObserver.cs
@@ -57,7 +57,7 @@ namespace LiveChartsCore.Kernel
             _onCollectionChanged = onCollectionChanged;
             _onItemPropertyChanged = onItemPropertyChanged;
 
-            if (checkINotifyPropertyChanged != null)
+            if (checkINotifyPropertyChanged is not null)
             {
                 this.checkINotifyPropertyChanged = checkINotifyPropertyChanged.Value;
                 return;
@@ -73,7 +73,7 @@ namespace LiveChartsCore.Kernel
         /// <returns></returns>
         public void Initialize(IEnumerable<T>? instance)
         {
-            if (instance == null) return;
+            if (instance is null) return;
 
             if (instance is INotifyCollectionChanged incc)
             {
@@ -92,7 +92,7 @@ namespace LiveChartsCore.Kernel
         /// <returns></returns>
         public void Dispose(IEnumerable<T>? instance)
         {
-            if (instance == null) return;
+            if (instance is null) return;
 
             if (instance is INotifyCollectionChanged incc)
             {

--- a/src/LiveChartsCore/Kernel/Data/DataProvider.cs
+++ b/src/LiveChartsCore/Kernel/Data/DataProvider.cs
@@ -74,7 +74,7 @@ namespace LiveChartsCore.Kernel.Data
         /// <returns></returns>
         public virtual IEnumerable<ChartPoint> Fetch(ISeries<TModel> series, IChart chart)
         {
-            if (series.Values == null) yield break;
+            if (series.Values is null) yield break;
 
             var mapper = series.Mapping ?? LiveCharts.CurrentSettings.GetMap<TModel>();
             var index = 0;
@@ -83,7 +83,7 @@ namespace LiveChartsCore.Kernel.Data
             {
                 var canvas = (MotionCanvas<TDrawingContext>)chart.Canvas;
                 _ = _byChartbyValueVisualMap.TryGetValue(canvas.Sync, out var d);
-                if (d == null)
+                if (d is null)
                 {
                     d = new Dictionary<int, ChartPoint>();
                     _byChartbyValueVisualMap[canvas.Sync] = d;
@@ -108,7 +108,7 @@ namespace LiveChartsCore.Kernel.Data
                 {
                     var canvas = (MotionCanvas<TDrawingContext>)chart.Canvas;
                     _ = _byChartByReferenceVisualMap.TryGetValue(canvas.Sync, out var d);
-                    if (d == null)
+                    if (d is null)
                     {
                         d = new Dictionary<TModel, ChartPoint>();
                         _byChartByReferenceVisualMap[canvas.Sync] = d;
@@ -138,16 +138,16 @@ namespace LiveChartsCore.Kernel.Data
                 var canvas = (MotionCanvas<TDrawingContext>)point.Context.Chart.CoreChart.Canvas;
                 _ = _byChartbyValueVisualMap.TryGetValue(canvas.Sync, out var d);
                 var byValueVisualMap = d;
-                if (d == null) return;
+                if (d is null) return;
                 _ = byValueVisualMap.Remove(point.Context.Index);
             }
             else
             {
-                if (point.Context.DataSource == null) return;
+                if (point.Context.DataSource is null) return;
                 var canvas = (MotionCanvas<TDrawingContext>)point.Context.Chart.CoreChart.Canvas;
                 _ = _byChartByReferenceVisualMap.TryGetValue(canvas.Sync, out var d);
                 var byReferenceVisualMap = d;
-                if (d == null) return;
+                if (d is null) return;
                 _ = byReferenceVisualMap.Remove((TModel)point.Context.DataSource);
             }
         }
@@ -185,7 +185,7 @@ namespace LiveChartsCore.Kernel.Data
                 var secondary = point.SecondaryValue;
                 var tertiary = point.TertiaryValue;
 
-                if (stack != null) primary = stack.StackPoint(point);
+                if (stack is not null) primary = stack.StackPoint(point);
 
                 bounds.PrimaryBounds.AppendValue(primary);
                 bounds.SecondaryBounds.AppendValue(secondary);
@@ -198,7 +198,7 @@ namespace LiveChartsCore.Kernel.Data
                     bounds.VisibleTertiaryBounds.AppendValue(tertiary);
                 }
 
-                if (previous != null)
+                if (previous is not null)
                 {
                     var dx = Math.Abs(previous.SecondaryValue - point.SecondaryValue);
                     var dy = Math.Abs(previous.PrimaryValue - point.PrimaryValue);
@@ -258,7 +258,7 @@ namespace LiveChartsCore.Kernel.Data
                     bounds.VisibleTertiaryBounds.AppendValue(tertiary);
                 }
 
-                if (previous != null)
+                if (previous is not null)
                 {
                     var dx = Math.Abs(previous.SecondaryValue - point.SecondaryValue);
                     var dy = Math.Abs(previous.PrimaryValue - point.PrimaryValue);
@@ -286,7 +286,7 @@ namespace LiveChartsCore.Kernel.Data
             PieChart<TDrawingContext> chart, IPieSeries<TDrawingContext> series)
         {
             var stack = chart.SeriesContext.GetStackPosition(series, series.GetStackGroup());
-            if (stack == null) throw new NullReferenceException("Unexpected null stacker");
+            if (stack is null) throw new NullReferenceException("Unexpected null stacker");
 
             var bounds = new DimensionalBounds();
             var hasData = false;

--- a/src/LiveChartsCore/Kernel/Extensions.cs
+++ b/src/LiveChartsCore/Kernel/Extensions.cs
@@ -54,7 +54,7 @@ namespace LiveChartsCore.Kernel
 
             foreach (var point in foundPoints)
             {
-                if (point.Point.Context.HoverArea == null) continue;
+                if (point.Point.Context.HoverArea is null) continue;
                 point.Point.Context.HoverArea.SuggestTooltipPlacement(placementContext);
                 count++;
             }
@@ -95,7 +95,7 @@ namespace LiveChartsCore.Kernel
 
             foreach (var foundPoint in foundPoints)
             {
-                if (foundPoint.Point.Context.HoverArea == null) continue;
+                if (foundPoint.Point.Context.HoverArea is null) continue;
                 foundPoint.Point.Context.HoverArea.SuggestTooltipPlacement(placementContext);
                 found = true;
                 break; // we only care about the first one.
@@ -128,8 +128,8 @@ namespace LiveChartsCore.Kernel
         public static AxisTick GetTick<TDrawingContext>(this IAxis<TDrawingContext> axis, SizeF controlSize, Bounds bounds)
            where TDrawingContext : DrawingContext
         {
-            var max = axis.MaxLimit == null ? bounds.Max : axis.MaxLimit.Value;
-            var min = axis.MinLimit == null ? bounds.Min : axis.MinLimit.Value;
+            var max = axis.MaxLimit is null ? bounds.Max : axis.MaxLimit.Value;
+            var min = axis.MinLimit is null ? bounds.Min : axis.MinLimit.Value;
 
             var range = max - min;
             var separations = axis.Orientation == AxisOrientation.Y
@@ -153,7 +153,7 @@ namespace LiveChartsCore.Kernel
         /// <exception cref="Exception">At least one property is required when calling {nameof(TransitionateProperties)}</exception>
         public static TransitionBuilder TransitionateProperties(this IAnimatable animatable, params string[] properties)
         {
-            return properties == null || properties.Length == 0
+            return properties is null || properties.Length == 0
                 ? throw new Exception($"At least one property is required when calling {nameof(TransitionateProperties)}")
                 : new TransitionBuilder(animatable, properties);
         }

--- a/src/LiveChartsCore/Kernel/LiveChartsSettings.cs
+++ b/src/LiveChartsCore/Kernel/LiveChartsSettings.cs
@@ -160,7 +160,7 @@ namespace LiveChartsCore.Kernel
         internal IDataFactoryProvider<TDrawingContext> GetFactory<TDrawingContext>()
             where TDrawingContext : DrawingContext
         {
-            return _currentFactory == null
+            return _currentFactory is null
                 ? throw new NotImplementedException($"There is no a {nameof(IDataFactoryProvider<TDrawingContext>)} registered")
                 : (IDataFactoryProvider<TDrawingContext>)_currentFactory;
         }
@@ -296,7 +296,7 @@ namespace LiveChartsCore.Kernel
                  })
                  .HasMap<short?>((model, point) =>
                  {
-                     if (model == null)
+                     if (model is null)
                      {
                          point.IsNull = true;
                          return;
@@ -307,7 +307,7 @@ namespace LiveChartsCore.Kernel
                  })
                  .HasMap<int?>((model, point) =>
                  {
-                     if (model == null)
+                     if (model is null)
                      {
                          point.IsNull = true;
                          return;
@@ -318,7 +318,7 @@ namespace LiveChartsCore.Kernel
                  })
                  .HasMap<long?>((model, point) =>
                  {
-                     if (model == null)
+                     if (model is null)
                      {
                          point.IsNull = true;
                          return;
@@ -329,7 +329,7 @@ namespace LiveChartsCore.Kernel
                  })
                  .HasMap<float?>((model, point) =>
                  {
-                     if (model == null)
+                     if (model is null)
                      {
                          point.IsNull = true;
                          return;
@@ -340,7 +340,7 @@ namespace LiveChartsCore.Kernel
                  })
                  .HasMap<double?>((model, point) =>
                  {
-                     if (model == null)
+                     if (model is null)
                      {
                          point.IsNull = true;
                          return;
@@ -351,7 +351,7 @@ namespace LiveChartsCore.Kernel
                  })
                  .HasMap<decimal?>((model, point) =>
                  {
-                     if (model == null)
+                     if (model is null)
                      {
                          point.IsNull = true;
                          return;
@@ -362,11 +362,11 @@ namespace LiveChartsCore.Kernel
                  })
                  .HasMap<WeightedPoint>((model, point) =>
                  {
-                     if (model == null)
+                     if (model is null)
                          throw new Exception(
                              $"A {nameof(WeightedPoint)} can not be null, instead set to null to any of its properties.");
 
-                     if (model.Weight == null || model.X == null || model.Y == null)
+                     if (model.Weight is null || model.X is null || model.Y is null)
                      {
                          point.IsNull = true;
                          return;
@@ -382,11 +382,11 @@ namespace LiveChartsCore.Kernel
                  })
                  .HasMap<ObservableValue>((model, point) =>
                  {
-                     if (model == null)
+                     if (model is null)
                          throw new Exception(
                              $"A {nameof(ObservableValue)} can not be null, instead set to null to any of its properties.");
 
-                     if (model.Value == null)
+                     if (model.Value is null)
                      {
                          point.IsNull = true;
                          return;
@@ -401,11 +401,11 @@ namespace LiveChartsCore.Kernel
                  })
                  .HasMap<ObservableValueF>((model, point) =>
                  {
-                     if (model == null)
+                     if (model is null)
                          throw new Exception(
                              $"A {nameof(ObservableValueF)} can not be null, instead set to null to any of its properties.");
 
-                     if (model.Value == null)
+                     if (model.Value is null)
                      {
                          point.IsNull = true;
                          return;
@@ -420,11 +420,11 @@ namespace LiveChartsCore.Kernel
                  })
                  .HasMap<ObservablePoint>((model, point) =>
                  {
-                     if (model == null)
+                     if (model is null)
                          throw new Exception(
                              $"A {nameof(ObservablePoint)} can not be null, instead set to null to any of its properties.");
 
-                     if (model.X == null || model.Y == null)
+                     if (model.X is null || model.Y is null)
                      {
                          point.IsNull = true;
                          return;
@@ -439,11 +439,11 @@ namespace LiveChartsCore.Kernel
                  })
                  .HasMap<ObservablePointF>((model, point) =>
                  {
-                     if (model == null)
+                     if (model is null)
                          throw new Exception(
                              $"A {nameof(ObservablePointF)} can not be null, instead set to null to any of its properties.");
 
-                     if (model.X == null || model.Y == null)
+                     if (model.X is null || model.Y is null)
                      {
                          point.IsNull = true;
                          return;
@@ -455,12 +455,12 @@ namespace LiveChartsCore.Kernel
                  })
                  .HasMap<DateTimePoint>((model, point) =>
                  {
-                     if (model == null)
+                     if (model is null)
                          throw new Exception(
                              $"A {nameof(DateTimePoint)} can not be null, instead set to null the " +
                              $"{nameof(DateTimePoint.Value)} property.");
 
-                     if (model.Value == null)
+                     if (model.Value is null)
                      {
                          point.IsNull = true;
                          return;
@@ -472,12 +472,12 @@ namespace LiveChartsCore.Kernel
                  })
                  .HasMap<DateTimePointF>((model, point) =>
                  {
-                     if (model == null)
+                     if (model is null)
                          throw new Exception(
                              $"A {nameof(DateTimePointF)} can not be null, instead set to null the " +
                              $"{nameof(DateTimePointF.Value)} property.");
 
-                     if (model.Value == null)
+                     if (model.Value is null)
                      {
                          point.IsNull = true;
                          return;
@@ -489,7 +489,7 @@ namespace LiveChartsCore.Kernel
                  })
                  .HasMap<FinancialPoint>((model, point) =>
                  {
-                     if (model == null)
+                     if (model is null)
                          throw new Exception(
                              $"A {nameof(DateTimePointF)} can not be null, instead set to null the " +
                              $"{nameof(DateTimePointF.Value)} property.");

--- a/src/LiveChartsCore/Kernel/PointStatesDictionary.cs
+++ b/src/LiveChartsCore/Kernel/PointStatesDictionary.cs
@@ -50,7 +50,7 @@ namespace LiveChartsCore.Kernel
             get => !_states.TryGetValue(stateName, out var state) ? null : state;
             set
             {
-                if (value == null)
+                if (value is null)
                     throw new InvalidOperationException(
                         $"A null instance is not valid at this point, to delete a key please use the {nameof(DeleteState)}() method.");
 
@@ -58,10 +58,10 @@ namespace LiveChartsCore.Kernel
 
                 _states[stateName] = value;
 
-                if (Chart == null) return;
+                if (Chart is null) return;
 
-                if (value.Fill != null) Chart.Canvas.AddDrawableTask(value.Fill);
-                if (value.Stroke != null) Chart.Canvas.AddDrawableTask(value.Stroke);
+                if (value.Fill is not null) Chart.Canvas.AddDrawableTask(value.Fill);
+                if (value.Stroke is not null) Chart.Canvas.AddDrawableTask(value.Stroke);
             }
         }
 
@@ -118,10 +118,10 @@ namespace LiveChartsCore.Kernel
         /// <returns></returns>
         private void RemoveState(StrokeAndFillDrawable<TDrawingContext> state)
         {
-            if (Chart == null) return;
+            if (Chart is null) return;
 
-            if (state.Fill != null) Chart.Canvas.RemovePaintTask(state.Fill);
-            if (state.Stroke != null) Chart.Canvas.RemovePaintTask(state.Stroke);
+            if (state.Fill is not null) Chart.Canvas.RemovePaintTask(state.Fill);
+            if (state.Stroke is not null) Chart.Canvas.RemovePaintTask(state.Stroke);
         }
     }
 }

--- a/src/LiveChartsCore/Kernel/SeriesContext.cs
+++ b/src/LiveChartsCore/Kernel/SeriesContext.cs
@@ -211,7 +211,7 @@ namespace LiveChartsCore.Kernel
 
             var s = GetStacker(series, stackGroup);
 
-            return s == null
+            return s is null
                 ? null
                 : new StackPosition<TDrawingContext>
                 {

--- a/src/LiveChartsCore/Kernel/StrokeAndFillDrawable.cs
+++ b/src/LiveChartsCore/Kernel/StrokeAndFillDrawable.cs
@@ -40,14 +40,14 @@ namespace LiveChartsCore.Kernel
         public StrokeAndFillDrawable(IPaintTask<TDrawingContext>? stroke, IPaintTask<TDrawingContext>? fill, bool isHoverState = false)
         {
             Stroke = stroke;
-            if (stroke != null)
+            if (stroke is not null)
             {
                 stroke.IsStroke = true;
                 stroke.IsFill = false;
             }
 
             Fill = fill;
-            if (fill != null)
+            if (fill is not null)
             {
                 fill.IsStroke = false;
                 fill.IsFill = true;

--- a/src/LiveChartsCore/LineSeries.cs
+++ b/src/LiveChartsCore/LineSeries.cs
@@ -113,9 +113,9 @@ namespace LiveChartsCore
             var secondaryScale = new Scaler(drawLocation, drawMarginSize, secondaryAxis);
             var primaryScale = new Scaler(drawLocation, drawMarginSize, primaryAxis);
             var previousPrimaryScale =
-                primaryAxis.PreviousDataBounds == null ? null : new Scaler(drawLocation, drawMarginSize, primaryAxis, true);
+                primaryAxis.PreviousDataBounds is null ? null : new Scaler(drawLocation, drawMarginSize, primaryAxis, true);
             var previousSecondaryScale =
-                secondaryAxis.PreviousDataBounds == null ? null : new Scaler(drawLocation, drawMarginSize, secondaryAxis, true);
+                secondaryAxis.PreviousDataBounds is null ? null : new Scaler(drawLocation, drawMarginSize, secondaryAxis, true);
 
             var gs = _geometrySize;
             var hgs = gs / 2f;
@@ -137,14 +137,14 @@ namespace LiveChartsCore
 
             var actualZIndex = ZIndex == 0 ? ((ISeries)this).SeriesId : ZIndex;
 
-            if (stacker != null)
+            if (stacker is not null)
             {
                 // easy workaround to set an automatic and valid z-index for stacked area series
                 // the problem of this solution is that the user needs to set z-indexes above 1000
                 // if the user needs to add more series to the chart.
                 actualZIndex = 1000 - stacker.Position;
-                if (Fill != null) Fill.ZIndex = actualZIndex;
-                if (Stroke != null) Stroke.ZIndex = actualZIndex;
+                if (Fill is not null) Fill.ZIndex = actualZIndex;
+                if (Stroke is not null) Stroke.ZIndex = actualZIndex;
             }
 
             var dls = unchecked((float)DataLabelsSize);
@@ -176,7 +176,7 @@ namespace LiveChartsCore
                     strokePathHelper = _strokePathHelperContainer[segmentI];
                 }
 
-                if (Fill != null)
+                if (Fill is not null)
                 {
                     wasFillInitialized = fillPathHelper.Initialize(SetDefaultPathTransitions, chartAnimation);
                     Fill.AddGeometryToPaintTask(cartesianChart.Canvas, fillPathHelper.Path);
@@ -184,7 +184,7 @@ namespace LiveChartsCore
                     Fill.ZIndex = actualZIndex + 0.1;
                     Fill.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
                 }
-                if (Stroke != null)
+                if (Stroke is not null)
                 {
                     wasStrokeInitialized = strokePathHelper.Initialize(SetDefaultPathTransitions, chartAnimation);
                     Stroke.AddGeometryToPaintTask(cartesianChart.Canvas, strokePathHelper.Path);
@@ -196,7 +196,7 @@ namespace LiveChartsCore
                 foreach (var data in GetSpline(segment, secondaryScale, primaryScale, stacker))
                 {
                     var s = 0f;
-                    if (stacker != null)
+                    if (stacker is not null)
                     {
                         s = stacker.GetStack(data.TargetPoint).Start;
                     }
@@ -206,7 +206,7 @@ namespace LiveChartsCore
 
                     var visual = (LineBezierVisualPoint<TDrawingContext, TVisual, TBezierSegment, TPathArgs>?)data.TargetPoint.Context.Visual;
 
-                    if (visual == null)
+                    if (visual is null)
                     {
                         var v = new LineBezierVisualPoint<TDrawingContext, TVisual, TBezierSegment, TPathArgs>();
 
@@ -223,13 +223,13 @@ namespace LiveChartsCore
                         var y1b = p - hgs;
                         var y2b = p - hgs;
 
-                        if (previousSecondaryScale != null && previousPrimaryScale != null)
+                        if (previousSecondaryScale is not null && previousPrimaryScale is not null)
                         {
                             pg = previousPrimaryScale.ToPixels(pivot);
                             xg = previousSecondaryScale.ToPixels(data.TargetPoint.SecondaryValue) - hgs;
                             yg = previousPrimaryScale.ToPixels(data.TargetPoint.PrimaryValue + s) - hgs;
 
-                            if (data.OriginalData == null) throw new Exception("Original data not found");
+                            if (data.OriginalData is null) throw new Exception("Original data not found");
 
                             x0b = previousSecondaryScale.ToPixels(data.OriginalData.X0);
                             x1b = previousSecondaryScale.ToPixels(data.OriginalData.X1);
@@ -259,8 +259,8 @@ namespace LiveChartsCore
 
                     _ = everFetched.Add(data.TargetPoint);
 
-                    if (GeometryFill != null) GeometryFill.AddGeometryToPaintTask(cartesianChart.Canvas, visual.Geometry);
-                    if (GeometryStroke != null) GeometryStroke.AddGeometryToPaintTask(cartesianChart.Canvas, visual.Geometry);
+                    if (GeometryFill is not null) GeometryFill.AddGeometryToPaintTask(cartesianChart.Canvas, visual.Geometry);
+                    if (GeometryStroke is not null) GeometryStroke.AddGeometryToPaintTask(cartesianChart.Canvas, visual.Geometry);
 
                     visual.Bezier.X0 = data.X0;
                     visual.Bezier.Y0 = data.Y0;
@@ -269,7 +269,7 @@ namespace LiveChartsCore
                     visual.Bezier.X2 = data.X2;
                     visual.Bezier.Y2 = data.Y2;
 
-                    if (Fill != null)
+                    if (Fill is not null)
                     {
                         if (data.IsFirst)
                         {
@@ -309,13 +309,13 @@ namespace LiveChartsCore
                                     nameof(fillPathHelper.EndSegment.Y), nameof(fillPathHelper.EndSegment.X));
                         }
                     }
-                    if (Stroke != null)
+                    if (Stroke is not null)
                     {
                         if (data.IsFirst)
                         {
                             if (wasStrokeInitialized || cartesianChart.IsZoomingOrPanning)
                             {
-                                if (cartesianChart.IsZoomingOrPanning && previousPrimaryScale != null && previousSecondaryScale != null)
+                                if (cartesianChart.IsZoomingOrPanning && previousPrimaryScale is not null && previousSecondaryScale is not null)
                                 {
                                     strokePathHelper.StartPoint.X = previousSecondaryScale.ToPixels(data.OriginalData?.X0 ?? 0);
                                     strokePathHelper.StartPoint.Y = previousPrimaryScale.ToPixels(data.OriginalData?.Y0 ?? 0);
@@ -330,7 +330,7 @@ namespace LiveChartsCore
                                    nameof(strokePathHelper.StartPoint.Y), nameof(strokePathHelper.StartPoint.X));
                             }
 
-                            if (!cartesianChart.IsFirstDraw && previousSecondaryScale != null && previousPrimaryScale != null)
+                            if (!cartesianChart.IsFirstDraw && previousSecondaryScale is not null && previousPrimaryScale is not null)
                             {
                                 strokePathHelper.StartPoint.X = previousSecondaryScale.ToPixels(data.OriginalData?.X0 ?? 0);
                                 strokePathHelper.StartPoint.Y = previousPrimaryScale.ToPixels(data.OriginalData?.Y0 ?? 0);
@@ -363,11 +363,11 @@ namespace LiveChartsCore
                     OnPointMeasured(data.TargetPoint);
                     _ = toDeletePoints.Remove(data.TargetPoint);
 
-                    if (DataLabelsPaint != null)
+                    if (DataLabelsPaint is not null)
                     {
                         var label = (TLabel?)data.TargetPoint.Context.Label;
 
-                        if (label == null)
+                        if (label is null)
                         {
                             var l = new TLabel { X = x - hgs, Y = p - hgs };
 
@@ -395,13 +395,13 @@ namespace LiveChartsCore
                     }
                 }
 
-                if (GeometryFill != null)
+                if (GeometryFill is not null)
                 {
                     cartesianChart.Canvas.AddDrawableTask(GeometryFill);
                     GeometryFill.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
                     GeometryFill.ZIndex = actualZIndex + 0.3;
                 }
-                if (GeometryStroke != null)
+                if (GeometryStroke is not null)
                 {
                     cartesianChart.Canvas.AddDrawableTask(GeometryStroke);
                     GeometryStroke.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
@@ -414,16 +414,16 @@ namespace LiveChartsCore
             {
                 var iFill = _fillPathHelperContainer.Count - 1;
                 var fillHelper = _fillPathHelperContainer[iFill];
-                if (Fill != null) Fill.RemoveGeometryFromPainTask(cartesianChart.Canvas, fillHelper.Path);
+                if (Fill is not null) Fill.RemoveGeometryFromPainTask(cartesianChart.Canvas, fillHelper.Path);
                 _fillPathHelperContainer.RemoveAt(iFill);
 
                 var iStroke = _strokePathHelperContainer.Count - 1;
                 var strokeHelper = _strokePathHelperContainer[iStroke];
-                if (Stroke != null) Stroke.RemoveGeometryFromPainTask(cartesianChart.Canvas, strokeHelper.Path);
+                if (Stroke is not null) Stroke.RemoveGeometryFromPainTask(cartesianChart.Canvas, strokeHelper.Path);
                 _strokePathHelperContainer.RemoveAt(iStroke);
             }
 
-            if (DataLabelsPaint != null)
+            if (DataLabelsPaint is not null)
             {
                 cartesianChart.Canvas.AddDrawableTask(DataLabelsPaint);
                 DataLabelsPaint.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
@@ -529,7 +529,7 @@ namespace LiveChartsCore
             var w = LegendShapeSize;
             var sh = 0f;
 
-            if (_geometryStroke != null)
+            if (_geometryStroke is not null)
             {
                 var strokeClone = _geometryStroke.CloneTask();
                 var visual = new TVisual
@@ -544,7 +544,7 @@ namespace LiveChartsCore
                 w += 2 * _geometryStroke.StrokeThickness;
                 context.PaintSchedules.Add(new PaintSchedule<TDrawingContext>(strokeClone, visual));
             }
-            else if (Stroke != null)
+            else if (Stroke is not null)
             {
                 var strokeClone = Stroke.CloneTask();
                 var visual = new TVisual
@@ -560,13 +560,13 @@ namespace LiveChartsCore
                 context.PaintSchedules.Add(new PaintSchedule<TDrawingContext>(strokeClone, visual));
             }
 
-            if (_geometryFill != null)
+            if (_geometryFill is not null)
             {
                 var fillClone = _geometryFill.CloneTask();
                 var visual = new TVisual { X = sh, Y = sh, Height = lss, Width = lss };
                 context.PaintSchedules.Add(new PaintSchedule<TDrawingContext>(fillClone, visual));
             }
-            else if (Fill != null)
+            else if (Fill is not null)
             {
                 var fillClone = Fill.CloneTask();
                 var visual = new TVisual { X = sh, Y = sh, Height = lss, Width = lss };
@@ -602,7 +602,7 @@ namespace LiveChartsCore
                 var nys = 0f;
                 var nnys = 0f;
 
-                if (stacker != null)
+                if (stacker is not null)
                 {
                     pys = stacker.GetStack(previous).Start;
                     cys = stacker.GetStack(current).Start;
@@ -719,7 +719,7 @@ namespace LiveChartsCore
         protected override void SoftDeletePoint(ChartPoint point, Scaler primaryScale, Scaler secondaryScale)
         {
             var visual = (LineBezierVisualPoint<TDrawingContext, TVisual, TBezierSegment, TPathArgs>?)point.Context.Visual;
-            if (visual == null) return;
+            if (visual is null) return;
 
             var chartView = (ICartesianChartView<TDrawingContext>)point.Context.Chart;
             if (chartView.Core.IsZoomingOrPanning)
@@ -741,11 +741,11 @@ namespace LiveChartsCore
             visual.Geometry.Width = 0;
             visual.Geometry.RemoveOnCompleted = true;
 
-            if (dataProvider == null) throw new Exception("Data provider not found");
+            if (dataProvider is null) throw new Exception("Data provider not found");
             dataProvider.DisposePoint(point);
 
             var label = (TLabel?)point.Context.Label;
-            if (label == null) return;
+            if (label is null) return;
 
             label.TextSize = 1;
             label.RemoveOnCompleted = true;
@@ -757,20 +757,20 @@ namespace LiveChartsCore
             base.SoftDelete(chart);
             var canvas = ((ICartesianChartView<TDrawingContext>)chart).CoreCanvas;
 
-            if (Fill != null)
+            if (Fill is not null)
             {
                 foreach (var pathHelper in _fillPathHelperContainer.ToArray())
                     Fill.RemoveGeometryFromPainTask(canvas, pathHelper.Path);
             }
 
-            if (Stroke != null)
+            if (Stroke is not null)
             {
                 foreach (var pathHelper in _strokePathHelperContainer.ToArray())
                     Stroke.RemoveGeometryFromPainTask(canvas, pathHelper.Path);
             }
 
-            if (GeometryFill != null) canvas.RemovePaintTask(GeometryFill);
-            if (GeometryStroke != null) canvas.RemovePaintTask(GeometryStroke);
+            if (GeometryFill is not null) canvas.RemovePaintTask(GeometryFill);
+            if (GeometryStroke is not null) canvas.RemovePaintTask(GeometryStroke);
         }
 
         /// <summary>

--- a/src/LiveChartsCore/LiveCharts.cs
+++ b/src/LiveChartsCore/LiveCharts.cs
@@ -117,7 +117,7 @@ namespace LiveChartsCore
         /// <exception cref="NullReferenceException">$"{nameof(LiveChartsSettings)} must not be null.</exception>
         public static void Configure(Action<LiveChartsSettings> configuration)
         {
-            if (configuration == null) throw new NullReferenceException($"{nameof(LiveChartsSettings)} must not be null.");
+            if (configuration is null) throw new NullReferenceException($"{nameof(LiveChartsSettings)} must not be null.");
 
             IsConfigured = true;
             configuration(CurrentSettings);

--- a/src/LiveChartsCore/Measure/Scaler.cs
+++ b/src/LiveChartsCore/Measure/Scaler.cs
@@ -51,7 +51,7 @@ namespace LiveChartsCore.Measure
             var maxLimit = usePreviousScale ? axis.PreviousMaxLimit : axis.MaxLimit;
             var minLimit = usePreviousScale ? axis.PreviousMinLimit : axis.MinLimit;
 
-            if (actualBounds == null || actualVisibleBounds == null) throw new Exception("bounds not found");
+            if (actualBounds is null || actualVisibleBounds is null) throw new Exception("bounds not found");
 
             if (double.IsInfinity(actualBounds.Delta) || double.IsInfinity(actualVisibleBounds.Delta))
             {
@@ -87,7 +87,7 @@ namespace LiveChartsCore.Measure
                 _maxVal = (float)(axis.IsInverted ? actualBounds.Min : actualBounds.Max);
                 _minVal = (float)(axis.IsInverted ? actualBounds.Max : actualBounds.Min);
 
-                if (maxLimit != null || minLimit != null)
+                if (maxLimit is not null || minLimit is not null)
                 {
                     _maxVal = (float)(axis.IsInverted ? minLimit ?? _minVal : maxLimit ?? _maxVal);
                     _minVal = (float)(axis.IsInverted ? maxLimit ?? _maxVal : minLimit ?? _minVal);
@@ -115,7 +115,7 @@ namespace LiveChartsCore.Measure
                 _maxVal = (float)(axis.IsInverted ? actualBounds.Max : actualBounds.Min);
                 _minVal = (float)(axis.IsInverted ? actualBounds.Min : actualBounds.Max);
 
-                if (maxLimit != null || minLimit != null)
+                if (maxLimit is not null || minLimit is not null)
                 {
                     _maxVal = (float)(axis.IsInverted ? maxLimit ?? _maxVal : minLimit ?? _minVal);
                     _minVal = (float)(axis.IsInverted ? minLimit ?? _minVal : maxLimit ?? _maxVal);

--- a/src/LiveChartsCore/Motion/MotionProperty.cs
+++ b/src/LiveChartsCore/Motion/MotionProperty.cs
@@ -90,7 +90,7 @@ namespace LiveChartsCore.Motion
         {
             fromValue = GetMovement(animatable);
             toValue = value;
-            if (Animation != null)
+            if (Animation is not null)
             {
                 if (animatable._currentTime == long.MinValue) // the animatable is not in the canvas yet.
                 {
@@ -115,7 +115,7 @@ namespace LiveChartsCore.Motion
         /// <returns></returns>
         public T GetMovement(Animatable animatable)
         {
-            if (Animation == null || Animation.EasingFunction == null || fromValue == null || IsCompleted) return OnGetMovement(1);
+            if (Animation is null || Animation.EasingFunction is null || fromValue is null || IsCompleted) return OnGetMovement(1);
 
             if (_requiresToInitialize)
             {

--- a/src/LiveChartsCore/Motion/MotionProperty.cs
+++ b/src/LiveChartsCore/Motion/MotionProperty.cs
@@ -48,7 +48,7 @@ namespace LiveChartsCore.Motion
         /// Initializes a new instance of the <see cref="MotionProperty{T}"/> class.
         /// </summary>
         /// <param name="propertyName">Name of the property.</param>
-        public MotionProperty(string propertyName)
+        protected MotionProperty(string propertyName)
         {
             PropertyName = propertyName;
         }

--- a/src/LiveChartsCore/PieChart.cs
+++ b/src/LiveChartsCore/PieChart.cs
@@ -60,12 +60,12 @@ namespace LiveChartsCore
             view.PointStates.Chart = this;
             foreach (var item in view.PointStates.GetStates())
             {
-                if (item.Fill != null)
+                if (item.Fill is not null)
                 {
                     item.Fill.ZIndex += 1000000;
                     canvas.AddDrawableTask(item.Fill);
                 }
-                if (item.Stroke != null)
+                if (item.Stroke is not null)
                 {
                     item.Stroke.ZIndex += 1000000;
                     canvas.AddDrawableTask(item.Stroke);
@@ -135,7 +135,7 @@ namespace LiveChartsCore
         /// <inheritdoc cref="IChart.Update(ChartUpdateParams?)" />
         public override void Update(ChartUpdateParams? chartUpdateParams = null)
         {
-            if (chartUpdateParams == null) chartUpdateParams = new ChartUpdateParams();
+            if (chartUpdateParams is null) chartUpdateParams = new ChartUpdateParams();
 
             if (chartUpdateParams.IsAutomaticUpdate && !View.AutoUpdateEnaled) return;
 
@@ -191,7 +191,7 @@ namespace LiveChartsCore
                 seriesContext = new SeriesContext<TDrawingContext>(Series);
 
                 var theme = LiveCharts.CurrentSettings.GetTheme<TDrawingContext>();
-                if (theme.CurrentColors == null || theme.CurrentColors.Length == 0)
+                if (theme.CurrentColors is null || theme.CurrentColors.Length == 0)
                     throw new Exception("Default colors are not valid");
                 var forceApply = ThemeId != LiveCharts.CurrentSettings.ThemeId && !IsFirstDraw;
 
@@ -217,14 +217,14 @@ namespace LiveChartsCore
                     series.IsNotifyingChanges = true;
                 }
 
-                if (legend != null && SeriesMiniatureChanged(Series, LegendPosition))
+                if (legend is not null && SeriesMiniatureChanged(Series, LegendPosition))
                 {
                     legend.Draw(this);
                     Update();
                     preserveFirstDraw = IsFirstDraw;
                 }
 
-                if (viewDrawMargin == null)
+                if (viewDrawMargin is null)
                 {
                     var m = viewDrawMargin ?? new Margin();
                     SetDrawMargin(controlSize, m);

--- a/src/LiveChartsCore/PieChart.cs
+++ b/src/LiveChartsCore/PieChart.cs
@@ -135,7 +135,7 @@ namespace LiveChartsCore
         /// <inheritdoc cref="IChart.Update(ChartUpdateParams?)" />
         public override void Update(ChartUpdateParams? chartUpdateParams = null)
         {
-            if (chartUpdateParams is null) chartUpdateParams = new ChartUpdateParams();
+            chartUpdateParams ??= new ChartUpdateParams();
 
             if (chartUpdateParams.IsAutomaticUpdate && !View.AutoUpdateEnaled) return;
 

--- a/src/LiveChartsCore/PieSeries.cs
+++ b/src/LiveChartsCore/PieSeries.cs
@@ -57,7 +57,7 @@ namespace LiveChartsCore
         /// <summary>
         /// Initializes a new instance of the <see cref="PieSeries{TModel, TVisual, TLabel, TDrawingContext}"/> class.
         /// </summary>
-        public PieSeries(bool isGauge = false, bool isGaugeFill = false)
+        protected PieSeries(bool isGauge = false, bool isGaugeFill = false)
             : base(SeriesProperties.PieSeries | SeriesProperties.Stacked |
                   (isGauge ? SeriesProperties.Gauge : 0) | (isGaugeFill ? SeriesProperties.GaugeFill : 0) | SeriesProperties.Solid)
         {

--- a/src/LiveChartsCore/PieSeries.cs
+++ b/src/LiveChartsCore/PieSeries.cs
@@ -151,19 +151,19 @@ namespace LiveChartsCore
             var chartTotal = (float?)view.Total;
 
             var actualZIndex = ZIndex == 0 ? ((ISeries)this).SeriesId : ZIndex;
-            if (Fill != null)
+            if (Fill is not null)
             {
                 Fill.ZIndex = actualZIndex + 0.1;
                 Fill.SetClipRectangle(pieChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
                 pieChart.Canvas.AddDrawableTask(Fill);
             }
-            if (Stroke != null)
+            if (Stroke is not null)
             {
                 Stroke.ZIndex = actualZIndex + 0.2;
                 Stroke.SetClipRectangle(pieChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
                 pieChart.Canvas.AddDrawableTask(Stroke);
             }
-            if (DataLabelsPaint != null)
+            if (DataLabelsPaint is not null)
             {
                 DataLabelsPaint.ZIndex = 1000 + actualZIndex + 0.3;
                 DataLabelsPaint.SetClipRectangle(pieChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
@@ -175,7 +175,7 @@ namespace LiveChartsCore
 
             var dls = (float)DataLabelsSize;
             var stacker = pieChart.SeriesContext.GetStackPosition(this, GetStackGroup());
-            if (stacker == null) throw new NullReferenceException("Unexpected null stacker");
+            if (stacker is null) throw new NullReferenceException("Unexpected null stacker");
 
             var toDeletePoints = new HashSet<ChartPoint>(everFetched);
 
@@ -221,7 +221,7 @@ namespace LiveChartsCore
 
                 if (point.IsNull)
                 {
-                    if (visual != null)
+                    if (visual is not null)
                     {
                         visual.CenterX = cx;
                         visual.CenterY = cy;
@@ -262,7 +262,7 @@ namespace LiveChartsCore
                     end = completeAngle - 0.1f;
                 }
 
-                if (visual == null)
+                if (visual is null)
                 {
                     var p = new TVisual
                     {
@@ -287,8 +287,8 @@ namespace LiveChartsCore
                     _ = everFetched.Add(point);
                 }
 
-                if (Fill != null) Fill.AddGeometryToPaintTask(pieChart.Canvas, visual);
-                if (Stroke != null) Stroke.AddGeometryToPaintTask(pieChart.Canvas, visual);
+                if (Fill is not null) Fill.AddGeometryToPaintTask(pieChart.Canvas, visual);
+                if (Stroke is not null) Stroke.AddGeometryToPaintTask(pieChart.Canvas, visual);
 
                 var dougnutGeometry = visual;
 
@@ -320,11 +320,11 @@ namespace LiveChartsCore
                 OnPointMeasured(point);
                 _ = toDeletePoints.Remove(point);
 
-                if (DataLabelsPaint != null && point.PrimaryValue > 0)
+                if (DataLabelsPaint is not null && point.PrimaryValue > 0)
                 {
                     var label = (TLabel?)point.Context.Label;
 
-                    if (label == null)
+                    if (label is null)
                     {
                         var l = new TLabel { X = cx, Y = cy };
 
@@ -395,7 +395,7 @@ namespace LiveChartsCore
         /// <inheritdoc cref="IPieSeries{TDrawingContext}.GetBounds(PieChart{TDrawingContext})"/>
         public DimensionalBounds GetBounds(PieChart<TDrawingContext> chart)
         {
-            return dataProvider == null
+            return dataProvider is null
                 ? throw new Exception("Data provider not found")
                 : dataProvider.GetPieBounds(chart, this).Bounds;
         }
@@ -429,7 +429,7 @@ namespace LiveChartsCore
 
             var w = LegendShapeSize;
             var sh = 0f;
-            if (Stroke != null)
+            if (Stroke is not null)
             {
                 var strokeClone = Stroke.CloneTask();
                 var visual = new TVisual
@@ -449,7 +449,7 @@ namespace LiveChartsCore
                 context.PaintSchedules.Add(new PaintSchedule<TDrawingContext>(strokeClone, visual));
             }
 
-            if (Fill != null)
+            if (Fill is not null)
             {
                 var fillClone = Fill.CloneTask();
                 var visual = new TVisual
@@ -545,18 +545,18 @@ namespace LiveChartsCore
         protected override void SoftDeletePoint(ChartPoint point, Scaler primaryScale, Scaler secondaryScale)
         {
             var visual = (TVisual?)point.Context.Visual;
-            if (visual == null) return;
+            if (visual is null) return;
 
             visual.StartAngle += visual.SweepAngle;
             visual.SweepAngle = 0;
             visual.CornerRadius = 0;
             visual.RemoveOnCompleted = true;
 
-            if (dataProvider == null) throw new Exception("Data provider not found");
+            if (dataProvider is null) throw new Exception("Data provider not found");
             dataProvider.DisposePoint(point);
 
             var label = (TLabel?)point.Context.Label;
-            if (label == null) return;
+            if (label is null) return;
 
             label.TextSize = 1;
             label.RemoveOnCompleted = true;

--- a/src/LiveChartsCore/RowSeries.cs
+++ b/src/LiveChartsCore/RowSeries.cs
@@ -69,7 +69,7 @@ namespace LiveChartsCore
             var drawMarginSize = cartesianChart.DrawMarginSize;
             var secondaryScale = new Scaler(drawLocation, drawMarginSize, primaryAxis);
             var previousSecondaryScale =
-                primaryAxis.PreviousDataBounds == null ? null : new Scaler(drawLocation, drawMarginSize, primaryAxis);
+                primaryAxis.PreviousDataBounds is null ? null : new Scaler(drawLocation, drawMarginSize, primaryAxis);
             var primaryScale = new Scaler(drawLocation, drawMarginSize, secondaryAxis);
 
             var uw = secondaryScale.ToPixels(0f) - secondaryScale.ToPixels((float)primaryAxis.UnitWidth);
@@ -99,19 +99,19 @@ namespace LiveChartsCore
             }
 
             var actualZIndex = ZIndex == 0 ? ((ISeries)this).SeriesId : ZIndex;
-            if (Fill != null)
+            if (Fill is not null)
             {
                 Fill.ZIndex = actualZIndex + 0.1;
                 Fill.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
                 cartesianChart.Canvas.AddDrawableTask(Fill);
             }
-            if (Stroke != null)
+            if (Stroke is not null)
             {
                 Stroke.ZIndex = actualZIndex + 0.1;
                 Stroke.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
                 cartesianChart.Canvas.AddDrawableTask(Stroke);
             }
-            if (DataLabelsPaint != null)
+            if (DataLabelsPaint is not null)
             {
                 DataLabelsPaint.ZIndex = actualZIndex + 0.1;
                 DataLabelsPaint.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
@@ -133,7 +133,7 @@ namespace LiveChartsCore
 
                 if (point.IsNull)
                 {
-                    if (visual != null)
+                    if (visual is not null)
                     {
                         visual.X = p;
                         visual.Y = secondary - uwm + cp;
@@ -145,10 +145,10 @@ namespace LiveChartsCore
                     continue;
                 }
 
-                if (visual == null)
+                if (visual is null)
                 {
                     var yi = secondary - uwm + cp;
-                    if (previousSecondaryScale != null) yi = previousSecondaryScale.ToPixels(point.SecondaryValue) - uwm + cp;
+                    if (previousSecondaryScale is not null) yi = previousSecondaryScale.ToPixels(point.SecondaryValue) - uwm + cp;
 
                     var r = new TVisual
                     {
@@ -173,8 +173,8 @@ namespace LiveChartsCore
                     _ = everFetched.Add(point);
                 }
 
-                if (Fill != null) Fill.AddGeometryToPaintTask(cartesianChart.Canvas, visual);
-                if (Stroke != null) Stroke.AddGeometryToPaintTask(cartesianChart.Canvas, visual);
+                if (Fill is not null) Fill.AddGeometryToPaintTask(cartesianChart.Canvas, visual);
+                if (Stroke is not null) Stroke.AddGeometryToPaintTask(cartesianChart.Canvas, visual);
 
                 var sizedGeometry = visual;
 
@@ -198,11 +198,11 @@ namespace LiveChartsCore
                 OnPointMeasured(point);
                 _ = toDeletePoints.Remove(point);
 
-                if (DataLabelsPaint != null)
+                if (DataLabelsPaint is not null)
                 {
                     var label = (TLabel?)point.Context.Label;
 
-                    if (label == null)
+                    if (label is null)
                     {
                         var l = new TLabel { X = p, Y = secondary - uwm + cp };
 
@@ -315,7 +315,7 @@ namespace LiveChartsCore
         protected override void SoftDeletePoint(ChartPoint point, Scaler primaryScale, Scaler secondaryScale)
         {
             var visual = (TVisual?)point.Context.Visual;
-            if (visual == null) return;
+            if (visual is null) return;
 
             var p = primaryScale.ToPixels(pivot);
 
@@ -326,7 +326,7 @@ namespace LiveChartsCore
             visual.Width = 0;
             visual.RemoveOnCompleted = true;
 
-            if (dataProvider == null) throw new Exception("Data provider not found");
+            if (dataProvider is null) throw new Exception("Data provider not found");
             dataProvider.DisposePoint(point);
         }
     }

--- a/src/LiveChartsCore/ScatterSeries.cs
+++ b/src/LiveChartsCore/ScatterSeries.cs
@@ -91,19 +91,19 @@ namespace LiveChartsCore
             var yScale = new Scaler(drawLocation, drawMarginSize, primaryAxis);
 
             var actualZIndex = ZIndex == 0 ? ((ISeries)this).SeriesId : ZIndex;
-            if (Fill != null)
+            if (Fill is not null)
             {
                 Fill.ZIndex = actualZIndex + 0.1;
                 Fill.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
                 cartesianChart.Canvas.AddDrawableTask(Fill);
             }
-            if (Stroke != null)
+            if (Stroke is not null)
             {
                 Stroke.ZIndex = actualZIndex + 0.2;
                 Stroke.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
                 cartesianChart.Canvas.AddDrawableTask(Stroke);
             }
-            if (DataLabelsPaint != null)
+            if (DataLabelsPaint is not null)
             {
                 DataLabelsPaint.ZIndex = actualZIndex + 0.3;
                 DataLabelsPaint.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
@@ -128,7 +128,7 @@ namespace LiveChartsCore
 
                 if (point.IsNull)
                 {
-                    if (visual != null)
+                    if (visual is not null)
                     {
                         visual.X = x - hgs;
                         visual.Y = y - hgs;
@@ -146,7 +146,7 @@ namespace LiveChartsCore
                     hgs = gs / 2f;
                 }
 
-                if (visual == null)
+                if (visual is null)
                 {
                     var r = new TVisual
                     {
@@ -164,8 +164,8 @@ namespace LiveChartsCore
                     _ = everFetched.Add(point);
                 }
 
-                if (Fill != null) Fill.AddGeometryToPaintTask(cartesianChart.Canvas, visual);
-                if (Stroke != null) Stroke.AddGeometryToPaintTask(cartesianChart.Canvas, visual);
+                if (Fill is not null) Fill.AddGeometryToPaintTask(cartesianChart.Canvas, visual);
+                if (Stroke is not null) Stroke.AddGeometryToPaintTask(cartesianChart.Canvas, visual);
 
                 var sizedGeometry = visual;
 
@@ -180,7 +180,7 @@ namespace LiveChartsCore
                 OnPointMeasured(point);
                 _ = toDeletePoints.Remove(point);
 
-                if (DataLabelsPaint != null)
+                if (DataLabelsPaint is not null)
                 {
                     if (point.Context.Label is not TLabel label)
                     {
@@ -270,7 +270,7 @@ namespace LiveChartsCore
 
             var w = LegendShapeSize;
             var sh = 0f;
-            if (Stroke != null)
+            if (Stroke is not null)
             {
                 var strokeClone = Stroke.CloneTask();
                 var visual = new TVisual
@@ -286,7 +286,7 @@ namespace LiveChartsCore
                 context.PaintSchedules.Add(new PaintSchedule<TDrawingContext>(strokeClone, visual));
             }
 
-            if (Fill != null)
+            if (Fill is not null)
             {
                 var fillClone = Fill.CloneTask();
                 var visual = new TVisual { X = sh, Y = sh, Height = (float)LegendShapeSize, Width = (float)LegendShapeSize };
@@ -306,7 +306,7 @@ namespace LiveChartsCore
             var visual = (TVisual?)chartPoint.Context.Visual;
             var chart = chartPoint.Context.Chart;
 
-            if (visual == null) throw new Exception("Unable to initialize the point instance.");
+            if (visual is null) throw new Exception("Unable to initialize the point instance.");
 
             _ = visual
                .TransitionateProperties(
@@ -324,17 +324,17 @@ namespace LiveChartsCore
         protected override void SoftDeletePoint(ChartPoint point, Scaler primaryScale, Scaler secondaryScale)
         {
             var visual = (TVisual?)point.Context.Visual;
-            if (visual == null) return;
+            if (visual is null) return;
 
             visual.Height = 0;
             visual.Width = 0;
             visual.RemoveOnCompleted = true;
 
-            if (dataProvider == null) throw new Exception("Data provider not found");
+            if (dataProvider is null) throw new Exception("Data provider not found");
             dataProvider.DisposePoint(point);
 
             var label = (TLabel?)point.Context.Label;
-            if (label == null) return;
+            if (label is null) return;
 
             label.TextSize = 1;
             label.RemoveOnCompleted = true;

--- a/src/LiveChartsCore/Section.cs
+++ b/src/LiveChartsCore/Section.cs
@@ -197,17 +197,17 @@ namespace LiveChartsCore
             var secondaryScale = new Scaler(drawLocation, drawMarginSize, secondaryAxis);
             var primaryScale = new Scaler(drawLocation, drawMarginSize, primaryAxis);
 
-            var xi = Xi == null ? drawLocation.X : secondaryScale.ToPixels((float)Xi);
-            var xj = Xj == null ? drawLocation.X + drawMarginSize.Width : secondaryScale.ToPixels((float)Xj);
+            var xi = Xi is null ? drawLocation.X : secondaryScale.ToPixels((float)Xi);
+            var xj = Xj is null ? drawLocation.X + drawMarginSize.Width : secondaryScale.ToPixels((float)Xj);
 
-            var yi = Yi == null ? drawLocation.Y : primaryScale.ToPixels((float)Yi);
-            var yj = Yj == null ? drawLocation.Y + drawMarginSize.Height : primaryScale.ToPixels((float)Yj);
+            var yi = Yi is null ? drawLocation.Y : primaryScale.ToPixels((float)Yi);
+            var yj = Yj is null ? drawLocation.Y + drawMarginSize.Height : primaryScale.ToPixels((float)Yj);
 
-            if (Fill != null)
+            if (Fill is not null)
             {
                 Fill.ZIndex = ZIndex ?? -3;
 
-                if (_fillSizedGeometry == null)
+                if (_fillSizedGeometry is null)
                 {
                     _fillSizedGeometry = new TSizedGeometry
                     {
@@ -240,11 +240,11 @@ namespace LiveChartsCore
                 chart.Canvas.AddDrawableTask(Fill);
             }
 
-            if (Stroke != null)
+            if (Stroke is not null)
             {
                 Stroke.ZIndex = ZIndex ?? -3;
 
-                if (_strokeSizedGeometry == null)
+                if (_strokeSizedGeometry is null)
                 {
                     _strokeSizedGeometry = new TSizedGeometry
                     {

--- a/src/LiveChartsCore/Series.cs
+++ b/src/LiveChartsCore/Series.cs
@@ -89,7 +89,7 @@ namespace LiveChartsCore
         /// Initializes a new instance of the <see cref="Series{TModel, TVisual, TLabel, TDrawingContext}"/> class.
         /// </summary>
         /// <param name="properties">The properties.</param>
-        public Series(SeriesProperties properties)
+        protected Series(SeriesProperties properties)
         {
             SeriesProperties = properties;
             _observer = new CollectionDeepObserver<TModel>(

--- a/src/LiveChartsCore/Series.cs
+++ b/src/LiveChartsCore/Series.cs
@@ -224,7 +224,7 @@ namespace LiveChartsCore
         /// <inheritdoc cref="ISeries.Fetch(IChart)"/>
         protected IEnumerable<ChartPoint> Fetch(IChart chart)
         {
-            if (dataProvider == null) throw new Exception("Data provider not found");
+            if (dataProvider is null) throw new Exception("Data provider not found");
             _ = subscribedTo.Add(chart);
             return dataProvider.Fetch(this, chart);
         }
@@ -245,20 +245,20 @@ namespace LiveChartsCore
         public void AddPointToState(ChartPoint chartPoint, string state)
         {
             var chart = (IChartView<TDrawingContext>)chartPoint.Context.Chart;
-            if (chart.PointStates == null ||
+            if (chart.PointStates is null ||
                 (chart.TooltipPosition == TooltipPosition.Hidden && state == HoverState)) return;
 
             var s = chart.PointStates[state];
 
-            if (s == null)
+            if (s is null)
                 throw new Exception($"The state '{state}' was not found");
 
-            if (chartPoint.Context.Visual == null) return;
+            if (chartPoint.Context.Visual is null) return;
 
             var visual = (TVisual)chartPoint.Context.Visual;
             var highlitable = visual.HighlightableGeometry;
 
-            if (highlitable == null)
+            if (highlitable is null)
                 throw new Exception(
                     $"The {nameof(ChartPoint)}.{nameof(ChartPoint.Context)}.{nameof(ChartPoint.Context.Visual)}" +
                     $".{nameof(IVisualChartPoint<TDrawingContext>.HighlightableGeometry)} property is null, " +
@@ -268,14 +268,14 @@ namespace LiveChartsCore
 
             var core = (Chart<TDrawingContext>)chartPoint.Context.Chart.CoreChart;
 
-            if (s.Fill != null)
+            if (s.Fill is not null)
             {
                 s.Fill.SetClipRectangle(
                     core.Canvas,
                     new RectangleF(core.DrawMarginLocation, core.DrawMarginSize));
                 s.Fill.AddGeometryToPaintTask(chart.CoreCanvas, highlitable);
             }
-            if (s.Stroke != null)
+            if (s.Stroke is not null)
             {
                 s.Stroke.SetClipRectangle(
                     core.Canvas,
@@ -290,15 +290,15 @@ namespace LiveChartsCore
             var chart = (IChartView<TDrawingContext>)chartPoint.Context.Chart;
             var s = chart.PointStates[state];
 
-            if (s == null)
+            if (s is null)
                 throw new Exception($"The state '{state}' was not found");
 
-            if (chartPoint.Context.Visual == null) return;
+            if (chartPoint.Context.Visual is null) return;
 
             var visual = (TVisual)chartPoint.Context.Visual;
             var highlitable = visual.HighlightableGeometry;
 
-            if (highlitable == null)
+            if (highlitable is null)
                 throw new Exception(
                     $"The {nameof(ChartPoint)}.{nameof(ChartPoint.Context)}.{nameof(ChartPoint.Context.Visual)}" +
                     $".{nameof(IVisualChartPoint<TDrawingContext>.HighlightableGeometry)} property is null, " +
@@ -306,14 +306,14 @@ namespace LiveChartsCore
 
             OnRemovedFromState(visual, chart);
 
-            if (s.Fill != null) s.Fill.RemoveGeometryFromPainTask(chart.CoreCanvas, highlitable);
-            if (s.Stroke != null) s.Stroke.RemoveGeometryFromPainTask(chart.CoreCanvas, highlitable);
+            if (s.Fill is not null) s.Fill.RemoveGeometryFromPainTask(chart.CoreCanvas, highlitable);
+            if (s.Stroke is not null) s.Stroke.RemoveGeometryFromPainTask(chart.CoreCanvas, highlitable);
         }
 
         /// <inheritdoc cref="ISeries.RestartAnimations"/>
         public void RestartAnimations()
         {
-            if (dataProvider == null) throw new Exception("Data provider not found");
+            if (dataProvider is null) throw new Exception("Data provider not found");
             dataProvider.RestartVisuals();
         }
 
@@ -416,7 +416,7 @@ namespace LiveChartsCore
         private IEnumerable<TooltipPoint> FilterTooltipPoints(
             IEnumerable<ChartPoint>? points, IChart chart, PointF pointerPosition, TooltipFindingStrategy automaticStategy)
         {
-            if (points == null) return Enumerable.Empty<TooltipPoint>();
+            if (points is null) return Enumerable.Empty<TooltipPoint>();
             var tolerance = float.MaxValue;
 
             if (this is ICartesianSeries<TDrawingContext> cartesianSeries)
@@ -452,7 +452,7 @@ namespace LiveChartsCore
 
             foreach (var point in points)
             {
-                if (point == null || point.Context.HoverArea == null) continue;
+                if (point is null || point.Context.HoverArea is null) continue;
                 var d = point.Context.HoverArea.GetDistanceToPoint(pointerPosition, automaticStategy); //chart.TooltipFindingStrategy
                 if (d > tolerance || d > minD.Item1) continue;
 

--- a/src/LiveChartsCore/StackedBarSeries.cs
+++ b/src/LiveChartsCore/StackedBarSeries.cs
@@ -81,7 +81,7 @@ namespace LiveChartsCore
 
             var w = LegendShapeSize;
             var sh = 0f;
-            if (Stroke != null)
+            if (Stroke is not null)
             {
                 var strokeClone = Stroke.CloneTask();
                 var visual = new TVisual
@@ -97,7 +97,7 @@ namespace LiveChartsCore
                 context.PaintSchedules.Add(new PaintSchedule<TDrawingContext>(strokeClone, visual));
             }
 
-            if (Fill != null)
+            if (Fill is not null)
             {
                 var fillClone = Fill.CloneTask();
                 var visual = new TVisual { X = sh, Y = sh, Height = (float)LegendShapeSize, Width = (float)LegendShapeSize };

--- a/src/LiveChartsCore/StackedBarSeries.cs
+++ b/src/LiveChartsCore/StackedBarSeries.cs
@@ -51,7 +51,7 @@ namespace LiveChartsCore
         /// Initializes a new instance of the <see cref="StackedBarSeries{TModel, TVisual, TLabel, TDrawingContext}"/> class.
         /// </summary>
         /// <param name="properties">The series properties.</param>
-        public StackedBarSeries(SeriesProperties properties)
+        protected StackedBarSeries(SeriesProperties properties)
             : base(properties)
         {
             HoverState = LiveCharts.StackedBarSeriesHoverKey;

--- a/src/LiveChartsCore/StackedColumnSeries.cs
+++ b/src/LiveChartsCore/StackedColumnSeries.cs
@@ -68,7 +68,7 @@ namespace LiveChartsCore
             var secondaryScale = new Scaler(drawLocation, drawMarginSize, secondaryAxis);
             var primaryScale = new Scaler(drawLocation, drawMarginSize, primaryAxis);
             var previousSecondaryScale =
-                secondaryAxis.PreviousDataBounds == null ? null : new Scaler(drawLocation, drawMarginSize, secondaryAxis);
+                secondaryAxis.PreviousDataBounds is null ? null : new Scaler(drawLocation, drawMarginSize, secondaryAxis);
 
             var uw = secondaryScale.ToPixels(1f) - secondaryScale.ToPixels(0f);
 
@@ -95,19 +95,19 @@ namespace LiveChartsCore
             }
 
             var actualZIndex = ZIndex == 0 ? ((ISeries)this).SeriesId : ZIndex;
-            if (Fill != null)
+            if (Fill is not null)
             {
                 Fill.ZIndex = actualZIndex + 0.1;
                 Fill.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
                 cartesianChart.Canvas.AddDrawableTask(Fill);
             }
-            if (Stroke != null)
+            if (Stroke is not null)
             {
                 Stroke.ZIndex = actualZIndex + 0.2;
                 Stroke.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
                 cartesianChart.Canvas.AddDrawableTask(Stroke);
             }
-            if (DataLabelsPaint != null)
+            if (DataLabelsPaint is not null)
             {
                 DataLabelsPaint.ZIndex = actualZIndex + 0.3;
                 DataLabelsPaint.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
@@ -118,7 +118,7 @@ namespace LiveChartsCore
             var toDeletePoints = new HashSet<ChartPoint>(everFetched);
 
             var stacker = cartesianChart.SeriesContext.GetStackPosition(this, GetStackGroup());
-            if (stacker == null) throw new NullReferenceException("Unexpected null stacker");
+            if (stacker is null) throw new NullReferenceException("Unexpected null stacker");
 
             var rx = (float)Rx;
             var ry = (float)Ry;
@@ -130,7 +130,7 @@ namespace LiveChartsCore
 
                 if (point.IsNull)
                 {
-                    if (visual != null)
+                    if (visual is not null)
                     {
                         visual.X = secondary - uwm + cp;
                         visual.Y = p;
@@ -142,10 +142,10 @@ namespace LiveChartsCore
                     continue;
                 }
 
-                if (visual == null)
+                if (visual is null)
                 {
                     var xi = secondary - uwm + cp;
-                    if (previousSecondaryScale != null) xi = previousSecondaryScale.ToPixels(point.SecondaryValue) - uwm + cp;
+                    if (previousSecondaryScale is not null) xi = previousSecondaryScale.ToPixels(point.SecondaryValue) - uwm + cp;
 
                     var r = new TVisual
                     {
@@ -165,8 +165,8 @@ namespace LiveChartsCore
                     _ = everFetched.Add(point);
                 }
 
-                if (Fill != null) Fill.AddGeometryToPaintTask(cartesianChart.Canvas, visual);
-                if (Stroke != null) Stroke.AddGeometryToPaintTask(cartesianChart.Canvas, visual);
+                if (Fill is not null) Fill.AddGeometryToPaintTask(cartesianChart.Canvas, visual);
+                if (Stroke is not null) Stroke.AddGeometryToPaintTask(cartesianChart.Canvas, visual);
 
                 var sizedGeometry = visual;
 
@@ -188,7 +188,7 @@ namespace LiveChartsCore
                 OnPointMeasured(point);
                 _ = toDeletePoints.Remove(point);
 
-                if (DataLabelsPaint != null)
+                if (DataLabelsPaint is not null)
                 {
                     if (point.Context.Label is not TLabel label)
                     {
@@ -313,7 +313,7 @@ namespace LiveChartsCore
         protected override void SoftDeletePoint(ChartPoint point, Scaler primaryScale, Scaler secondaryScale)
         {
             var visual = (TVisual?)point.Context.Visual;
-            if (visual == null) return;
+            if (visual is null) return;
 
             var p = primaryScale.ToPixels(pivot);
 
@@ -324,10 +324,10 @@ namespace LiveChartsCore
             visual.Height = 0;
             visual.RemoveOnCompleted = true;
 
-            if (dataProvider == null) throw new Exception("Data provider not found");
+            if (dataProvider is null) throw new Exception("Data provider not found");
             dataProvider.DisposePoint(point);
             var label = (TLabel?)point.Context.Label;
-            if (label == null) return;
+            if (label is null) return;
 
             label.TextSize = 1;
             label.RemoveOnCompleted = true;

--- a/src/LiveChartsCore/StackedRowSeries.cs
+++ b/src/LiveChartsCore/StackedRowSeries.cs
@@ -67,7 +67,7 @@ namespace LiveChartsCore
             var drawMarginSize = cartesianChart.DrawMarginSize;
             var secondaryScale = new Scaler(drawLocation, drawMarginSize, primaryAxis);
             var previousSecondaryScale =
-                primaryAxis.PreviousDataBounds == null ? null : new Scaler(drawLocation, drawMarginSize, primaryAxis);
+                primaryAxis.PreviousDataBounds is null ? null : new Scaler(drawLocation, drawMarginSize, primaryAxis);
             var primaryScale = new Scaler(drawLocation, drawMarginSize, secondaryAxis);
 
             var uw = secondaryScale.ToPixels(1f) - secondaryScale.ToPixels(0f);
@@ -93,19 +93,19 @@ namespace LiveChartsCore
             }
 
             var actualZIndex = ZIndex == 0 ? ((ISeries)this).SeriesId : ZIndex;
-            if (Fill != null)
+            if (Fill is not null)
             {
                 Fill.ZIndex = actualZIndex + 0.1;
                 Fill.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
                 cartesianChart.Canvas.AddDrawableTask(Fill);
             }
-            if (Stroke != null)
+            if (Stroke is not null)
             {
                 Stroke.ZIndex = actualZIndex + 0.2;
                 Stroke.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
                 cartesianChart.Canvas.AddDrawableTask(Stroke);
             }
-            if (DataLabelsPaint != null)
+            if (DataLabelsPaint is not null)
             {
                 DataLabelsPaint.ZIndex = actualZIndex + 0.3;
                 DataLabelsPaint.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
@@ -115,7 +115,7 @@ namespace LiveChartsCore
             var toDeletePoints = new HashSet<ChartPoint>(everFetched);
 
             var stacker = cartesianChart.SeriesContext.GetStackPosition(this, GetStackGroup());
-            if (stacker == null) throw new NullReferenceException("Unexpected null stacker");
+            if (stacker is null) throw new NullReferenceException("Unexpected null stacker");
 
             var rx = (float)Rx;
             var ry = (float)Ry;
@@ -127,7 +127,7 @@ namespace LiveChartsCore
 
                 if (point.IsNull)
                 {
-                    if (visual != null)
+                    if (visual is not null)
                     {
                         visual.X = p;
                         visual.Y = secondary - uwm + cp;
@@ -139,10 +139,10 @@ namespace LiveChartsCore
                     continue;
                 }
 
-                if (visual == null)
+                if (visual is null)
                 {
                     var yi = secondary - uwm + cp;
-                    if (previousSecondaryScale != null) yi = previousSecondaryScale.ToPixels(point.SecondaryValue) - uwm + cp;
+                    if (previousSecondaryScale is not null) yi = previousSecondaryScale.ToPixels(point.SecondaryValue) - uwm + cp;
 
                     var r = new TVisual
                     {
@@ -162,8 +162,8 @@ namespace LiveChartsCore
                     _ = everFetched.Add(point);
                 }
 
-                if (Fill != null) Fill.AddGeometryToPaintTask(cartesianChart.Canvas, visual);
-                if (Stroke != null) Stroke.AddGeometryToPaintTask(cartesianChart.Canvas, visual);
+                if (Fill is not null) Fill.AddGeometryToPaintTask(cartesianChart.Canvas, visual);
+                if (Stroke is not null) Stroke.AddGeometryToPaintTask(cartesianChart.Canvas, visual);
 
                 var sizedGeometry = visual;
 
@@ -185,11 +185,11 @@ namespace LiveChartsCore
                 OnPointMeasured(point);
                 _ = toDeletePoints.Remove(point);
 
-                if (DataLabelsPaint != null)
+                if (DataLabelsPaint is not null)
                 {
                     var label = (TLabel?)point.Context.Label;
 
-                    if (label == null)
+                    if (label is null)
                     {
                         var l = new TLabel { X = secondary - uwm + cp, Y = p };
 
@@ -323,7 +323,7 @@ namespace LiveChartsCore
         protected override void SoftDeletePoint(ChartPoint point, Scaler primaryScale, Scaler secondaryScale)
         {
             var visual = (TVisual?)point.Context.Visual;
-            if (visual == null) return;
+            if (visual is null) return;
 
             var p = primaryScale.ToPixels(pivot);
 
@@ -334,11 +334,11 @@ namespace LiveChartsCore
             visual.Width = 0;
             visual.RemoveOnCompleted = true;
 
-            if (dataProvider == null) throw new Exception("Data provider not found");
+            if (dataProvider is null) throw new Exception("Data provider not found");
             dataProvider.DisposePoint(point);
 
             var label = (TLabel?)point.Context.Label;
-            if (label == null) return;
+            if (label is null) return;
 
             label.TextSize = 1;
             label.RemoveOnCompleted = true;

--- a/src/LiveChartsCore/StepLineSeries.cs
+++ b/src/LiveChartsCore/StepLineSeries.cs
@@ -107,9 +107,9 @@ namespace LiveChartsCore
             var secondaryScale = new Scaler(drawLocation, drawMarginSize, secondaryAxis);
             var primaryScale = new Scaler(drawLocation, drawMarginSize, primaryAxis);
             var previousPrimaryScale =
-                primaryAxis.PreviousDataBounds == null ? null : new Scaler(drawLocation, drawMarginSize, primaryAxis, true);
+                primaryAxis.PreviousDataBounds is null ? null : new Scaler(drawLocation, drawMarginSize, primaryAxis, true);
             var previousSecondaryScale =
-                secondaryAxis.PreviousDataBounds == null ? null : new Scaler(drawLocation, drawMarginSize, secondaryAxis, true);
+                secondaryAxis.PreviousDataBounds is null ? null : new Scaler(drawLocation, drawMarginSize, secondaryAxis, true);
 
             var gs = _geometrySize;
             var hgs = gs / 2f;
@@ -131,14 +131,14 @@ namespace LiveChartsCore
 
             var actualZIndex = ZIndex == 0 ? ((ISeries)this).SeriesId : ZIndex;
 
-            if (stacker != null)
+            if (stacker is not null)
             {
                 // easy workaround to set an automatic and valid z-index for stacked area series
                 // the problem of this solution is that the user needs to set z-indexes above 1000
                 // if the user needs to add more series to the chart.
                 actualZIndex = 1000 - stacker.Position;
-                if (Fill != null) Fill.ZIndex = actualZIndex;
-                if (Stroke != null) Stroke.ZIndex = actualZIndex;
+                if (Fill is not null) Fill.ZIndex = actualZIndex;
+                if (Stroke is not null) Stroke.ZIndex = actualZIndex;
             }
 
             var dls = unchecked((float)DataLabelsSize);
@@ -170,7 +170,7 @@ namespace LiveChartsCore
                     strokePathHelper = _strokePathHelperContainer[segmentI];
                 }
 
-                if (Fill != null)
+                if (Fill is not null)
                 {
                     wasFillInitialized = fillPathHelper.Initialize(SetDefaultPathTransitions, chartAnimation);
                     Fill.AddGeometryToPaintTask(cartesianChart.Canvas, fillPathHelper.Path);
@@ -178,7 +178,7 @@ namespace LiveChartsCore
                     Fill.ZIndex = actualZIndex + 0.1;
                     Fill.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
                 }
-                if (Stroke != null)
+                if (Stroke is not null)
                 {
                     wasStrokeInitialized = strokePathHelper.Initialize(SetDefaultPathTransitions, chartAnimation);
                     Stroke.AddGeometryToPaintTask(cartesianChart.Canvas, strokePathHelper.Path);
@@ -190,7 +190,7 @@ namespace LiveChartsCore
                 foreach (var data in GetStepLine(segment, secondaryScale, primaryScale, stacker))
                 {
                     var s = 0f;
-                    if (stacker != null)
+                    if (stacker is not null)
                     {
                         s = stacker.GetStack(data.TargetPoint).Start;
                     }
@@ -200,7 +200,7 @@ namespace LiveChartsCore
 
                     var visual = (StepLineVisualPoint<TDrawingContext, TVisual, TStepLineSegment, TPathArgs>?)data.TargetPoint.Context.Visual;
 
-                    if (visual == null)
+                    if (visual is null)
                     {
                         var v = new StepLineVisualPoint<TDrawingContext, TVisual, TStepLineSegment, TPathArgs>();
 
@@ -217,13 +217,13 @@ namespace LiveChartsCore
                         var y1b = p - hgs;
                         var y2b = p - hgs;
 
-                        if (previousSecondaryScale != null && previousPrimaryScale != null)
+                        if (previousSecondaryScale is not null && previousPrimaryScale is not null)
                         {
                             pg = previousPrimaryScale.ToPixels(pivot);
                             xg = previousSecondaryScale.ToPixels(data.TargetPoint.SecondaryValue) - hgs;
                             yg = previousPrimaryScale.ToPixels(data.TargetPoint.PrimaryValue + s) - hgs;
 
-                            if (data.OriginalData == null) throw new Exception("Original data not found");
+                            if (data.OriginalData is null) throw new Exception("Original data not found");
 
                             x0b = previousSecondaryScale.ToPixels(data.OriginalData.X0);
                             x1b = previousSecondaryScale.ToPixels(data.OriginalData.X1);
@@ -251,15 +251,15 @@ namespace LiveChartsCore
 
                     _ = everFetched.Add(data.TargetPoint);
 
-                    if (GeometryFill != null) GeometryFill.AddGeometryToPaintTask(cartesianChart.Canvas, visual.Geometry);
-                    if (GeometryStroke != null) GeometryStroke.AddGeometryToPaintTask(cartesianChart.Canvas, visual.Geometry);
+                    if (GeometryFill is not null) GeometryFill.AddGeometryToPaintTask(cartesianChart.Canvas, visual.Geometry);
+                    if (GeometryStroke is not null) GeometryStroke.AddGeometryToPaintTask(cartesianChart.Canvas, visual.Geometry);
 
                     visual.StepSegment.X0 = data.X0;
                     visual.StepSegment.Y0 = data.Y0;
                     visual.StepSegment.X1 = data.X1;
                     visual.StepSegment.Y1 = data.Y1;
 
-                    if (Fill != null)
+                    if (Fill is not null)
                     {
                         if (data.IsFirst)
                         {
@@ -299,13 +299,13 @@ namespace LiveChartsCore
                                     nameof(fillPathHelper.EndSegment.Y), nameof(fillPathHelper.EndSegment.X));
                         }
                     }
-                    if (Stroke != null)
+                    if (Stroke is not null)
                     {
                         if (data.IsFirst)
                         {
                             if (wasStrokeInitialized || cartesianChart.IsZoomingOrPanning)
                             {
-                                if (cartesianChart.IsZoomingOrPanning && previousPrimaryScale != null && previousSecondaryScale != null)
+                                if (cartesianChart.IsZoomingOrPanning && previousPrimaryScale is not null && previousSecondaryScale is not null)
                                 {
                                     strokePathHelper.StartPoint.X = previousSecondaryScale.ToPixels(data.OriginalData?.X0 ?? 0);
                                     strokePathHelper.StartPoint.Y = previousPrimaryScale.ToPixels(data.OriginalData?.Y0 ?? 0);
@@ -320,7 +320,7 @@ namespace LiveChartsCore
                                    nameof(strokePathHelper.StartPoint.Y), nameof(strokePathHelper.StartPoint.X));
                             }
 
-                            if (!cartesianChart.IsFirstDraw && previousSecondaryScale != null && previousPrimaryScale != null)
+                            if (!cartesianChart.IsFirstDraw && previousSecondaryScale is not null && previousPrimaryScale is not null)
                             {
                                 strokePathHelper.StartPoint.X = previousSecondaryScale.ToPixels(data.OriginalData?.X0 ?? 0);
                                 strokePathHelper.StartPoint.Y = previousPrimaryScale.ToPixels(data.OriginalData?.Y0 ?? 0);
@@ -353,11 +353,11 @@ namespace LiveChartsCore
                     OnPointMeasured(data.TargetPoint);
                     _ = toDeletePoints.Remove(data.TargetPoint);
 
-                    if (DataLabelsPaint != null)
+                    if (DataLabelsPaint is not null)
                     {
                         var label = (TLabel?)data.TargetPoint.Context.Label;
 
-                        if (label == null)
+                        if (label is null)
                         {
                             var l = new TLabel { X = x - hgs, Y = p - hgs };
 
@@ -384,13 +384,13 @@ namespace LiveChartsCore
                     }
                 }
 
-                if (GeometryFill != null)
+                if (GeometryFill is not null)
                 {
                     cartesianChart.Canvas.AddDrawableTask(GeometryFill);
                     GeometryFill.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
                     GeometryFill.ZIndex = actualZIndex + 0.3;
                 }
-                if (GeometryStroke != null)
+                if (GeometryStroke is not null)
                 {
                     cartesianChart.Canvas.AddDrawableTask(GeometryStroke);
                     GeometryStroke.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
@@ -403,16 +403,16 @@ namespace LiveChartsCore
             {
                 var iFill = _fillPathHelperContainer.Count - 1;
                 var fillHelper = _fillPathHelperContainer[iFill];
-                if (Fill != null) Fill.RemoveGeometryFromPainTask(cartesianChart.Canvas, fillHelper.Path);
+                if (Fill is not null) Fill.RemoveGeometryFromPainTask(cartesianChart.Canvas, fillHelper.Path);
                 _fillPathHelperContainer.RemoveAt(iFill);
 
                 var iStroke = _strokePathHelperContainer.Count - 1;
                 var strokeHelper = _strokePathHelperContainer[iStroke];
-                if (Stroke != null) Stroke.RemoveGeometryFromPainTask(cartesianChart.Canvas, strokeHelper.Path);
+                if (Stroke is not null) Stroke.RemoveGeometryFromPainTask(cartesianChart.Canvas, strokeHelper.Path);
                 _strokePathHelperContainer.RemoveAt(iStroke);
             }
 
-            if (DataLabelsPaint != null)
+            if (DataLabelsPaint is not null)
             {
                 cartesianChart.Canvas.AddDrawableTask(DataLabelsPaint);
                 DataLabelsPaint.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
@@ -516,7 +516,7 @@ namespace LiveChartsCore
             var w = LegendShapeSize;
             var sh = 0f;
 
-            if (_geometryStroke != null)
+            if (_geometryStroke is not null)
             {
                 var strokeClone = _geometryStroke.CloneTask();
                 var visual = new TVisual
@@ -531,7 +531,7 @@ namespace LiveChartsCore
                 w += 2 * _geometryStroke.StrokeThickness;
                 context.PaintSchedules.Add(new PaintSchedule<TDrawingContext>(strokeClone, visual));
             }
-            else if (Stroke != null)
+            else if (Stroke is not null)
             {
                 var strokeClone = Stroke.CloneTask();
                 var visual = new TVisual
@@ -547,13 +547,13 @@ namespace LiveChartsCore
                 context.PaintSchedules.Add(new PaintSchedule<TDrawingContext>(strokeClone, visual));
             }
 
-            if (_geometryFill != null)
+            if (_geometryFill is not null)
             {
                 var fillClone = _geometryFill.CloneTask();
                 var visual = new TVisual { X = sh, Y = sh, Height = lss, Width = lss };
                 context.PaintSchedules.Add(new PaintSchedule<TDrawingContext>(fillClone, visual));
             }
-            else if (Fill != null)
+            else if (Fill is not null)
             {
                 var fillClone = Fill.CloneTask();
                 var visual = new TVisual { X = sh, Y = sh, Height = lss, Width = lss };
@@ -584,7 +584,7 @@ namespace LiveChartsCore
                 current = points[i];
                 next = points[i + 1 > points.Length - 1 ? points.Length - 1 : i + 1];
 
-                if (stacker != null)
+                if (stacker is not null)
                 {
                     cys = stacker.GetStack(current).Start;
                 }
@@ -665,7 +665,7 @@ namespace LiveChartsCore
         protected override void SoftDeletePoint(ChartPoint point, Scaler primaryScale, Scaler secondaryScale)
         {
             var visual = (StepLineVisualPoint<TDrawingContext, TVisual, TStepLineSegment, TPathArgs>?)point.Context.Visual;
-            if (visual == null) return;
+            if (visual is null) return;
 
             var chartView = (ICartesianChartView<TDrawingContext>)point.Context.Chart;
             if (chartView.Core.IsZoomingOrPanning)
@@ -687,11 +687,11 @@ namespace LiveChartsCore
             visual.Geometry.Width = 0;
             visual.Geometry.RemoveOnCompleted = true;
 
-            if (dataProvider == null) throw new Exception("Data provider not found");
+            if (dataProvider is null) throw new Exception("Data provider not found");
             dataProvider.DisposePoint(point);
 
             var label = (TLabel?)point.Context.Label;
-            if (label == null) return;
+            if (label is null) return;
 
             label.TextSize = 1;
             label.RemoveOnCompleted = true;
@@ -703,20 +703,20 @@ namespace LiveChartsCore
             base.SoftDelete(chart);
             var canvas = ((ICartesianChartView<TDrawingContext>)chart).CoreCanvas;
 
-            if (Fill != null)
+            if (Fill is not null)
             {
                 foreach (var pathHelper in _fillPathHelperContainer.ToArray())
                     Fill.RemoveGeometryFromPainTask(canvas, pathHelper.Path);
             }
 
-            if (Stroke != null)
+            if (Stroke is not null)
             {
                 foreach (var pathHelper in _strokePathHelperContainer.ToArray())
                     Stroke.RemoveGeometryFromPainTask(canvas, pathHelper.Path);
             }
 
-            if (GeometryFill != null) canvas.RemovePaintTask(GeometryFill);
-            if (GeometryStroke != null) canvas.RemovePaintTask(GeometryStroke);
+            if (GeometryFill is not null) canvas.RemovePaintTask(GeometryFill);
+            if (GeometryStroke is not null) canvas.RemovePaintTask(GeometryStroke);
         }
 
         /// <summary>

--- a/src/LiveChartsCore/StrokeAndFillCartesianSeries.cs
+++ b/src/LiveChartsCore/StrokeAndFillCartesianSeries.cs
@@ -112,9 +112,9 @@ namespace LiveChartsCore
                 deleted.Add(point);
             }
 
-            if (Fill != null) core.Canvas.RemovePaintTask(Fill);
-            if (Stroke != null) core.Canvas.RemovePaintTask(Stroke);
-            if (DataLabelsPaint != null) core.Canvas.RemovePaintTask(DataLabelsPaint);
+            if (Fill is not null) core.Canvas.RemovePaintTask(Fill);
+            if (Stroke is not null) core.Canvas.RemovePaintTask(Stroke);
+            if (DataLabelsPaint is not null) core.Canvas.RemovePaintTask(DataLabelsPaint);
 
             foreach (var item in deleted) _ = everFetched.Remove(item);
         }

--- a/src/LiveChartsCore/StrokeAndFillCartesianSeries.cs
+++ b/src/LiveChartsCore/StrokeAndFillCartesianSeries.cs
@@ -48,7 +48,7 @@ namespace LiveChartsCore
         /// Initializes a new instance of the <see cref="StrokeAndFillCartesianSeries{TModel, TVisual, TLabel, TDrawingContext}"/> class.
         /// </summary>
         /// <param name="properties">The properties.</param>
-        public StrokeAndFillCartesianSeries(SeriesProperties properties) : base(properties)
+        protected StrokeAndFillCartesianSeries(SeriesProperties properties) : base(properties)
         {
 
         }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/CartesianChart.axaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/CartesianChart.axaml.cs
@@ -89,7 +89,7 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
 
             var stylesBuilder = LiveCharts.CurrentSettings.GetTheme<SkiaSharpDrawingContext>();
             var initializer = stylesBuilder.GetVisualsInitializer();
-            if (stylesBuilder.CurrentColors == null || stylesBuilder.CurrentColors.Length == 0)
+            if (stylesBuilder.CurrentColors is null || stylesBuilder.CurrentColors.Length == 0)
                 throw new Exception("Default colors are not valid");
             initializer.ApplyStyleToChart(this);
 
@@ -321,10 +321,10 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
         public IChart CoreChart => core ?? throw new Exception("Core not set yet.");
 
         /// <inheritdoc cref="IChartView{TDrawingContext}.CoreCanvas" />
-        public MotionCanvas<SkiaSharpDrawingContext> CoreCanvas => core == null ? throw new Exception("core not found") : core.Canvas;
+        public MotionCanvas<SkiaSharpDrawingContext> CoreCanvas => core is null ? throw new Exception("core not found") : core.Canvas;
 
         CartesianChart<SkiaSharpDrawingContext> ICartesianChartView<SkiaSharpDrawingContext>.Core =>
-            core == null ? throw new Exception("core not found") : (CartesianChart<SkiaSharpDrawingContext>)core;
+            core is null ? throw new Exception("core not found") : (CartesianChart<SkiaSharpDrawingContext>)core;
 
         System.Drawing.Color IChartView.BackColor
         {
@@ -339,7 +339,7 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
             }
         }
 
-        SizeF IChartView.ControlSize => _avaloniaCanvas == null
+        SizeF IChartView.ControlSize => _avaloniaCanvas is null
                     ? new()
                     : new()
                     {
@@ -631,7 +631,7 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
             get => core?.UpdaterThrottler ?? throw new Exception("core not set yet.");
             set
             {
-                if (core == null) throw new Exception("core not set yet.");
+                if (core is null) throw new Exception("core not set yet.");
                 core.UpdaterThrottler = value;
             }
         }
@@ -641,7 +641,7 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
         /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.ScaleUIPoint(PointF, int, int)" />
         public PointF ScaleUIPoint(PointF point, int xAxisIndex = 0, int yAxisIndex = 0)
         {
-            if (core == null) throw new Exception("core not found");
+            if (core is null) throw new Exception("core not found");
             var cartesianCore = (CartesianChart<SkiaSharpDrawingContext>)core;
             return cartesianCore.ScaleUIPoint(point, xAxisIndex, yAxisIndex);
         }
@@ -649,7 +649,7 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
         /// <inheritdoc cref="IChartView{TDrawingContext}.ShowTooltip(IEnumerable{TooltipPoint})"/>
         public void ShowTooltip(IEnumerable<TooltipPoint> points)
         {
-            if (tooltip == null || core == null) return;
+            if (tooltip is null || core is null) return;
 
             tooltip.Show(points, core);
         }
@@ -657,13 +657,13 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
         /// <inheritdoc cref="IChartView{TDrawingContext}.HideTooltip"/>
         public void HideTooltip()
         {
-            if (tooltip == null || core == null) return;
+            if (tooltip is null || core is null) return;
 
             foreach (var state in PointStates.GetStates())
             {
                 if (!state.IsHoverState) continue;
-                if (state.Fill != null) state.Fill.ClearGeometriesFromPaintTask(core.Canvas);
-                if (state.Stroke != null) state.Stroke.ClearGeometriesFromPaintTask(core.Canvas);
+                if (state.Fill is not null) state.Fill.ClearGeometriesFromPaintTask(core.Canvas);
+                if (state.Stroke is not null) state.Stroke.ClearGeometriesFromPaintTask(core.Canvas);
             }
 
             tooltip.Hide();
@@ -700,7 +700,7 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
         {
             base.OnPropertyChanged(change);
 
-            if (core == null || change.Property.Name == nameof(IsPointerOver)) return;
+            if (core is null || change.Property.Name == nameof(IsPointerOver)) return;
 
             if (change.Property.Name == nameof(Series))
             {
@@ -745,21 +745,21 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
 
         private void OnDeepCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
-            if (core == null) return;
+            if (core is null) return;
 
             _ = Dispatcher.UIThread.InvokeAsync(() => core.Update(), DispatcherPriority.Background);
         }
 
         private void OnDeepCollectionPropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
-            if (core == null) return;
+            if (core is null) return;
 
             _ = Dispatcher.UIThread.InvokeAsync(() => core.Update(), DispatcherPriority.Background);
         }
 
         private void CartesianChart_PointerWheelChanged(object? sender, PointerWheelEventArgs e)
         {
-            if (core == null) return;
+            if (core is null) return;
 
             var c = (CartesianChart<SkiaSharpDrawingContext>)core;
             var p = e.GetPosition(this);

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/DefaultLegend.axaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/DefaultLegend.axaml.cs
@@ -50,7 +50,7 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
         {
             InitializeComponent();
             var t = (DataTemplate?)Resources["defaultTemplate"];
-            if (t == null) throw new Exception("default template not found");
+            if (t is null) throw new Exception("default template not found");
             _defaultTemplate = t;
         }
 
@@ -195,7 +195,7 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
             };
 
             var templated = template.Build(model);
-            if (templated == null) return;
+            if (templated is null) return;
 
             Content = templated;
         }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/DefaultTooltip.axaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/DefaultTooltip.axaml.cs
@@ -179,12 +179,11 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
             if (location.Value.Y < 0) y = 0;
             if (location.Value.Y + Bounds.Height > h) x = h - Bounds.Height;
 
-            if (Transitions is null)
-                Transitions = new Transitions
-                {
-                    new DoubleTransition { Property = Canvas.TopProperty, Duration = TimeSpan.FromMilliseconds(300) },
-                    new DoubleTransition { Property = Canvas.LeftProperty, Duration = TimeSpan.FromMilliseconds(300) },
-                };
+            Transitions ??= new Transitions
+            {
+                new DoubleTransition {Property = Canvas.TopProperty, Duration = TimeSpan.FromMilliseconds(300)},
+                new DoubleTransition {Property = Canvas.LeftProperty, Duration = TimeSpan.FromMilliseconds(300)},
+            };
 
             Canvas.SetTop(this, y);
             Canvas.SetLeft(this, x);

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/DefaultTooltip.axaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/DefaultTooltip.axaml.cs
@@ -51,7 +51,7 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
         {
             InitializeComponent();
             var t = (DataTemplate?)Resources["defaultTemplate"];
-            if (t == null) throw new Exception("default template not found");
+            if (t is null) throw new Exception("default template not found");
             _defaultTemplate = t;
             TooltipTemplate = t;
             Canvas.SetTop(this, 0);
@@ -156,7 +156,7 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
                     chart.TooltipPosition, new System.Drawing.SizeF((float)Bounds.Width, (float)Bounds.Height));
             }
 
-            if (location == null) throw new Exception("location not found");
+            if (location is null) throw new Exception("location not found");
 
             Points = tooltipPoints;
             TooltipBackground = avaloniaChart.TooltipBackground;
@@ -179,7 +179,7 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
             if (location.Value.Y < 0) y = 0;
             if (location.Value.Y + Bounds.Height > h) x = h - Bounds.Height;
 
-            if (Transitions == null)
+            if (Transitions is null)
                 Transitions = new Transitions
                 {
                     new DoubleTransition { Property = Canvas.TopProperty, Duration = TimeSpan.FromMilliseconds(300) },
@@ -225,7 +225,7 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
             };
 
             var templated = template.Build(model);
-            if (templated == null) return;
+            if (templated is null) return;
 
             Content = templated;
         }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/PieChart.axaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/PieChart.axaml.cs
@@ -83,7 +83,7 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
 
             var stylesBuilder = LiveCharts.CurrentSettings.GetTheme<SkiaSharpDrawingContext>();
             var initializer = stylesBuilder.GetVisualsInitializer();
-            if (stylesBuilder.CurrentColors == null || stylesBuilder.CurrentColors.Length == 0)
+            if (stylesBuilder.CurrentColors is null || stylesBuilder.CurrentColors.Length == 0)
                 throw new Exception("Default colors are not valid");
             initializer.ApplyStyleToChart(this);
 
@@ -92,12 +92,12 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
             _seriesObserver = new CollectionDeepObserver<ISeries>(
                (object? sender, NotifyCollectionChangedEventArgs e) =>
                {
-                   if (core == null) return;
+                   if (core is null) return;
                    _ = Dispatcher.UIThread.InvokeAsync(() => core.Update(), DispatcherPriority.Background);
                },
                (object? sender, PropertyChangedEventArgs e) =>
                {
-                   if (core == null) return;
+                   if (core is null) return;
                    _ = Dispatcher.UIThread.InvokeAsync(() => core.Update(), DispatcherPriority.Background);
                });
 
@@ -306,9 +306,9 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
         };
 
         /// <inheritdoc cref="IChartView{TDrawingContext}.CoreCanvas" />
-        public MotionCanvas<SkiaSharpDrawingContext> CoreCanvas => core == null ? throw new Exception("core not found") : core.Canvas;
+        public MotionCanvas<SkiaSharpDrawingContext> CoreCanvas => core is null ? throw new Exception("core not found") : core.Canvas;
 
-        PieChart<SkiaSharpDrawingContext> IPieChartView<SkiaSharpDrawingContext>.Core => core == null ? throw new Exception("core not found") : (PieChart<SkiaSharpDrawingContext>)core;
+        PieChart<SkiaSharpDrawingContext> IPieChartView<SkiaSharpDrawingContext>.Core => core is null ? throw new Exception("core not found") : (PieChart<SkiaSharpDrawingContext>)core;
 
         /// <inheritdoc cref="IChartView.DrawMargin" />
         public Margin? DrawMargin
@@ -566,7 +566,7 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
             get => core?.UpdaterThrottler ?? throw new Exception("core not set yet.");
             set
             {
-                if (core == null) throw new Exception("core not set yet.");
+                if (core is null) throw new Exception("core not set yet.");
                 core.UpdaterThrottler = value;
             }
         }
@@ -576,7 +576,7 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
         /// <inheritdoc cref="IChartView{TDrawingContext}.ShowTooltip(IEnumerable{TooltipPoint})"/>
         public void ShowTooltip(IEnumerable<TooltipPoint> points)
         {
-            if (tooltip == null || core == null) return;
+            if (tooltip is null || core is null) return;
 
             tooltip.Show(points, core);
         }
@@ -584,13 +584,13 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
         /// <inheritdoc cref="IChartView{TDrawingContext}.HideTooltip"/>
         public void HideTooltip()
         {
-            if (tooltip == null || core == null) return;
+            if (tooltip is null || core is null) return;
 
             foreach (var state in PointStates.GetStates())
             {
                 if (!state.IsHoverState) continue;
-                if (state.Fill != null) state.Fill.ClearGeometriesFromPaintTask(core.Canvas);
-                if (state.Stroke != null) state.Stroke.ClearGeometriesFromPaintTask(core.Canvas);
+                if (state.Fill is not null) state.Fill.ClearGeometriesFromPaintTask(core.Canvas);
+                if (state.Stroke is not null) state.Stroke.ClearGeometriesFromPaintTask(core.Canvas);
             }
 
             tooltip.Hide();
@@ -626,7 +626,7 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
         {
             base.OnPropertyChanged(change);
 
-            if (core == null) return;
+            if (core is null) return;
 
             if (change.Property.Name == nameof(Series))
             {

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/CartesianChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/CartesianChart.cs
@@ -87,7 +87,7 @@ namespace LiveChartsCore.SkiaSharpView.WPF
                         var seriesObserver = chart._seriesObserver;
                         seriesObserver.Dispose((IEnumerable<ISeries>)args.OldValue);
                         seriesObserver.Initialize((IEnumerable<ISeries>)args.NewValue);
-                        if (chart.core == null) return;
+                        if (chart.core is null) return;
                         Application.Current.Dispatcher.Invoke(() => chart.core.Update());
                     },
                     (DependencyObject o, object value) =>
@@ -107,7 +107,7 @@ namespace LiveChartsCore.SkiaSharpView.WPF
                         var observer = chart._xObserver;
                         observer.Dispose((IEnumerable<IAxis>)args.OldValue);
                         observer.Initialize((IEnumerable<IAxis>)args.NewValue);
-                        if (chart.core == null) return;
+                        if (chart.core is null) return;
                         Application.Current.Dispatcher.Invoke(() => chart.core.Update());
                     },
                     (DependencyObject o, object value) =>
@@ -127,7 +127,7 @@ namespace LiveChartsCore.SkiaSharpView.WPF
                         var observer = chart._yObserver;
                         observer.Dispose((IEnumerable<IAxis>)args.OldValue);
                         observer.Initialize((IEnumerable<IAxis>)args.NewValue);
-                        if (chart.core == null) return;
+                        if (chart.core is null) return;
                         Application.Current.Dispatcher.Invoke(() => chart.core.Update());
                     },
                     (DependencyObject o, object value) =>
@@ -147,7 +147,7 @@ namespace LiveChartsCore.SkiaSharpView.WPF
                         var observer = chart._sectionsObserver;
                         observer.Dispose((IEnumerable<Section<SkiaSharpDrawingContext>>)args.OldValue);
                         observer.Initialize((IEnumerable<Section<SkiaSharpDrawingContext>>)args.NewValue);
-                        if (chart.core == null) return;
+                        if (chart.core is null) return;
                         Application.Current.Dispatcher.Invoke(() => chart.core.Update());
                     },
                     (DependencyObject o, object value) =>
@@ -193,7 +193,7 @@ namespace LiveChartsCore.SkiaSharpView.WPF
         #region properties
 
         CartesianChart<SkiaSharpDrawingContext> ICartesianChartView<SkiaSharpDrawingContext>.Core =>
-            core == null ? throw new Exception("core not found") : (CartesianChart<SkiaSharpDrawingContext>)core;
+            core is null ? throw new Exception("core not found") : (CartesianChart<SkiaSharpDrawingContext>)core;
 
         /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.Series" />
         public IEnumerable<ISeries> Series
@@ -269,7 +269,7 @@ namespace LiveChartsCore.SkiaSharpView.WPF
         /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.ScaleUIPoint(PointF, int, int)" />
         public PointF ScaleUIPoint(PointF point, int xAxisIndex = 0, int yAxisIndex = 0)
         {
-            if (core == null) throw new Exception("core not found");
+            if (core is null) throw new Exception("core not found");
             var cartesianCore = (CartesianChart<SkiaSharpDrawingContext>)core;
             return cartesianCore.ScaleUIPoint(point, xAxisIndex, yAxisIndex);
         }
@@ -280,7 +280,7 @@ namespace LiveChartsCore.SkiaSharpView.WPF
         /// <exception cref="Exception">canvas not found</exception>
         protected override void InitializeCore()
         {
-            if (canvas == null) throw new Exception("canvas not found");
+            if (canvas is null) throw new Exception("canvas not found");
 
             core = new CartesianChart<SkiaSharpDrawingContext>(this, LiveChartsSkiaSharp.DefaultPlatformBuilder, canvas.CanvasCore);
             legend = Template.FindName("legend", this) as IChartLegend<SkiaSharpDrawingContext>;
@@ -290,19 +290,19 @@ namespace LiveChartsCore.SkiaSharpView.WPF
 
         private void OnDeepCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
-            if (core == null) return;
+            if (core is null) return;
             Application.Current.Dispatcher.Invoke(() => core.Update());
         }
 
         private void OnDeepCollectionPropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
-            if (core == null) return;
+            if (core is null) return;
             Application.Current.Dispatcher.Invoke(() => core.Update());
         }
 
         private void OnMouseWheel(object? sender, System.Windows.Input.MouseWheelEventArgs e)
         {
-            if (core == null) throw new Exception("core not found");
+            if (core is null) throw new Exception("core not found");
             var c = (CartesianChart<SkiaSharpDrawingContext>)core;
             var p = e.GetPosition(this);
             c.Zoom(new PointF((float)p.X, (float)p.Y), e.Delta > 0 ? ZoomDirection.ZoomIn : ZoomDirection.ZoomOut);

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/Chart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/Chart.cs
@@ -75,7 +75,7 @@ namespace LiveChartsCore.SkiaSharpView.WPF
 
             var stylesBuilder = LiveCharts.CurrentSettings.GetTheme<SkiaSharpDrawingContext>();
             var initializer = stylesBuilder.GetVisualsInitializer();
-            if (stylesBuilder.CurrentColors == null || stylesBuilder.CurrentColors.Length == 0)
+            if (stylesBuilder.CurrentColors is null || stylesBuilder.CurrentColors.Length == 0)
                 throw new Exception("Default colors are not valid");
             initializer.ApplyStyleToChart(this);
 
@@ -298,12 +298,12 @@ namespace LiveChartsCore.SkiaSharpView.WPF
             set => SetValueOrCurrentValue(DrawMarginProperty, value);
         }
 
-        SizeF IChartView.ControlSize => canvas == null
+        SizeF IChartView.ControlSize => canvas is null
                     ? throw new Exception("Canvas not found")
                     : (new() { Width = (float)canvas.ActualWidth, Height = (float)canvas.ActualHeight });
 
         /// <inheritdoc cref="IChartView{TDrawingContext}.CoreCanvas" />
-        public MotionCanvas<SkiaSharpDrawingContext> CoreCanvas => canvas == null ? throw new Exception("Canvas not found") : canvas.CanvasCore;
+        public MotionCanvas<SkiaSharpDrawingContext> CoreCanvas => canvas is null ? throw new Exception("Canvas not found") : canvas.CanvasCore;
 
         /// <inheritdoc cref="IChartView.AnimationsSpeed" />
         public TimeSpan AnimationsSpeed
@@ -580,7 +580,7 @@ namespace LiveChartsCore.SkiaSharpView.WPF
             get => core?.UpdaterThrottler ?? throw new Exception("core not set yet.");
             set
             {
-                if (core == null) throw new Exception("core not set yet.");
+                if (core is null) throw new Exception("core not set yet.");
                 core.UpdaterThrottler = value;
             }
         }
@@ -600,7 +600,7 @@ namespace LiveChartsCore.SkiaSharpView.WPF
             this.canvas = canvas;
             InitializeCore();
 
-            if (core == null) throw new Exception("Core not found!");
+            if (core is null) throw new Exception("Core not found!");
             core.Measuring += OnCoreMeasuring;
             core.UpdateStarted += OnCoreUpdateStarted;
             core.UpdateFinished += OnCoreUpdateFinished;
@@ -609,7 +609,7 @@ namespace LiveChartsCore.SkiaSharpView.WPF
         /// <inheritdoc cref="IChartView{TDrawingContext}.ShowTooltip(IEnumerable{TooltipPoint})"/>
         public void ShowTooltip(IEnumerable<TooltipPoint> points)
         {
-            if (tooltip == null || core == null) return;
+            if (tooltip is null || core is null) return;
 
             tooltip.Show(points, core);
         }
@@ -617,13 +617,13 @@ namespace LiveChartsCore.SkiaSharpView.WPF
         /// <inheritdoc cref="IChartView{TDrawingContext}.HideTooltip"/>
         public void HideTooltip()
         {
-            if (tooltip == null || core == null) return;
+            if (tooltip is null || core is null) return;
 
             foreach (var state in PointStates.GetStates())
             {
                 if (!state.IsHoverState) continue;
-                if (state.Fill != null) state.Fill.ClearGeometriesFromPaintTask(core.Canvas);
-                if (state.Stroke != null) state.Stroke.ClearGeometriesFromPaintTask(core.Canvas);
+                if (state.Fill is not null) state.Fill.ClearGeometriesFromPaintTask(core.Canvas);
+                if (state.Stroke is not null) state.Stroke.ClearGeometriesFromPaintTask(core.Canvas);
             }
 
             tooltip.Hide();
@@ -651,13 +651,13 @@ namespace LiveChartsCore.SkiaSharpView.WPF
         protected static void OnDependencyPropertyChanged(DependencyObject o, DependencyPropertyChangedEventArgs args)
         {
             var chart = (Chart)o;
-            if (chart.core == null) return;
+            if (chart.core is null) return;
             Application.Current.Dispatcher.Invoke(() => chart.core.Update());
         }
 
         private void OnSizeChanged(object sender, SizeChangedEventArgs e)
         {
-            if (core == null) return;
+            if (core is null) return;
             Application.Current.Dispatcher.Invoke(() => core.Update());
         }
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/Chart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/Chart.cs
@@ -69,7 +69,7 @@ namespace LiveChartsCore.SkiaSharpView.WPF
         /// Initializes a new instance of the <see cref="Chart"/> class.
         /// </summary>
         /// <exception cref="Exception">Default colors are not valid</exception>
-        public Chart()
+        protected Chart()
         {
             if (!LiveCharts.IsConfigured) LiveCharts.Configure(LiveChartsSkiaSharp.DefaultPlatformBuilder);
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/DefaultTooltip.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/DefaultTooltip.xaml.cs
@@ -276,7 +276,7 @@ namespace LiveChartsCore.SkiaSharpView.WPF
                     chart.TooltipPosition, new System.Drawing.SizeF((float)border.ActualWidth, (float)border.ActualHeight));
             }
 
-            if (location == null) throw new Exception("location not supported");
+            if (location is null) throw new Exception("location not supported");
 
             IsOpen = true;
             Points = tooltipPoints;

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/MotionCanvas.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/MotionCanvas.cs
@@ -101,7 +101,7 @@ namespace LiveChartsCore.SkiaSharpView.WPF
             base.OnApplyTemplate();
 
             skiaElement = Template.FindName("skiaElement", this) as SKElement;
-            if (skiaElement == null)
+            if (skiaElement is null)
                 throw new Exception(
                     $"SkiaElement not found. This was probably caused because the control {nameof(MotionCanvas)} template was overridden, " +
                     $"If you override the template please add an {nameof(SKElement)} to the template and name it 'skiaElement'");
@@ -122,9 +122,9 @@ namespace LiveChartsCore.SkiaSharpView.WPF
         private (float dpiX, float dpiY) GetPixelDensity()
         {
             var presentationSource = PresentationSource.FromVisual(this);
-            if (presentationSource == null) return (1f, 1f);
+            if (presentationSource is null) return (1f, 1f);
             var compositionTarget = presentationSource.CompositionTarget;
-            if (compositionTarget == null) return (1f, 1f);
+            if (compositionTarget is null) return (1f, 1f);
 
             var matrix = compositionTarget.TransformToDevice;
             return ((float)matrix.M11, (float)matrix.M22);
@@ -142,7 +142,7 @@ namespace LiveChartsCore.SkiaSharpView.WPF
 
         private async void RunDrawingLoop()
         {
-            if (_isDrawingLoopRunning || skiaElement == null) return;
+            if (_isDrawingLoopRunning || skiaElement is null) return;
             _isDrawingLoopRunning = true;
 
             var ts = TimeSpan.FromSeconds(1 / FramesPerSecond);

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/PieChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/PieChart.cs
@@ -50,12 +50,12 @@ namespace LiveChartsCore.SkiaSharpView.WPF
             _seriesObserver = new CollectionDeepObserver<ISeries>(
                 (object? sender, NotifyCollectionChangedEventArgs e) =>
                 {
-                    if (core == null) return;
+                    if (core is null) return;
                     Application.Current.Dispatcher.Invoke(() => core.Update());
                 },
                 (object? sender, PropertyChangedEventArgs e) =>
                 {
-                    if (core == null) return;
+                    if (core is null) return;
                     Application.Current.Dispatcher.Invoke(() => core.Update());
                 });
 
@@ -74,7 +74,7 @@ namespace LiveChartsCore.SkiaSharpView.WPF
                         var seriesObserver = chart._seriesObserver;
                         seriesObserver.Dispose((IEnumerable<ISeries>)args.OldValue);
                         seriesObserver.Initialize((IEnumerable<ISeries>)args.NewValue);
-                        if (chart.core == null) return;
+                        if (chart.core is null) return;
                         Application.Current.Dispatcher.Invoke(() => chart.core.Update());
                     },
                     (DependencyObject o, object value) =>
@@ -103,7 +103,7 @@ namespace LiveChartsCore.SkiaSharpView.WPF
             DependencyProperty.Register(
                 nameof(Total), typeof(double?), typeof(Chart), new PropertyMetadata(null, OnDependencyPropertyChanged));
 
-        PieChart<SkiaSharpDrawingContext> IPieChartView<SkiaSharpDrawingContext>.Core => core == null ? throw new Exception("core not found") : (PieChart<SkiaSharpDrawingContext>)core;
+        PieChart<SkiaSharpDrawingContext> IPieChartView<SkiaSharpDrawingContext>.Core => core is null ? throw new Exception("core not found") : (PieChart<SkiaSharpDrawingContext>)core;
 
         /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.Series" />
         public IEnumerable<ISeries> Series
@@ -139,7 +139,7 @@ namespace LiveChartsCore.SkiaSharpView.WPF
         /// <exception cref="Exception">canvas not found</exception>
         protected override void InitializeCore()
         {
-            if (canvas == null) throw new Exception("canvas not found");
+            if (canvas is null) throw new Exception("canvas not found");
             core = new PieChart<SkiaSharpDrawingContext>(this, LiveChartsSkiaSharp.DefaultPlatformBuilder, canvas.CanvasCore);
             legend = Template.FindName("legend", this) as IChartLegend<SkiaSharpDrawingContext>;
             tooltip = Template.FindName("tooltip", this) as IChartTooltip<SkiaSharpDrawingContext>;

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WinForms/CartesianChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WinForms/CartesianChart.cs
@@ -73,7 +73,7 @@ namespace LiveChartsCore.SkiaSharpView.WinForms
             c.MouseUp += OnMouseUp;
         }
 
-        CartesianChart<SkiaSharpDrawingContext> ICartesianChartView<SkiaSharpDrawingContext>.Core => core == null ? throw new Exception("core not found") : (CartesianChart<SkiaSharpDrawingContext>)core;
+        CartesianChart<SkiaSharpDrawingContext> ICartesianChartView<SkiaSharpDrawingContext>.Core => core is null ? throw new Exception("core not found") : (CartesianChart<SkiaSharpDrawingContext>)core;
 
         /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.Series" />
 
@@ -167,26 +167,26 @@ namespace LiveChartsCore.SkiaSharpView.WinForms
         /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.ScaleUIPoint(PointF, int, int)" />
         public PointF ScaleUIPoint(PointF point, int xAxisIndex = 0, int yAxisIndex = 0)
         {
-            if (core == null) throw new Exception("core not found");
+            if (core is null) throw new Exception("core not found");
             var cartesianCore = (CartesianChart<SkiaSharpDrawingContext>)core;
             return cartesianCore.ScaleUIPoint(point, xAxisIndex, yAxisIndex);
         }
 
         private void OnDeepCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
-            if (core == null) return;
+            if (core is null) return;
             core.Update();
         }
 
         private void OnDeepCollectionPropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
-            if (core == null) return;
+            if (core is null) return;
             core.Update();
         }
 
         private void OnMouseWheel(object? sender, System.Windows.Forms.MouseEventArgs e)
         {
-            if (core == null) throw new Exception("core not found");
+            if (core is null) throw new Exception("core not found");
             var c = (CartesianChart<SkiaSharpDrawingContext>)core;
             var p = e.Location;
             c.Zoom(new PointF(p.X, p.Y), e.Delta > 0 ? ZoomDirection.ZoomIn : ZoomDirection.ZoomOut);

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WinForms/Chart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WinForms/Chart.cs
@@ -74,7 +74,7 @@ namespace LiveChartsCore.SkiaSharpView.WinForms
         /// <param name="tooltip">The default tool tip control.</param>
         /// <param name="legend">The default legend.</param>
         /// <exception cref="MotionCanvas"></exception>
-        public Chart(IChartTooltip<SkiaSharpDrawingContext>? tooltip, IChartLegend<SkiaSharpDrawingContext>? legend)
+        protected Chart(IChartTooltip<SkiaSharpDrawingContext>? tooltip, IChartLegend<SkiaSharpDrawingContext>? legend)
         {
             if (tooltip != null) this.tooltip = tooltip;
             if (legend != null) this.legend = legend;

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WinForms/Chart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WinForms/Chart.cs
@@ -76,8 +76,8 @@ namespace LiveChartsCore.SkiaSharpView.WinForms
         /// <exception cref="MotionCanvas"></exception>
         protected Chart(IChartTooltip<SkiaSharpDrawingContext>? tooltip, IChartLegend<SkiaSharpDrawingContext>? legend)
         {
-            if (tooltip != null) this.tooltip = tooltip;
-            if (legend != null) this.legend = legend;
+            if (tooltip is not null) this.tooltip = tooltip;
+            if (legend is not null) this.legend = legend;
 
             motionCanvas = new MotionCanvas();
             SuspendLayout();
@@ -100,7 +100,7 @@ namespace LiveChartsCore.SkiaSharpView.WinForms
 
             var stylesBuilder = LiveCharts.CurrentSettings.GetTheme<SkiaSharpDrawingContext>();
             var initializer = stylesBuilder.GetVisualsInitializer();
-            if (stylesBuilder.CurrentColors == null || stylesBuilder.CurrentColors.Length == 0)
+            if (stylesBuilder.CurrentColors is null || stylesBuilder.CurrentColors.Length == 0)
                 throw new Exception("Default colors are not valid");
             initializer.ApplyStyleToChart(this);
 
@@ -109,7 +109,7 @@ namespace LiveChartsCore.SkiaSharpView.WinForms
 
             InitializeCore();
 
-            if (core == null) throw new Exception("Core not found!");
+            if (core is null) throw new Exception("Core not found!");
             core.Measuring += OnCoreMeasuring;
             core.UpdateStarted += OnCoreUpdateStarted;
             core.UpdateFinished += OnCoreUpdateFinished;
@@ -237,7 +237,7 @@ namespace LiveChartsCore.SkiaSharpView.WinForms
             get => core?.UpdaterThrottler ?? throw new Exception("core not set yet.");
             set
             {
-                if (core == null) throw new Exception("core not set yet.");
+                if (core is null) throw new Exception("core not set yet.");
                 core.UpdaterThrottler = value;
             }
         }
@@ -247,7 +247,7 @@ namespace LiveChartsCore.SkiaSharpView.WinForms
         /// <inheritdoc cref="IChartView{TDrawingContext}.ShowTooltip(IEnumerable{TooltipPoint})"/>
         public void ShowTooltip(IEnumerable<TooltipPoint> points)
         {
-            if (tooltip == null || core == null) return;
+            if (tooltip is null || core is null) return;
 
             tooltip.Show(points, core);
         }
@@ -255,13 +255,13 @@ namespace LiveChartsCore.SkiaSharpView.WinForms
         /// <inheritdoc cref="IChartView{TDrawingContext}.HideTooltip"/>
         public void HideTooltip()
         {
-            if (tooltip == null || core == null) return;
+            if (tooltip is null || core is null) return;
 
             foreach (var state in PointStates.GetStates())
             {
                 if (!state.IsHoverState) continue;
-                if (state.Fill != null) state.Fill.ClearGeometriesFromPaintTask(core.Canvas);
-                if (state.Stroke != null) state.Stroke.ClearGeometriesFromPaintTask(core.Canvas);
+                if (state.Fill is not null) state.Fill.ClearGeometriesFromPaintTask(core.Canvas);
+                if (state.Stroke is not null) state.Stroke.ClearGeometriesFromPaintTask(core.Canvas);
             }
 
             tooltip.Hide();
@@ -286,7 +286,7 @@ namespace LiveChartsCore.SkiaSharpView.WinForms
         /// <returns></returns>
         protected void OnPropertyChanged()
         {
-            if (core == null) return;
+            if (core is null) return;
             core.Update();
         }
 
@@ -303,7 +303,7 @@ namespace LiveChartsCore.SkiaSharpView.WinForms
 
         private void OnResized(object? sender, EventArgs e)
         {
-            if (core == null) return;
+            if (core is null) return;
             core.Update();
         }
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WinForms/DefaultTooltip.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WinForms/DefaultTooltip.cs
@@ -76,7 +76,7 @@ namespace LiveChartsCore.SkiaSharpView.WinForms
                 location = tooltipPoints.GetPieTooltipLocation(
                     chart.TooltipPosition, new SizeF((float)size.Width, (float)size.Height));
             }
-            if (location == null) throw new Exception("location not supported");
+            if (location is null) throw new Exception("location not supported");
 
             BackColor = wfChart.TooltipBackColor;
             Height = (int)size.Height;
@@ -160,7 +160,7 @@ namespace LiveChartsCore.SkiaSharpView.WinForms
         /// <returns></returns>
         protected override void Dispose(bool disposing)
         {
-            if (disposing && (components != null))
+            if (disposing && (components is not null))
             {
                 components.Dispose();
             }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WinForms/PieChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WinForms/PieChart.cs
@@ -50,19 +50,19 @@ namespace LiveChartsCore.SkiaSharpView.WinForms
             _seriesObserver = new CollectionDeepObserver<ISeries>(
                (object? sender, NotifyCollectionChangedEventArgs e) =>
                {
-                   if (core == null) return;
+                   if (core is null) return;
                    core.Update();
                },
                (object? sender, PropertyChangedEventArgs e) =>
                {
-                   if (core == null) return;
+                   if (core is null) return;
                    core.Update();
                },
                true);
         }
 
         PieChart<SkiaSharpDrawingContext> IPieChartView<SkiaSharpDrawingContext>.Core =>
-            core == null ? throw new Exception("core not found") : (PieChart<SkiaSharpDrawingContext>)core;
+            core is null ? throw new Exception("core not found") : (PieChart<SkiaSharpDrawingContext>)core;
 
         /// <inheritdoc cref="IPieChartView{TDrawingContext}.Series" />
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/CartesianChart.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/CartesianChart.xaml.cs
@@ -70,7 +70,7 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
 
             var stylesBuilder = LiveCharts.CurrentSettings.GetTheme<SkiaSharpDrawingContext>();
             var initializer = stylesBuilder.GetVisualsInitializer();
-            if (stylesBuilder.CurrentColors == null || stylesBuilder.CurrentColors.Length == 0)
+            if (stylesBuilder.CurrentColors is null || stylesBuilder.CurrentColors.Length == 0)
                 throw new Exception("Default colors are not valid");
             initializer.ApplyStyleToChart(this);
 
@@ -90,7 +90,7 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
             canvas.SkCanvasView.EnableTouchEvents = true;
             canvas.SkCanvasView.Touch += OnSkCanvasTouched;
 
-            if (core == null) throw new Exception("Core not found!");
+            if (core is null) throw new Exception("Core not found!");
             core.Measuring += OnCoreMeasuring;
             core.UpdateStarted += OnCoreUpdateStarted;
             core.UpdateFinished += OnCoreUpdateFinished;
@@ -110,7 +110,7 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
                     var seriesObserver = chart._seriesObserver;
                     seriesObserver.Dispose((IEnumerable<ISeries>)oldValue);
                     seriesObserver.Initialize((IEnumerable<ISeries>)newValue);
-                    if (chart.core == null) return;
+                    if (chart.core is null) return;
                     MainThread.BeginInvokeOnMainThread(() => chart.core.Update());
                 });
 
@@ -126,7 +126,7 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
                     var observer = chart._xObserver;
                     observer.Dispose((IEnumerable<IAxis>)oldValue);
                     observer.Initialize((IEnumerable<IAxis>)newValue);
-                    if (chart.core == null) return;
+                    if (chart.core is null) return;
                     MainThread.BeginInvokeOnMainThread(() => chart.core.Update());
                 });
 
@@ -142,7 +142,7 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
                     var observer = chart._yObserver;
                     observer.Dispose((IEnumerable<IAxis>)oldValue);
                     observer.Initialize((IEnumerable<IAxis>)newValue);
-                    if (chart.core == null) return;
+                    if (chart.core is null) return;
                     MainThread.BeginInvokeOnMainThread(() => chart.core.Update());
                 });
 
@@ -155,7 +155,7 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
                     var observer = chart._sectionsObserverer;
                     observer.Dispose((IEnumerable<Section<SkiaSharpDrawingContext>>)oldValue);
                     observer.Initialize((IEnumerable<Section<SkiaSharpDrawingContext>>)newValue);
-                    if (chart.core == null) return;
+                    if (chart.core is null) return;
                     MainThread.BeginInvokeOnMainThread(() => chart.core.Update());
                 });
 
@@ -356,7 +356,7 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
             set => Background = new SolidColorBrush(new c(value.R / 255, value.G / 255, value.B / 255, value.A / 255));
         }
 
-        CartesianChart<SkiaSharpDrawingContext> ICartesianChartView<SkiaSharpDrawingContext>.Core => core == null ? throw new Exception("core not found") : (CartesianChart<SkiaSharpDrawingContext>)core;
+        CartesianChart<SkiaSharpDrawingContext> ICartesianChartView<SkiaSharpDrawingContext>.Core => core is null ? throw new Exception("core not found") : (CartesianChart<SkiaSharpDrawingContext>)core;
 
         SizeF IChartView.ControlSize => new()
         {
@@ -633,7 +633,7 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
             get => core?.UpdaterThrottler ?? throw new Exception("core not set yet.");
             set
             {
-                if (core == null) throw new Exception("core not set yet.");
+                if (core is null) throw new Exception("core not set yet.");
                 core.UpdaterThrottler = value;
             }
         }
@@ -643,7 +643,7 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
         /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.ScaleUIPoint(PointF, int, int)" />
         public PointF ScaleUIPoint(PointF point, int xAxisIndex = 0, int yAxisIndex = 0)
         {
-            if (core == null) throw new Exception("core not found");
+            if (core is null) throw new Exception("core not found");
             var cartesianCore = (CartesianChart<SkiaSharpDrawingContext>)core;
             return cartesianCore.ScaleUIPoint(point, xAxisIndex, yAxisIndex);
         }
@@ -651,7 +651,7 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
         /// <inheritdoc cref="IChartView{TDrawingContext}.ShowTooltip(IEnumerable{TooltipPoint})"/>
         public void ShowTooltip(IEnumerable<TooltipPoint> points)
         {
-            if (tooltip == null || core == null) return;
+            if (tooltip is null || core is null) return;
 
             ((IChartTooltip<SkiaSharpDrawingContext>)tooltip).Show(points, core);
         }
@@ -659,7 +659,7 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
         /// <inheritdoc cref="IChartView{TDrawingContext}.HideTooltip"/>
         public void HideTooltip()
         {
-            if (tooltip == null || core == null) return;
+            if (tooltip is null || core is null) return;
 
             ((IChartTooltip<SkiaSharpDrawingContext>)tooltip).Hide();
         }
@@ -691,31 +691,31 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
         protected static void OnBindablePropertyChanged(BindableObject o, object oldValue, object newValue)
         {
             var chart = (CartesianChart)o;
-            if (chart.core == null) return;
+            if (chart.core is null) return;
             MainThread.BeginInvokeOnMainThread(() => chart.core.Update());
         }
 
         private void OnDeepCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
-            if (core == null) return;
+            if (core is null) return;
             MainThread.BeginInvokeOnMainThread(() => core.Update());
         }
 
         private void OnDeepCollectionPropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
-            if (core == null) return;
+            if (core is null) return;
             MainThread.BeginInvokeOnMainThread(() => core.Update());
         }
 
         private void OnSizeChanged(object? sender, EventArgs e)
         {
-            if (core == null) return;
+            if (core is null) return;
             MainThread.BeginInvokeOnMainThread(() => core.Update());
         }
 
         private void PanGestureRecognizer_PanUpdated(object? sender, PanUpdatedEventArgs e)
         {
-            if (core == null) return;
+            if (core is null) return;
             if (e.StatusType != GestureStatus.Running) return;
 
             var c = (CartesianChart<SkiaSharpDrawingContext>)core;
@@ -727,7 +727,7 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
 
         private void PinchGestureRecognizer_PinchUpdated(object? sender, PinchGestureUpdatedEventArgs e)
         {
-            if (e.Status != GestureStatus.Running || Math.Abs(e.Scale - 1) < 0.05 || core == null) return;
+            if (e.Status != GestureStatus.Running || Math.Abs(e.Scale - 1) < 0.05 || core is null) return;
 
             var c = (CartesianChart<SkiaSharpDrawingContext>)core;
             var p = e.ScaleOrigin;
@@ -740,7 +740,7 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
 
         private void OnSkCanvasTouched(object? sender, SkiaSharp.Views.Forms.SKTouchEventArgs e)
         {
-            if (core == null) return;
+            if (core is null) return;
             if (TooltipPosition == TooltipPosition.Hidden) return;
             var location = new PointF(e.Location.X, e.Location.Y);
             core.InvokePointerDown(location);

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/DefaultTooltip.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/DefaultTooltip.xaml.cs
@@ -142,7 +142,7 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
                 location = tooltipPoints.GetPieTooltipLocation(
                     chart.TooltipPosition, new System.Drawing.SizeF((float)size.Width, (float)size.Height));
             }
-            if (location == null) throw new Exception("location not supported");
+            if (location is null) throw new Exception("location not supported");
 
             IsVisible = true;
             var template = mobileChart.TooltipTemplate ?? _defaultTemplate;
@@ -221,8 +221,8 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
                 foreach (var state in _chart.View.PointStates.GetStates())
                 {
                     if (!state.IsHoverState) continue;
-                    if (state.Fill != null) state.Fill.ClearGeometriesFromPaintTask(_chart.Canvas);
-                    if (state.Stroke != null) state.Stroke.ClearGeometriesFromPaintTask(_chart.Canvas);
+                    if (state.Fill is not null) state.Fill.ClearGeometriesFromPaintTask(_chart.Canvas);
+                    if (state.Stroke is not null) state.Stroke.ClearGeometriesFromPaintTask(_chart.Canvas);
                 }
 
                 _chart.Update();

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/HeightConverter.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/HeightConverter.cs
@@ -50,7 +50,7 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
         public object? Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
             var v = (IChartSeries<SkiaSharpDrawingContext>)value;
-            return v == null ? null : v.CanvasSchedule.Height / DeviceDisplay.MainDisplayInfo.Density;
+            return v is null ? null : v.CanvasSchedule.Height / DeviceDisplay.MainDisplayInfo.Density;
         }
 
         /// <summary>

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/MotionCanvas.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/MotionCanvas.xaml.cs
@@ -47,7 +47,7 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
         public MotionCanvas()
         {
             InitializeComponent();
-            if (skiaElement == null)
+            if (skiaElement is null)
                 throw new Exception(
                     $"SkiaElement not found. This was probably caused because the control {nameof(MotionCanvas)} template was overridden, " +
                     $"If you override the template please add an {nameof(SKCanvasView)} to the template and name it 'skiaElement'");

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/PieChart.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/PieChart.xaml.cs
@@ -66,7 +66,7 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
 
             var stylesBuilder = LiveCharts.CurrentSettings.GetTheme<SkiaSharpDrawingContext>();
             var initializer = stylesBuilder.GetVisualsInitializer();
-            if (stylesBuilder.CurrentColors == null || stylesBuilder.CurrentColors.Length == 0)
+            if (stylesBuilder.CurrentColors is null || stylesBuilder.CurrentColors.Length == 0)
                 throw new Exception("Default colors are not valid");
             initializer.ApplyStyleToChart(this);
 
@@ -76,12 +76,12 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
             _seriesObserver = new CollectionDeepObserver<ISeries>(
                (object sender, NotifyCollectionChangedEventArgs e) =>
                {
-                   if (core == null) return;
+                   if (core is null) return;
                    MainThread.BeginInvokeOnMainThread(() => core.Update());
                },
                (object sender, PropertyChangedEventArgs e) =>
                {
-                   if (core == null) return;
+                   if (core is null) return;
                    MainThread.BeginInvokeOnMainThread(() => core.Update());
                });
 
@@ -90,7 +90,7 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
             canvas.SkCanvasView.EnableTouchEvents = true;
             canvas.SkCanvasView.Touch += OnSkCanvasTouched;
 
-            if (core == null) throw new Exception("Core not found!");
+            if (core is null) throw new Exception("Core not found!");
             core.Measuring += OnCoreMeasuring;
             core.UpdateStarted += OnCoreUpdateStarted;
             core.UpdateFinished += OnCoreUpdateFinished;
@@ -110,7 +110,7 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
                       var seriesObserver = chart._seriesObserver;
                       seriesObserver.Dispose((IEnumerable<ISeries>)oldValue);
                       seriesObserver.Initialize((IEnumerable<ISeries>)newValue);
-                      if (chart.core == null) return;
+                      if (chart.core is null) return;
                       MainThread.BeginInvokeOnMainThread(() => chart.core.Update());
                   });
 
@@ -300,7 +300,7 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
         }
 
         PieChart<SkiaSharpDrawingContext> IPieChartView<SkiaSharpDrawingContext>.Core =>
-            core == null ? throw new Exception("core not found") : (PieChart<SkiaSharpDrawingContext>)core;
+            core is null ? throw new Exception("core not found") : (PieChart<SkiaSharpDrawingContext>)core;
 
         SizeF IChartView.ControlSize => new()
         {
@@ -549,7 +549,7 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
             get => core?.UpdaterThrottler ?? throw new Exception("core not set yet.");
             set
             {
-                if (core == null) throw new Exception("core not set yet.");
+                if (core is null) throw new Exception("core not set yet.");
                 core.UpdaterThrottler = value;
             }
         }
@@ -559,7 +559,7 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
         /// <inheritdoc cref="IChartView{TDrawingContext}.ShowTooltip(IEnumerable{TooltipPoint})"/>
         public void ShowTooltip(IEnumerable<TooltipPoint> points)
         {
-            if (tooltip == null || core == null) return;
+            if (tooltip is null || core is null) return;
 
             ((IChartTooltip<SkiaSharpDrawingContext>)tooltip).Show(points, core);
         }
@@ -567,7 +567,7 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
         /// <inheritdoc cref="IChartView{TDrawingContext}.HideTooltip"/>
         public void HideTooltip()
         {
-            if (tooltip == null || core == null) return;
+            if (tooltip is null || core is null) return;
 
             ((IChartTooltip<SkiaSharpDrawingContext>)tooltip).Hide();
         }
@@ -599,19 +599,19 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
         protected static void OnBindablePropertyChanged(BindableObject o, object oldValue, object newValue)
         {
             var chart = (PieChart)o;
-            if (chart.core == null) return;
+            if (chart.core is null) return;
             MainThread.BeginInvokeOnMainThread(() => chart.core.Update());
         }
 
         private void OnSizeChanged(object sender, EventArgs e)
         {
-            if (core == null) return;
+            if (core is null) return;
             MainThread.BeginInvokeOnMainThread(() => core.Update());
         }
 
         private void OnSkCanvasTouched(object? sender, SkiaSharp.Views.Forms.SKTouchEventArgs e)
         {
-            if (core == null) return;
+            if (core is null) return;
             if (TooltipPosition == TooltipPosition.Hidden) return;
             var location = new PointF(e.Location.X, e.Location.Y);
             core.InvokePointerDown(location);

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/WidthConverter.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/WidthConverter.cs
@@ -50,7 +50,7 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
         public object? Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
             var v = (IChartSeries<SkiaSharpDrawingContext>)value;
-            return v == null ? null : v.CanvasSchedule.Width / DeviceDisplay.MainDisplayInfo.Density;
+            return v is null ? null : v.CanvasSchedule.Width / DeviceDisplay.MainDisplayInfo.Density;
         }
 
         /// <summary>

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/Geometries/DoughnutGeometry.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/Geometries/DoughnutGeometry.cs
@@ -99,7 +99,7 @@ namespace LiveChartsCore.SkiaSharpView.Drawing.Geometries
         /// <inheritdoc cref="Geometry.OnDraw(SkiaSharpDrawingContext, SKPaint)" />
         public override void OnDraw(SkiaSharpDrawingContext context, SKPaint paint)
         {
-            if (AlternativeDraw != null)
+            if (AlternativeDraw is not null)
             {
                 AlternativeDraw(this, context, paint);
                 return;

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/Geometries/Geometry.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/Geometries/Geometry.cs
@@ -63,7 +63,7 @@ namespace LiveChartsCore.SkiaSharpView.Drawing.Geometries
         /// <summary>
         /// Initializes a new instance of the <see cref="Geometry"/> class.
         /// </summary>
-        public Geometry(bool hasCustomTransform = false)
+        protected Geometry(bool hasCustomTransform = false)
         {
             xProperty = RegisterMotionProperty(new FloatMotionProperty(nameof(X), 0));
             yProperty = RegisterMotionProperty(new FloatMotionProperty(nameof(Y), 0));

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/Geometries/SVGPathGeometry.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/Geometries/SVGPathGeometry.cs
@@ -61,7 +61,7 @@ namespace LiveChartsCore.SkiaSharpView.Drawing.Geometries
         /// <inheritdoc cref="Geometry.OnDraw(SkiaSharpDrawingContext, SKPaint)" />
         public override void OnDraw(SkiaSharpDrawingContext context, SKPaint paint)
         {
-            if (_svgPath == null)
+            if (_svgPath is null)
                 throw new System.NullReferenceException(
                     $"{nameof(SVG)} property is null and there is not a defined path to draw.");
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/Geometries/SizedGeometry.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/Geometries/SizedGeometry.cs
@@ -48,7 +48,7 @@ namespace LiveChartsCore.SkiaSharpView.Drawing.Geometries
         /// <summary>
         /// Initializes a new instance of the <see cref="SizedGeometry"/> class.
         /// </summary>
-        public SizedGeometry() : base()
+        protected SizedGeometry() : base()
         {
             widthProperty = RegisterMotionProperty(new FloatMotionProperty(nameof(Width), 0));
             heightProperty = RegisterMotionProperty(new FloatMotionProperty(nameof(Height), 0));

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/GaugeBuilder.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/GaugeBuilder.cs
@@ -25,7 +25,6 @@ using System.Collections.Generic;
 using LiveChartsCore.Defaults;
 using LiveChartsCore.Drawing;
 using LiveChartsCore.Kernel;
-using LiveChartsCore.Kernel.Sketches;
 using LiveChartsCore.Measure;
 using LiveChartsCore.SkiaSharpView.Drawing;
 using LiveChartsCore.SkiaSharpView.Painting;

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/GaugeBuilder.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/GaugeBuilder.cs
@@ -301,14 +301,14 @@ namespace LiveChartsCore.SkiaSharpView
         public void ApplyStylesToFill(PieSeries<ObservableValue> series)
         {
             if (Background != LiveChartsSkiaSharp.DefaultPaintTask) series.Fill = Background;
-            if (BackgroundInnerRadius != null) series.InnerRadius = BackgroundInnerRadius.Value;
-            if (BackgroundOffsetRadius != null)
+            if (BackgroundInnerRadius is not null) series.InnerRadius = BackgroundInnerRadius.Value;
+            if (BackgroundOffsetRadius is not null)
             {
                 series.RelativeOuterRadius = BackgroundOffsetRadius.Value;
                 series.RelativeInnerRadius = BackgroundOffsetRadius.Value;
             }
-            if (BackgroundMaxRadialColumnWidth != null) series.MaxRadialColumnWidth = BackgroundMaxRadialColumnWidth.Value;
-            if (RadialAlign != null) series.RadialAlign = RadialAlign.Value;
+            if (BackgroundMaxRadialColumnWidth is not null) series.MaxRadialColumnWidth = BackgroundMaxRadialColumnWidth.Value;
+            if (RadialAlign is not null) series.RadialAlign = RadialAlign.Value;
         }
 
         /// <summary>
@@ -323,23 +323,23 @@ namespace LiveChartsCore.SkiaSharpView
             {
                 if (t.Item3 != LiveChartsSkiaSharp.DefaultPaintTask) series.Fill = t.Item3;
             }
-            if (LabelsSize != null) series.DataLabelsSize = LabelsSize.Value;
-            if (LabelsPosition != null) series.DataLabelsPosition = LabelsPosition.Value;
-            if (InnerRadius != null) series.InnerRadius = InnerRadius.Value;
-            if (OffsetRadius != null)
+            if (LabelsSize is not null) series.DataLabelsSize = LabelsSize.Value;
+            if (LabelsPosition is not null) series.DataLabelsPosition = LabelsPosition.Value;
+            if (InnerRadius is not null) series.InnerRadius = InnerRadius.Value;
+            if (OffsetRadius is not null)
             {
                 series.RelativeInnerRadius = OffsetRadius.Value;
                 series.RelativeOuterRadius = OffsetRadius.Value;
             }
-            if (MaxRadialColumnWidth != null) series.MaxRadialColumnWidth = MaxRadialColumnWidth.Value;
-            if (RadialAlign != null) series.RadialAlign = RadialAlign.Value;
+            if (MaxRadialColumnWidth is not null) series.MaxRadialColumnWidth = MaxRadialColumnWidth.Value;
+            if (RadialAlign is not null) series.RadialAlign = RadialAlign.Value;
 
             series.DataLabelsFormatter = LabelFormatter;
         }
 
         private void OnPopertyChanged()
         {
-            if (_builtSeries == null) return;
+            if (_builtSeries is null) return;
 
             foreach (var item in _builtSeries)
             {

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/HeatFunctions.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/HeatFunctions.cs
@@ -68,7 +68,7 @@ namespace LiveChartsCore.SkiaSharpView
 
             foreach (var feature in geoJson.Features ?? new GeoJsonFeature[0])
             {
-                var name = feature.Properties != null ? feature.Properties["shortName"] : "";
+                var name = feature.Properties is not null ? feature.Properties["shortName"] : "";
                 Color? baseColor = values.TryGetValue(name, out var weight)
                     ? HeatFunctions.InterpolateColor((float)weight, weightBounds, heatMap, heatStops)
                     : null;

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/LiveChartsSkiaSharp.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/LiveChartsSkiaSharp.cs
@@ -363,7 +363,7 @@ namespace LiveChartsCore.SkiaSharpView
                         }
 
                         var color = colors[series.SeriesId % colors.Length];
-                        if (series.Name is null) series.Name = $"Series {series.SeriesId + 1}";
+                        series.Name ??= $"Series {series.SeriesId + 1}";
 
                         if ((series.SeriesProperties & SeriesProperties.PieSeries) == SeriesProperties.PieSeries ||
                             (series.SeriesProperties & SeriesProperties.Bar) == SeriesProperties.Bar)
@@ -488,7 +488,7 @@ namespace LiveChartsCore.SkiaSharpView
                         }
 
                         var color = colors[series.SeriesId % colors.Length];
-                        if (series.Name is null) series.Name = $"Series {series.SeriesId + 1}";
+                        series.Name ??= $"Series {series.SeriesId + 1}";
 
                         if ((series.SeriesProperties & SeriesProperties.PieSeries) == SeriesProperties.PieSeries ||
                             (series.SeriesProperties & SeriesProperties.Bar) == SeriesProperties.Bar)

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/LiveChartsSkiaSharp.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/LiveChartsSkiaSharp.cs
@@ -363,7 +363,7 @@ namespace LiveChartsCore.SkiaSharpView
                         }
 
                         var color = colors[series.SeriesId % colors.Length];
-                        if (series.Name == null) series.Name = $"Series {series.SeriesId + 1}";
+                        if (series.Name is null) series.Name = $"Series {series.SeriesId + 1}";
 
                         if ((series.SeriesProperties & SeriesProperties.PieSeries) == SeriesProperties.PieSeries ||
                             (series.SeriesProperties & SeriesProperties.Bar) == SeriesProperties.Bar)
@@ -488,7 +488,7 @@ namespace LiveChartsCore.SkiaSharpView
                         }
 
                         var color = colors[series.SeriesId % colors.Length];
-                        if (series.Name == null) series.Name = $"Series {series.SeriesId + 1}";
+                        if (series.Name is null) series.Name = $"Series {series.SeriesId + 1}";
 
                         if ((series.SeriesProperties & SeriesProperties.PieSeries) == SeriesProperties.PieSeries ||
                             (series.SeriesProperties & SeriesProperties.Bar) == SeriesProperties.Bar)

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/Effects/PathEffect.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/Effects/PathEffect.cs
@@ -60,7 +60,7 @@ namespace LiveChartsCore.SkiaSharpView.Painting.Effects
         /// <exception cref="NotImplementedException"></exception>
         public virtual void Dispose()
         {
-            if (SKPathEffect == null) return;
+            if (SKPathEffect is null) return;
             SKPathEffect.Dispose();
             SKPathEffect = null;
         }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/ImageFilters/ImageFilter.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/ImageFilters/ImageFilter.cs
@@ -57,7 +57,7 @@ namespace LiveChartsCore.SkiaSharpView.Painting.ImageFilters
         /// </summary>
         public virtual void Dispose()
         {
-            if (SKImageFilter == null) return;
+            if (SKImageFilter is null) return;
             SKImageFilter.Dispose();
             SKImageFilter = null;
         }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/ImageFilters/ImageFiltersMergeOperation.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/ImageFilters/ImageFiltersMergeOperation.cs
@@ -68,7 +68,7 @@ namespace LiveChartsCore.SkiaSharpView.Painting.ImageFilters
             foreach (var item in _filters)
             {
                 item.CreateFilter(drawingContext);
-                if (item.SKImageFilter == null) throw new System.Exception("Image filter is not valid");
+                if (item.SKImageFilter is null) throw new System.Exception("Image filter is not valid");
                 imageFilters[i++] = item.SKImageFilter;
             }
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/LinearGradientPaintTask.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/LinearGradientPaintTask.cs
@@ -137,7 +137,7 @@ namespace LiveChartsCore.SkiaSharpView.Painting
         /// <inheritdoc cref="IPaintTask{TDrawingContext}.InitializeTask(TDrawingContext)" />
         public override void InitializeTask(SkiaSharpDrawingContext drawingContext)
         {
-            if (skiaPaint == null) skiaPaint = new SKPaint();
+            if (skiaPaint is null) skiaPaint = new SKPaint();
 
             var size = GetDrawRectangleSize(drawingContext);
 
@@ -165,13 +165,13 @@ namespace LiveChartsCore.SkiaSharpView.Painting
             skiaPaint.StrokeMiter = StrokeMiter;
             skiaPaint.Style = IsStroke ? SKPaintStyle.Stroke : SKPaintStyle.Fill;
 
-            if (PathEffect != null)
+            if (PathEffect is not null)
             {
                 PathEffect.CreateEffect(drawingContext);
                 skiaPaint.PathEffect = PathEffect.SKPathEffect;
             }
 
-            if (ImageFilter != null)
+            if (ImageFilter is not null)
             {
                 ImageFilter.CreateFilter(drawingContext);
                 skiaPaint.ImageFilter = ImageFilter.SKImageFilter;
@@ -194,10 +194,10 @@ namespace LiveChartsCore.SkiaSharpView.Painting
         /// </summary>
         public override void Dispose()
         {
-            if (PathEffect != null) PathEffect.Dispose();
-            if (ImageFilter != null) ImageFilter.Dispose();
+            if (PathEffect is not null) PathEffect.Dispose();
+            if (ImageFilter is not null) ImageFilter.Dispose();
 
-            if (_drawingContext != null && GetClipRectangle(_drawingContext.MotionCanvas) != RectangleF.Empty)
+            if (_drawingContext is not null && GetClipRectangle(_drawingContext.MotionCanvas) != RectangleF.Empty)
             {
                 _drawingContext.Canvas.Restore();
                 _drawingContext = null;

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/LinearGradientPaintTask.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/LinearGradientPaintTask.cs
@@ -137,7 +137,7 @@ namespace LiveChartsCore.SkiaSharpView.Painting
         /// <inheritdoc cref="IPaintTask{TDrawingContext}.InitializeTask(TDrawingContext)" />
         public override void InitializeTask(SkiaSharpDrawingContext drawingContext)
         {
-            if (skiaPaint is null) skiaPaint = new SKPaint();
+            skiaPaint ??= new SKPaint();
 
             var size = GetDrawRectangleSize(drawingContext);
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/LinearGradientPaintTask.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/LinearGradientPaintTask.cs
@@ -23,7 +23,6 @@
 using System.Drawing;
 using LiveChartsCore.Drawing;
 using LiveChartsCore.SkiaSharpView.Drawing;
-using LiveChartsCore.SkiaSharpView.Painting.Effects;
 using SkiaSharp;
 
 namespace LiveChartsCore.SkiaSharpView.Painting

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/PaintTask.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/PaintTask.cs
@@ -180,7 +180,7 @@ namespace LiveChartsCore.SkiaSharpView.Painting
         public void AddGeometryToPaintTask(MotionCanvas<SkiaSharpDrawingContext> canvas, IDrawable<SkiaSharpDrawingContext> geometry)
         {
             var g = GetGeometriesByCanvas(canvas);
-            if (g == null)
+            if (g is null)
             {
                 g = new HashSet<IDrawable<SkiaSharpDrawingContext>>();
                 _geometriesByCanvas[canvas.Sync] = g;

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/PaintTask.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/PaintTask.cs
@@ -54,7 +54,7 @@ namespace LiveChartsCore.SkiaSharpView.Painting
         /// <summary>
         /// Initializes a new instance of the <see cref="PaintTask"/> class.
         /// </summary>
-        public PaintTask()
+        protected PaintTask()
         {
             strokeWidthTransition = RegisterMotionProperty(new FloatMotionProperty(nameof(StrokeThickness), 0f));
             _strokeMiterTransition = RegisterMotionProperty(new FloatMotionProperty(nameof(StrokeMiter), 0f));
@@ -64,7 +64,7 @@ namespace LiveChartsCore.SkiaSharpView.Painting
         /// Initializes a new instance of the <see cref="PaintTask"/> class.
         /// </summary>
         /// <param name="color">The color.</param>
-        public PaintTask(SKColor color) : this()
+        protected PaintTask(SKColor color) : this()
         {
             Color = color;
         }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/RadialGradientPaintTask.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/RadialGradientPaintTask.cs
@@ -67,7 +67,7 @@ namespace LiveChartsCore.SkiaSharpView.Painting
             SKShaderTileMode tileMode = SKShaderTileMode.Repeat)
         {
             _gradientStops = gradientStops;
-            if (center == null) _center = new SKPoint(0.5f, 0.5f);
+            if (center is null) _center = new SKPoint(0.5f, 0.5f);
             _radius = radius;
             _colorPos = colorPos;
             _tileMode = tileMode;
@@ -103,7 +103,7 @@ namespace LiveChartsCore.SkiaSharpView.Painting
         /// <inheritdoc cref="IPaintTask{TDrawingContext}.InitializeTask(TDrawingContext)" />
         public override void InitializeTask(SkiaSharpDrawingContext drawingContext)
         {
-            if (skiaPaint == null) skiaPaint = new SKPaint();
+            if (skiaPaint is null) skiaPaint = new SKPaint();
 
             var size = GetDrawRectangleSize(drawingContext);
             var center = new SKPoint(size.Location.X + _center.X * size.Width, size.Location.Y + _center.Y * size.Height);
@@ -127,13 +127,13 @@ namespace LiveChartsCore.SkiaSharpView.Painting
             skiaPaint.StrokeMiter = StrokeMiter;
             skiaPaint.Style = IsStroke ? SKPaintStyle.Stroke : SKPaintStyle.Fill;
 
-            if (PathEffect != null)
+            if (PathEffect is not null)
             {
                 PathEffect.CreateEffect(drawingContext);
                 skiaPaint.PathEffect = PathEffect.SKPathEffect;
             }
 
-            if (ImageFilter != null)
+            if (ImageFilter is not null)
             {
                 ImageFilter.CreateFilter(drawingContext);
                 skiaPaint.ImageFilter = ImageFilter.SKImageFilter;
@@ -168,10 +168,10 @@ namespace LiveChartsCore.SkiaSharpView.Painting
         /// </summary>
         public override void Dispose()
         {
-            if (PathEffect != null) PathEffect.Dispose();
-            if (ImageFilter != null) ImageFilter.Dispose();
+            if (PathEffect is not null) PathEffect.Dispose();
+            if (ImageFilter is not null) ImageFilter.Dispose();
 
-            if (_drawingContext != null && GetClipRectangle(_drawingContext.MotionCanvas) != RectangleF.Empty)
+            if (_drawingContext is not null && GetClipRectangle(_drawingContext.MotionCanvas) != RectangleF.Empty)
             {
                 _drawingContext.Canvas.Restore();
                 _drawingContext = null;

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/RadialGradientPaintTask.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/RadialGradientPaintTask.cs
@@ -103,7 +103,7 @@ namespace LiveChartsCore.SkiaSharpView.Painting
         /// <inheritdoc cref="IPaintTask{TDrawingContext}.InitializeTask(TDrawingContext)" />
         public override void InitializeTask(SkiaSharpDrawingContext drawingContext)
         {
-            if (skiaPaint is null) skiaPaint = new SKPaint();
+            skiaPaint ??= new SKPaint();
 
             var size = GetDrawRectangleSize(drawingContext);
             var center = new SKPoint(size.Location.X + _center.X * size.Width, size.Location.Y + _center.Y * size.Height);

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/RadialGradientPaintTask.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/RadialGradientPaintTask.cs
@@ -23,7 +23,6 @@
 using System.Drawing;
 using LiveChartsCore.Drawing;
 using LiveChartsCore.SkiaSharpView.Drawing;
-using LiveChartsCore.SkiaSharpView.Painting.Effects;
 using SkiaSharp;
 
 namespace LiveChartsCore.SkiaSharpView.Painting

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/SolidColorPaintTask.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/SolidColorPaintTask.cs
@@ -90,7 +90,7 @@ namespace LiveChartsCore.SkiaSharpView.Painting
         /// <inheritdoc cref="IPaintTask{TDrawingContext}.InitializeTask(TDrawingContext)" />
         public override void InitializeTask(SkiaSharpDrawingContext drawingContext)
         {
-            if (skiaPaint is null) skiaPaint = new SKPaint();
+            skiaPaint ??= new SKPaint();
 
             skiaPaint.Color = Color;
             skiaPaint.IsAntialias = IsAntialias;

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/SolidColorPaintTask.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/SolidColorPaintTask.cs
@@ -90,7 +90,7 @@ namespace LiveChartsCore.SkiaSharpView.Painting
         /// <inheritdoc cref="IPaintTask{TDrawingContext}.InitializeTask(TDrawingContext)" />
         public override void InitializeTask(SkiaSharpDrawingContext drawingContext)
         {
-            if (skiaPaint == null) skiaPaint = new SKPaint();
+            if (skiaPaint is null) skiaPaint = new SKPaint();
 
             skiaPaint.Color = Color;
             skiaPaint.IsAntialias = IsAntialias;
@@ -101,13 +101,13 @@ namespace LiveChartsCore.SkiaSharpView.Painting
             skiaPaint.StrokeWidth = StrokeThickness;
             skiaPaint.Style = IsStroke ? SKPaintStyle.Stroke : SKPaintStyle.Fill;
 
-            if (PathEffect != null)
+            if (PathEffect is not null)
             {
                 PathEffect.CreateEffect(drawingContext);
                 skiaPaint.PathEffect = PathEffect.SKPathEffect;
             }
 
-            if (ImageFilter != null)
+            if (ImageFilter is not null)
             {
                 ImageFilter.CreateFilter(drawingContext);
                 skiaPaint.ImageFilter = ImageFilter.SKImageFilter;
@@ -128,7 +128,7 @@ namespace LiveChartsCore.SkiaSharpView.Painting
         /// <inheritdoc cref="IPaintTask{TDrawingContext}.SetOpacity(TDrawingContext, IGeometry{TDrawingContext})" />
         public override void SetOpacity(SkiaSharpDrawingContext context, IGeometry<SkiaSharpDrawingContext> geometry)
         {
-            if (context.PaintTask == null || context.Paint == null) return;
+            if (context.PaintTask is null || context.Paint is null) return;
 
             var baseColor = context.PaintTask.Color;
             context.Paint.Color =
@@ -138,8 +138,8 @@ namespace LiveChartsCore.SkiaSharpView.Painting
         /// <inheritdoc cref="IPaintTask{TDrawingContext}.ResetOpacity(TDrawingContext, IGeometry{TDrawingContext})" />
         public override void ResetOpacity(SkiaSharpDrawingContext context, IGeometry<SkiaSharpDrawingContext> geometry)
         {
-            if (context.PaintTask == null || context.Paint == null) return;
-            if (ImageFilter != null) ImageFilter.Dispose();
+            if (context.PaintTask is null || context.Paint is null) return;
+            if (ImageFilter is not null) ImageFilter.Dispose();
 
             var baseColor = context.PaintTask.Color;
             context.Paint.Color = baseColor;
@@ -150,9 +150,9 @@ namespace LiveChartsCore.SkiaSharpView.Painting
         /// </summary>
         public override void Dispose()
         {
-            if (PathEffect != null) PathEffect.Dispose();
+            if (PathEffect is not null) PathEffect.Dispose();
 
-            if (_drawingContext != null && GetClipRectangle(_drawingContext.MotionCanvas) != RectangleF.Empty)
+            if (_drawingContext is not null && GetClipRectangle(_drawingContext.MotionCanvas) != RectangleF.Empty)
             {
                 _drawingContext.Canvas.Restore();
                 _drawingContext = null;

--- a/tests/LiveChartsCore.UnitTesting/MockedObjects/TestCartesianChartView.cs
+++ b/tests/LiveChartsCore.UnitTesting/MockedObjects/TestCartesianChartView.cs
@@ -19,7 +19,7 @@ namespace LiveChartsCore.UnitTesting.MockedObjects
 
             var stylesBuilder = LiveCharts.CurrentSettings.GetTheme<SkiaSharpDrawingContext>();
             var initializer = stylesBuilder.GetVisualsInitializer();
-            if (stylesBuilder.CurrentColors == null || stylesBuilder.CurrentColors.Length == 0)
+            if (stylesBuilder.CurrentColors is null || stylesBuilder.CurrentColors.Length == 0)
                 throw new Exception("Default colors are not valid");
             initializer.ApplyStyleToChart(this);
 


### PR DESCRIPTION
List of changes by commits:
 - Optimize `using` directives.
   - Remove empty lines at start of `cs` files
   - Remove unused `using` directives
   - Sort `using` directives alphabetically
 - Made constructor methods `protected` in the abstract classes.
   - Since an abstract class can't be instantiated a `public` constructor is useless.
 - Use C# 9.0 logical patterns (`is`, `is not`) instead of equality operator for null checks.
 - Use `??=` operator when possible.