### PR TITLE
Allow WinUI MotionCanvas to be unloaded/re-loaded correctly

### DIFF
--- a/src/skiasharp/LiveChartsCore.SkiaSharpVew.WinUI/MotionCanvas.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpVew.WinUI/MotionCanvas.xaml.cs
@@ -49,7 +49,6 @@ namespace LiveChartsCore.SkiaSharpView.WinUI
         {
             InitializeComponent();
             Loaded += OnLoaded;
-            CanvasCore.Invalidated += OnCanvasCoreInvalidated;
             Unloaded += OnUnloaded;
         }
 
@@ -91,6 +90,8 @@ namespace LiveChartsCore.SkiaSharpView.WinUI
 
         private void OnLoaded(object sender, RoutedEventArgs e)
         {
+            CanvasCore.Invalidated += OnCanvasCoreInvalidated;
+
             var canvas = (SKXamlCanvas)FindName("canvas");
             _skiaElement = canvas;
             _skiaElement.PaintSurface += OnPaintSurface;


### PR DESCRIPTION
@beto-rodriguez I don't have my machine set up for WinUI testing, so **I haven't done any testing on this**, but it looks like the same issue with loading/unloading the `MotionCanvas` might also exist for that platform.

Feel free to mark this PR as ready/merge it if it looks good.