### PR TITLE
Clean up

### DIFF
--- a/samples/AvaloniaSample/Pies/Processing/View.axaml.cs
+++ b/samples/AvaloniaSample/Pies/Processing/View.axaml.cs
@@ -29,17 +29,13 @@ namespace AvaloniaSample.Pies.Processing
             if (value is not IEnumerable enumerable) return null;
 
             var enumerator = enumerable.GetEnumerator();
-            enumerator.MoveNext();
-
-            var firstPaintTask = enumerator.Current;
-            if (firstPaintTask is not SolidColorPaintTask solidPaintTask) return null;
-
-            return new SolidColorBrush(
-                new Color(
+            return enumerator.MoveNext() && enumerator.Current is SolidColorPaintTask solidPaintTask
+                ? new SolidColorBrush(new Color(
                     solidPaintTask.Color.Alpha,
                     solidPaintTask.Color.Red,
                     solidPaintTask.Color.Green,
-                    solidPaintTask.Color.Blue));
+                    solidPaintTask.Color.Blue))
+                : null;
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)

--- a/samples/ViewModelsSamples/General/UserDefinedTypes/ViewModel.cs
+++ b/samples/ViewModelsSamples/General/UserDefinedTypes/ViewModel.cs
@@ -55,7 +55,7 @@ namespace ViewModelsSamples.General.UserDefinedTypes
                 );
         }
 
-        public ISeries[] Series { get; set; } = new[]
+        public ISeries[] Series { get; set; } = new ISeries[]
         {
             new LineSeries<City>
             {

--- a/samples/WPFSample/Pies/Processing/View.xaml.cs
+++ b/samples/WPFSample/Pies/Processing/View.xaml.cs
@@ -26,17 +26,13 @@ namespace WPFSample.Pies.Processing
             if (value is not IEnumerable enumerable) return null;
 
             var enumerator = enumerable.GetEnumerator();
-            enumerator.MoveNext();
-
-            var firstPaintTask = enumerator.Current;
-            if (firstPaintTask is not SolidColorPaintTask solidPaintTask) return null;
-
-            return new SolidColorBrush(
-                Color.FromArgb(
+            return enumerator.MoveNext() && enumerator.Current is SolidColorPaintTask solidPaintTask
+                ? new SolidColorBrush(Color.FromArgb(
                     solidPaintTask.Color.Alpha,
                     solidPaintTask.Color.Red,
                     solidPaintTask.Color.Green,
-                    solidPaintTask.Color.Blue));
+                    solidPaintTask.Color.Blue))
+                : null;
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)

--- a/samples/WinFormsSample/General/Legends/View.cs
+++ b/samples/WinFormsSample/General/Legends/View.cs
@@ -30,7 +30,7 @@ namespace WinFormsSample.General.Legends
             Controls.Add(cartesianChart);
 
             var b1 = new ComboBox { Text = "hidden", Location = new System.Drawing.Point(0, 0) };
-            b1.Items.AddRange(new[] { "hidden", "top", "left", "right", "bottom" });
+            b1.Items.AddRange(new object[] { "hidden", "top", "left", "right", "bottom" });
             b1.SelectedValueChanged += (object sender, System.EventArgs e) =>
             {
                 if (b1.SelectedItem.ToString() == "hidden") cartesianChart.LegendPosition = LegendPosition.Hidden;

--- a/samples/WinFormsSample/General/Tooltips/View.cs
+++ b/samples/WinFormsSample/General/Tooltips/View.cs
@@ -29,7 +29,7 @@ namespace WinFormsSample.General.Tooltips
             Controls.Add(cartesianChart);
 
             var b1 = new ComboBox { Text = "hidden", Location = new System.Drawing.Point(0, 0) };
-            b1.Items.AddRange(new[] { "hidden", "top", "left", "right", "bottom", "center" });
+            b1.Items.AddRange(new object[] { "hidden", "top", "left", "right", "bottom", "center" });
             b1.SelectedValueChanged += (object sender, System.EventArgs e) =>
             {
                 if (b1.SelectedItem.ToString() == "hidden") cartesianChart.TooltipPosition = TooltipPosition.Hidden;

--- a/samples/XamarinSample/XamarinSample/XamarinSample/Pies/Processing/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/Pies/Processing/View.xaml.cs
@@ -20,20 +20,16 @@ namespace XamarinSample.Pies.Processing
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            var enumerable = value as IEnumerable;
-            if (value is null) return null;
+            if (value is not IEnumerable enumerable) return null;
 
             var enumerator = enumerable.GetEnumerator();
-            enumerator.MoveNext();
-
-            var firstPaintTask = enumerator.Current;
-            if (!(firstPaintTask is SolidColorPaintTask solidPaintTask)) return null;
-
-            return Color.FromRgba(
+            return enumerator.MoveNext() && enumerator.Current is SolidColorPaintTask solidPaintTask
+                ? Color.FromRgba(
                     solidPaintTask.Color.Red,
                     solidPaintTask.Color.Green,
                     solidPaintTask.Color.Blue,
-                    solidPaintTask.Color.Alpha);
+                    solidPaintTask.Color.Alpha)
+                : null;
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)

--- a/samples/XamarinSample/XamarinSample/XamarinSample/XamarinSample.csproj
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/XamarinSample.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
+    <LangVersion>9</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/LiveChartsCore/Chart.cs
+++ b/src/LiveChartsCore/Chart.cs
@@ -120,7 +120,7 @@ namespace LiveChartsCore
         /// <summary>
         /// The previous series
         /// </summary>
-        protected IChartSeries<TDrawingContext>[] previousSeries = new IChartSeries<TDrawingContext>[0];
+        protected IReadOnlyList<IChartSeries<TDrawingContext>> previousSeries = new IChartSeries<TDrawingContext>[0];
 
         /// <summary>
         /// The previous legend position
@@ -470,14 +470,14 @@ namespace LiveChartsCore
         /// <param name="newSeries">The new series.</param>
         /// <param name="position">The legend position.</param>
         /// <returns></returns>
-        protected bool SeriesMiniatureChanged(IChartSeries<TDrawingContext>[] newSeries, LegendPosition position)
+        protected bool SeriesMiniatureChanged(IReadOnlyList<IChartSeries<TDrawingContext>> newSeries, LegendPosition position)
         {
             if (position != previousLegendPosition) return true;
-            if (previousSeries.Length != newSeries.Length) return true;
+            if (previousSeries.Count != newSeries.Count) return true;
 
-            for (var i = 0; i < newSeries.Length; i++)
+            for (var i = 0; i < newSeries.Count; i++)
             {
-                if (i + 1 > previousSeries.Length) return true;
+                if (i + 1 > previousSeries.Count) return true;
 
                 var a = previousSeries[i];
                 var b = newSeries[i];

--- a/src/LiveChartsCore/Collections/RangeObservableCollection.cs
+++ b/src/LiveChartsCore/Collections/RangeObservableCollection.cs
@@ -190,13 +190,13 @@ namespace LiveChartsCore.Collections // we use this namespace, because .Net migh
             {
                 if (countable.Count == 0)
                     return;
-                else if (countable.Count == 1)
-                    using (var enumerator = countable.GetEnumerator())
-                    {
-                        _ = enumerator.MoveNext();
-                        _ = Remove(enumerator.Current);
-                        return;
-                    }
+                if (countable.Count == 1)
+                {
+                    using var enumerator = countable.GetEnumerator();
+                    _ = enumerator.MoveNext();
+                    _ = Remove(enumerator.Current);
+                    return;
+                }
             }
             else if (!collection.Any())
                 return;

--- a/src/LiveChartsCore/Geo/Maps.cs
+++ b/src/LiveChartsCore/Geo/Maps.cs
@@ -43,10 +43,8 @@ namespace LiveChartsCore.Geo
 
             var map = "LiveChartsCore.Geo.world.geojson";
 
-            using (var reader = new StreamReader(a.GetManifestResourceStream(map)))
-            {
-                return JsonConvert.DeserializeObject<GeoJsonFile>(reader.ReadToEnd()) ?? throw new Exception("Map not found");
-            }
+            using var reader = new StreamReader(a.GetManifestResourceStream(map));
+            return JsonConvert.DeserializeObject<GeoJsonFile>(reader.ReadToEnd()) ?? throw new Exception("Map not found");
         }
 
         /// <summary>

--- a/src/LiveChartsCore/Kernel/StrokeAndFillDrawable.cs
+++ b/src/LiveChartsCore/Kernel/StrokeAndFillDrawable.cs
@@ -62,7 +62,7 @@ namespace LiveChartsCore.Kernel
         /// <value>
         /// The stroke.
         /// </value>
-        public IPaintTask<TDrawingContext>? Stroke { get; } = null;
+        public IPaintTask<TDrawingContext>? Stroke { get; }
 
         /// <summary>
         /// Gets the fill.
@@ -70,7 +70,7 @@ namespace LiveChartsCore.Kernel
         /// <value>
         /// The fill.
         /// </value>
-        public IPaintTask<TDrawingContext>? Fill { get; } = null;
+        public IPaintTask<TDrawingContext>? Fill { get; }
 
         /// <summary>
         /// Gets or sets a value indicating whether this instance is hover state.

--- a/src/LiveChartsCore/LineSeries.cs
+++ b/src/LiveChartsCore/LineSeries.cs
@@ -94,7 +94,7 @@ namespace LiveChartsCore
             set => SetPaintProperty(ref _geometryFill, value);
         }
 
-        /// <inheritdoc cref="ILineSeries{TDrawingContext}.GeometrySize"/>
+        /// <inheritdoc cref="ILineSeries{TDrawingContext}.GeometryStroke"/>
         public IPaintTask<TDrawingContext>? GeometryStroke
         {
             get => _geometryStroke;

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/DefaultLegend.axaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/DefaultLegend.axaml.cs
@@ -49,9 +49,8 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
         public DefaultLegend()
         {
             InitializeComponent();
-            var t = (DataTemplate?)Resources["defaultTemplate"];
-            if (t is null) throw new Exception("default template not found");
-            _defaultTemplate = t;
+            _defaultTemplate = (DataTemplate?)Resources["defaultTemplate"] ??
+                               throw new Exception("default template not found");
         }
 
         /// <summary>

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/DefaultTooltip.axaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/DefaultTooltip.axaml.cs
@@ -66,7 +66,7 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
         /// <value>
         /// The tool tip template.
         /// </value>
-        public DataTemplate? TooltipTemplate { get; set; } = null;
+        public DataTemplate? TooltipTemplate { get; set; }
 
         /// <summary>
         /// Gets or sets the points.

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/DefaultTooltip.axaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/DefaultTooltip.axaml.cs
@@ -50,10 +50,13 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
         public DefaultTooltip()
         {
             InitializeComponent();
-            var t = (DataTemplate?)Resources["defaultTemplate"];
-            if (t is null) throw new Exception("default template not found");
-            _defaultTemplate = t;
-            TooltipTemplate = t;
+
+            var template = (DataTemplate?)Resources["defaultTemplate"] ??
+                           throw new Exception("default template not found");
+
+            _defaultTemplate = template;
+            TooltipTemplate = template;
+
             Canvas.SetTop(this, 0);
             Canvas.SetLeft(this, 0);
         }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/HeightConverter.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/HeightConverter.cs
@@ -49,8 +49,9 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
         /// </remarks>
         public object? Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            var v = (IChartSeries<SkiaSharpDrawingContext>)value;
-            return v is null ? null : v.CanvasSchedule.Height / DeviceDisplay.MainDisplayInfo.Density;
+            return value is IChartSeries<SkiaSharpDrawingContext> v
+                ? v.CanvasSchedule.Height / DeviceDisplay.MainDisplayInfo.Density
+                : null;
         }
 
         /// <summary>

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/PaintTasksValueConverter.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/PaintTasksValueConverter.cs
@@ -48,8 +48,9 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
         /// </remarks>
         public object? Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            var v = (IChartSeries<SkiaSharpDrawingContext>)value;
-            return v?.CanvasSchedule.PaintSchedules;
+            return value is IChartSeries<SkiaSharpDrawingContext> v
+                ? v.CanvasSchedule.PaintSchedules
+                : null;
         }
 
         /// <summary>

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/WidthConverter.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/WidthConverter.cs
@@ -49,8 +49,9 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
         /// </remarks>
         public object? Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            var v = (IChartSeries<SkiaSharpDrawingContext>)value;
-            return v is null ? null : v.CanvasSchedule.Width / DeviceDisplay.MainDisplayInfo.Density;
+            return value is IChartSeries<SkiaSharpDrawingContext> v
+                ? v.CanvasSchedule.Width / DeviceDisplay.MainDisplayInfo.Density
+                : null;
         }
 
         /// <summary>

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/Geometries/DoughnutGeometry.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/Geometries/DoughnutGeometry.cs
@@ -107,58 +107,56 @@ namespace LiveChartsCore.SkiaSharpView.Drawing.Geometries
 
             if (CornerRadius > 0) throw new NotImplementedException($"{nameof(CornerRadius)} is not implemented.");
 
-            using (var path = new SKPath())
-            {
-                var cx = CenterX;
-                var cy = CenterY;
-                var wedge = InnerRadius;
-                var r = Width * 0.5f;
-                var startAngle = StartAngle;
-                var sweepAngle = SweepAngle;
-                const float toRadians = (float)(Math.PI / 180);
-                var pushout = PushOut;
+            using var path = new SKPath();
+            var cx = CenterX;
+            var cy = CenterY;
+            var wedge = InnerRadius;
+            var r = Width * 0.5f;
+            var startAngle = StartAngle;
+            var sweepAngle = SweepAngle;
+            const float toRadians = (float)(Math.PI / 180);
+            var pushout = PushOut;
 
-                path.MoveTo(
-                    (float)(cx + Math.Cos(startAngle * toRadians) * wedge),
-                    (float)(cy + Math.Sin(startAngle * toRadians) * wedge));
-                path.LineTo(
-                    (float)(cx + Math.Cos(startAngle * toRadians) * (r + pushout)),
-                    (float)(cy + Math.Sin(startAngle * toRadians) * (r + pushout)));
-                path.ArcTo(
-                    new SKRect { Left = X, Top = Y, Size = new SKSize { Width = Width, Height = Height } },
-                    startAngle,
-                    sweepAngle,
-                    false);
-                path.LineTo(
-                    (float)(cx + Math.Cos((sweepAngle + startAngle) * toRadians) * wedge),
-                    (float)(cy + Math.Sin((sweepAngle + startAngle) * toRadians) * wedge));
-                path.ArcTo(
-                    new SKPoint { X = wedge + pushout, Y = wedge + pushout },
-                    0,
-                    sweepAngle > 180 ? SKPathArcSize.Large : SKPathArcSize.Small,
-                    SKPathDirection.CounterClockwise,
-                    new SKPoint
-                    {
-                        X = (float)(cx + Math.Cos(startAngle * toRadians) * wedge),
-                        Y = (float)(cy + Math.Sin(startAngle * toRadians) * wedge)
-                    });
-
-                path.Close();
-
-                if (pushout > 0)
+            path.MoveTo(
+                (float)(cx + Math.Cos(startAngle * toRadians) * wedge),
+                (float)(cy + Math.Sin(startAngle * toRadians) * wedge));
+            path.LineTo(
+                (float)(cx + Math.Cos(startAngle * toRadians) * (r + pushout)),
+                (float)(cy + Math.Sin(startAngle * toRadians) * (r + pushout)));
+            path.ArcTo(
+                new SKRect { Left = X, Top = Y, Size = new SKSize { Width = Width, Height = Height } },
+                startAngle,
+                sweepAngle,
+                false);
+            path.LineTo(
+                (float)(cx + Math.Cos((sweepAngle + startAngle) * toRadians) * wedge),
+                (float)(cy + Math.Sin((sweepAngle + startAngle) * toRadians) * wedge));
+            path.ArcTo(
+                new SKPoint { X = wedge + pushout, Y = wedge + pushout },
+                0,
+                sweepAngle > 180 ? SKPathArcSize.Large : SKPathArcSize.Small,
+                SKPathDirection.CounterClockwise,
+                new SKPoint
                 {
-                    var pushoutAngle = startAngle + 0.5f * sweepAngle;
-                    var x = pushout * (float)Math.Cos(pushoutAngle * toRadians);
-                    var y = pushout * (float)Math.Sin(pushoutAngle * toRadians);
+                    X = (float)(cx + Math.Cos(startAngle * toRadians) * wedge),
+                    Y = (float)(cy + Math.Sin(startAngle * toRadians) * wedge)
+                });
 
-                    _ = context.Canvas.Save();
-                    context.Canvas.Translate(x, y);
-                }
+            path.Close();
 
-                context.Canvas.DrawPath(path, context.Paint);
+            if (pushout > 0)
+            {
+                var pushoutAngle = startAngle + 0.5f * sweepAngle;
+                var x = pushout * (float)Math.Cos(pushoutAngle * toRadians);
+                var y = pushout * (float)Math.Sin(pushoutAngle * toRadians);
 
-                if (pushout > 0) context.Canvas.Restore();
+                _ = context.Canvas.Save();
+                context.Canvas.Translate(x, y);
             }
+
+            context.Canvas.DrawPath(path, context.Paint);
+
+            if (pushout > 0) context.Canvas.Restore();
         }
     }
 }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/Geometries/PathGeometry.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/Geometries/PathGeometry.cs
@@ -57,31 +57,29 @@ namespace LiveChartsCore.SkiaSharpView.Drawing.Geometries
 
             var toRemoveSegments = new List<IPathCommand<SKPath>>();
 
-            using (var path = new SKPath())
+            using var path = new SKPath();
+            var isValid = true;
+
+            foreach (var segment in toExecute)
             {
-                var isValid = true;
+                segment.IsValid = true;
+                segment.Execute(path, GetCurrentTime(), this);
+                isValid = isValid && segment.IsValid;
 
-                foreach (var segment in toExecute)
-                {
-                    segment.IsValid = true;
-                    segment.Execute(path, GetCurrentTime(), this);
-                    isValid = isValid && segment.IsValid;
-
-                    if (segment.IsValid && segment.RemoveOnCompleted) toRemoveSegments.Add(segment);
-                }
-
-                foreach (var segment in toRemoveSegments)
-                {
-                    _ = _commands.Remove(segment);
-                    isValid = false;
-                }
-
-                if (IsClosed) path.Close();
-
-                context.Canvas.DrawPath(path, context.Paint);
-
-                if (!isValid) Invalidate();
+                if (segment.IsValid && segment.RemoveOnCompleted) toRemoveSegments.Add(segment);
             }
+
+            foreach (var segment in toRemoveSegments)
+            {
+                _ = _commands.Remove(segment);
+                isValid = false;
+            }
+
+            if (IsClosed) path.Close();
+
+            context.Canvas.DrawPath(path, context.Paint);
+
+            if (!isValid) Invalidate();
         }
 
         /// <inheritdoc cref="IPathGeometry{TDrawingContext, TPathArgs}.AddCommand(IPathCommand{TPathArgs})" />

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/Geometries/PathShape.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/Geometries/PathShape.cs
@@ -94,39 +94,37 @@ namespace LiveChartsCore.SkiaSharpView.Drawing.Geometries
 
             var toRemoveSegments = new List<IPathCommand<SKPath>>();
 
-            using (var path = new SKPath())
+            using var path = new SKPath();
+            var isValid = true;
+
+            foreach (var segment in toExecute)
             {
-                var isValid = true;
+                segment.IsValid = true;
+                segment.Execute(path, GetCurrentTime(), this);
+                isValid = isValid && segment.IsValid;
 
-                foreach (var segment in toExecute)
-                {
-                    segment.IsValid = true;
-                    segment.Execute(path, GetCurrentTime(), this);
-                    isValid = isValid && segment.IsValid;
-
-                    if (segment.IsValid && segment.RemoveOnCompleted) toRemoveSegments.Add(segment);
-                }
-
-                foreach (var segment in toRemoveSegments)
-                {
-                    _ = _commands.Remove(segment);
-                    isValid = false;
-                }
-
-                if (IsClosed) path.Close();
-
-                context.Paint.Color = FillColor.AsSKColor();
-                context.Paint.StrokeWidth = 0;
-                context.Paint.Style = SKPaintStyle.Fill;
-                context.Canvas.DrawPath(path, context.Paint);
-
-                context.Paint.Color = StrokeColor.AsSKColor();
-                context.Paint.StrokeWidth = StrokeThickness;
-                context.Paint.Style = SKPaintStyle.Stroke;
-                context.Canvas.DrawPath(path, context.Paint);
-
-                if (!isValid) Invalidate();
+                if (segment.IsValid && segment.RemoveOnCompleted) toRemoveSegments.Add(segment);
             }
+
+            foreach (var segment in toRemoveSegments)
+            {
+                _ = _commands.Remove(segment);
+                isValid = false;
+            }
+
+            if (IsClosed) path.Close();
+
+            context.Paint.Color = FillColor.AsSKColor();
+            context.Paint.StrokeWidth = 0;
+            context.Paint.Style = SKPaintStyle.Fill;
+            context.Canvas.DrawPath(path, context.Paint);
+
+            context.Paint.Color = StrokeColor.AsSKColor();
+            context.Paint.StrokeWidth = StrokeThickness;
+            context.Paint.Style = SKPaintStyle.Stroke;
+            context.Canvas.DrawPath(path, context.Paint);
+
+            if (!isValid) Invalidate();
         }
     }
 }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/LinearGradientPaintTask.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/LinearGradientPaintTask.cs
@@ -38,8 +38,8 @@ namespace LiveChartsCore.SkiaSharpView.Painting
         private readonly SKColor[] _gradientStops;
         private readonly SKPoint _startPoint;
         private readonly SKPoint _endPoint;
-        private readonly float[]? _colorPos = null;
-        private readonly SKShaderTileMode _tileMode = SKShaderTileMode.Repeat;
+        private readonly float[]? _colorPos;
+        private readonly SKShaderTileMode _tileMode;
         private SkiaSharpDrawingContext? _drawingContext;
 
         /// <summary>


### PR DESCRIPTION
- Fix `LineSeries.GeometryStroke` documentation.
- Remove redundant initialization of fields and properties.
- Join null check with assignment.
- Fix uses of co-variant arrays.
- Convert to `using` declaration.
- Review value converters.
  - Fix possible invalid cast exception.
  - Fix possible undefined behavior (Get `IEnumerator.Current` while `IEnumerator.MoveNext` returned `false`).
  - Set XamarinSample project `LangVersion` to 9

