### PR TITLE
Support null values in DateTimePoint constructor

### DIFF
--- a/src/LiveChartsCore/Defaults/DateTimePoint.cs
+++ b/src/LiveChartsCore/Defaults/DateTimePoint.cs
@@ -45,7 +45,7 @@ namespace LiveChartsCore.Defaults
         /// </summary>
         /// <param name="dateTime">The date time.</param>
         /// <param name="value">The value.</param>
-        public DateTimePoint(DateTime dateTime, double value)
+        public DateTimePoint(DateTime dateTime, double? value)
         {
             _dateTime = dateTime;
             _value = value;


### PR DESCRIPTION
The `Value` property in `DateTimePoint` is already nullable, this PR just changes the associated constructor parameter to match