### PR TITLE
Load Theme Correctly in `DrawMarginFrame`

### DIFF
--- a/src/skiasharp/LiveChartsCore.SkiaSharp/DrawMarginFrame.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/DrawMarginFrame.cs
@@ -35,6 +35,7 @@ namespace LiveChartsCore.SkiaSharpView
         /// </summary>
         public DrawMarginFrame()
         {
+            if (!LiveCharts.IsConfigured) LiveCharts.Configure(LiveChartsSkiaSharp.DefaultPlatformBuilder);
             var stylesBuilder = LiveCharts.CurrentSettings.GetTheme<SkiaSharpDrawingContext>();
             var initializer = stylesBuilder.GetVisualsInitializer();
 


### PR DESCRIPTION
Ensure LiveCharts is configured before attempting to load the current theme in `DrawMarginFrame`. This update matches the pattern used in other classes that load the theme.

Fixes #53