### PR TITLE
[bugfix] Fix crashing when window closing on WinUI

### DIFF
--- a/src/LiveChartsCore/CartesianChart.cs
+++ b/src/LiveChartsCore/CartesianChart.cs
@@ -344,6 +344,8 @@ namespace LiveChartsCore
         /// <returns></returns>
         protected override void Measure()
         {
+            if (_chartView.ControlSize.IsEmpty) return;
+
             lock (canvas.Sync)
             {
 #if DEBUG

--- a/src/LiveChartsCore/PieChart.cs
+++ b/src/LiveChartsCore/PieChart.cs
@@ -154,6 +154,7 @@ namespace LiveChartsCore
         /// <returns></returns>
         protected override void Measure()
         {
+            if (_chartView.ControlSize.IsEmpty) return;
             lock (canvas.Sync)
             {
                 InvokeOnMeasuring();

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/Geometries/Geometry.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/Geometries/Geometry.cs
@@ -101,6 +101,10 @@ namespace LiveChartsCore.SkiaSharpView.Drawing.Geometries
         /// <param name="context">The context.</param>
         public override void Draw(SkiaSharpDrawingContext context)
         {
+            if ((context == null) || (context.Canvas == null))
+            {
+                return;
+            }
             var hasRotation = Rotation != 0;
 
             if (_hasTransform || hasRotation || hasCustomTransform)

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/Geometries/PathGeometry.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/Geometries/PathGeometry.cs
@@ -51,6 +51,10 @@ namespace LiveChartsCore.SkiaSharpView.Drawing.Geometries
         /// <inheritdoc cref="Geometry.OnDraw(SkiaSharpDrawingContext, SKPaint)" />
         public override void Draw(SkiaSharpDrawingContext context)
         {
+            if ((context == null) || (context.Canvas == null))
+            {
+                return;
+            }
             if (_commands.Count == 0) return;
 
             var toExecute = _drawingCommands ??= _commands.ToArray();

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/Geometries/PathShape.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/Geometries/PathShape.cs
@@ -88,6 +88,10 @@ namespace LiveChartsCore.SkiaSharpView.Drawing.Geometries
         /// <inheritdoc cref="Draw(SkiaSharpDrawingContext)"/>
         public override void Draw(SkiaSharpDrawingContext context)
         {
+            if ((context == null) || (context.Canvas == null))
+            {
+                return;
+            }
             if (_commands.Count == 0) return;
 
             var toExecute = _drawingCommands ??= _commands.ToArray();


### PR DESCRIPTION
I fixed crashing when window closing on WinUI.
To reproduce the bug, the chart menus located on the left must be quickly switched before the animation ends.
Then you can see the result like the attached picture.
![00](https://user-images.githubusercontent.com/51893532/127242417-dc38a1c2-3727-483d-8daf-ef39e7423097.png)

To fix this bug, I've modified code in 2-ways.
1. In Measure() and Draw() methods, I insert codes to check whether control to draw is disposed.
2. In MotionCanvas.xaml.cs, I insert codes to stop drawing when control was unloded.