### PR TITLE
No system.drawing

### DIFF
--- a/samples/ViewModelsSamples/Axes/ColorsAndPosition/ViewModel.cs
+++ b/samples/ViewModelsSamples/Axes/ColorsAndPosition/ViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using LiveChartsCore;
+using LiveChartsCore.Drawing;
 using LiveChartsCore.Measure;
 using LiveChartsCore.SkiaSharpView;
 using LiveChartsCore.SkiaSharpView.Painting;
@@ -6,7 +7,6 @@ using LiveChartsCore.Themes;
 using SkiaSharp;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Drawing;
 using System.Windows.Input;
 
 namespace ViewModelsSamples.Axes.ColorsAndPosition
@@ -15,7 +15,7 @@ namespace ViewModelsSamples.Axes.ColorsAndPosition
     {
         private AxisPosition _selectedPosition;
         private int _selectedColor = 0;
-        private readonly Color[] _colors = ColorPalletes.FluentDesign;
+        private readonly LvcColor[] _colors = ColorPalletes.FluentDesign;
 
         public ViewModel()
         {

--- a/samples/ViewModelsSamples/Heat/Basic/ViewModel.cs
+++ b/samples/ViewModelsSamples/Heat/Basic/ViewModel.cs
@@ -1,8 +1,8 @@
 ﻿using System.Collections.ObjectModel;
-using System.Drawing;
 using LiveChartsCore;
 using LiveChartsCore.Defaults;
 using LiveChartsCore.SkiaSharpView;
+using SkiaSharp;
 
 namespace ViewModelsSamples.Heat.Basic
 {
@@ -14,9 +14,9 @@ namespace ViewModelsSamples.Heat.Basic
             {
                 HeatMap = new[]
                 {
-                    Color.FromArgb(255, 255, 241, 118), // the first element is the "coldest"
-                    Color.DarkSlateGray,
-                    Color.Blue // the last element is the "hottest"
+                    new SKColor(255, 241, 118).AsLvcColor(), // the first element is the "coldest"
+                    SKColors.DarkSlateGray.AsLvcColor(),
+                    SKColors.Blue.AsLvcColor() // the last element is the "hottest"
                 },
                 Values = new ObservableCollection<WeightedPoint>
                 {

--- a/samples/ViewModelsSamples/Lines/Properties/ViewModel.cs
+++ b/samples/ViewModelsSamples/Lines/Properties/ViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using LiveChartsCore;
+using LiveChartsCore.Drawing;
 using LiveChartsCore.SkiaSharpView;
 using LiveChartsCore.SkiaSharpView.Painting;
 using LiveChartsCore.Themes;
@@ -6,7 +7,6 @@ using SkiaSharp;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Drawing;
 using System.Runtime.CompilerServices;
 using System.Windows.Input;
 
@@ -14,7 +14,7 @@ namespace ViewModelsSamples.Lines.Properties
 {
     public class ViewModel : INotifyPropertyChanged
     {
-        private readonly Color[] colors = ColorPalletes.FluentDesign;
+        private readonly LvcColor[] colors = ColorPalletes.FluentDesign;
         private readonly Random random = new Random();
         private LineSeries<double> lineSeries;
         private int currentColor = 0;

--- a/samples/ViewModelsSamples/StepLines/Properties/ViewModel.cs
+++ b/samples/ViewModelsSamples/StepLines/Properties/ViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using LiveChartsCore;
+using LiveChartsCore.Drawing;
 using LiveChartsCore.SkiaSharpView;
 using LiveChartsCore.SkiaSharpView.Painting;
 using LiveChartsCore.Themes;
@@ -6,7 +7,6 @@ using SkiaSharp;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Drawing;
 using System.Runtime.CompilerServices;
 using System.Windows.Input;
 
@@ -14,7 +14,7 @@ namespace ViewModelsSamples.StepLines.Properties
 {
     public class ViewModel : INotifyPropertyChanged
     {
-        private readonly Color[] colors = ColorPalletes.FluentDesign;
+        private readonly LvcColor[] colors = ColorPalletes.FluentDesign;
         private readonly Random random = new Random();
         private StepLineSeries<double> lineSeries;
         private int currentColor = 0;

--- a/samples/WinFormsSample/General/TemplatedTooltips/CustomTooltip.cs
+++ b/samples/WinFormsSample/General/TemplatedTooltips/CustomTooltip.cs
@@ -1,4 +1,5 @@
 ﻿using LiveChartsCore;
+using LiveChartsCore.Drawing;
 using LiveChartsCore.Kernel;
 using LiveChartsCore.Kernel.Sketches;
 using LiveChartsCore.SkiaSharpView.Drawing;
@@ -38,17 +39,17 @@ namespace WinFormsSample.General.TemplatedTooltips
             if (activePoints.Count > 0 && tooltipPoints.All(x => activePoints.ContainsKey(x.Point))) return;
 
             var size = DrawAndMesure(tooltipPoints, wfChart);
-            PointF? location = null;
+            LvcPoint? location = null;
 
             if (chart is CartesianChart<SkiaSharpDrawingContext>)
             {
                 location = tooltipPoints.GetCartesianTooltipLocation(
-                    chart.TooltipPosition, new SizeF((float)size.Width, (float)size.Height), chart.ControlSize);
+                    chart.TooltipPosition, new LvcSize((float)size.Width, (float)size.Height), chart.ControlSize);
             }
             if (chart is PieChart<SkiaSharpDrawingContext>)
             {
                 location = tooltipPoints.GetPieTooltipLocation(
-                    chart.TooltipPosition, new SizeF((float)size.Width, (float)size.Height));
+                    chart.TooltipPosition, new LvcSize((float)size.Width, (float)size.Height));
             }
 
             BackColor = Color.FromArgb(255, 30, 30, 30);

--- a/samples/WinUISample/WinUI/WinUI/WinUISample - Backup.csproj
+++ b/samples/WinUISample/WinUI/WinUI/WinUISample - Backup.csproj
@@ -46,6 +46,7 @@
     <None Remove="General\ChartToImage\View.xaml" />
     <None Remove="General\Animations\View.xaml" />
     <None Remove="Heat\Basic\View.xaml" />
+    <None Remove="Polar\Basic\View.xaml" />
     <None Remove="StepLines\Area\View.xaml" />
     <None Remove="StepLines\AutoUpdate\View.xaml" />
     <None Remove="StepLines\Basic\View.xaml" />
@@ -255,7 +256,7 @@
       <XamlRuntime>$(DefaultXamlRuntime)</XamlRuntime>
     </Page>
     <Page Update="Polar\Basic\View.xaml">
-      <Generator>MSBuild:Compile</Generator>
+      <XamlRuntime>$(DefaultXamlRuntime)</XamlRuntime>
     </Page>
     <Page Update="Scatter\AutoUpdate - Copy\View.xaml">
       <XamlRuntime>$(DefaultXamlRuntime)</XamlRuntime>

--- a/src/LiveChartsCore/Axis.cs
+++ b/src/LiveChartsCore/Axis.cs
@@ -25,7 +25,6 @@ using LiveChartsCore.Drawing;
 using LiveChartsCore.Drawing.Common;
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
 using LiveChartsCore.Measure;
 using System.ComponentModel;
@@ -41,10 +40,11 @@ namespace LiveChartsCore
     /// <typeparam name="TDrawingContext">The type of the drawing context.</typeparam>
     /// <typeparam name="TTextGeometry">The type of the text geometry.</typeparam>
     /// <typeparam name="TLineGeometry">The type of the line geometry.</typeparam>
-    public abstract class Axis<TDrawingContext, TTextGeometry, TLineGeometry> : ChartElement<TDrawingContext>, ICartesianAxis, IPlane<TDrawingContext>
-        where TDrawingContext : DrawingContext
-        where TTextGeometry : ILabelGeometry<TDrawingContext>, new()
-        where TLineGeometry : ILineGeometry<TDrawingContext>, new()
+    public abstract class Axis<TDrawingContext, TTextGeometry, TLineGeometry>
+        : ChartElement<TDrawingContext>, ICartesianAxis, IPlane<TDrawingContext>
+            where TDrawingContext : DrawingContext
+            where TTextGeometry : ILabelGeometry<TDrawingContext>, new()
+            where TLineGeometry : ILineGeometry<TDrawingContext>, new()
     {
         #region fields
 
@@ -245,7 +245,7 @@ namespace LiveChartsCore
             if (SeparatorsPaint is not null)
             {
                 SeparatorsPaint.ZIndex = -1;
-                SeparatorsPaint.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
+                SeparatorsPaint.SetClipRectangle(cartesianChart.Canvas, new LvcRectangle(drawLocation, drawMarginSize));
                 cartesianChart.Canvas.AddDrawableTask(SeparatorsPaint);
             }
 
@@ -486,9 +486,9 @@ namespace LiveChartsCore
         }
 
         /// <inheritdoc cref="IPlane{TDrawingContext}.GetNameLabelSize(Chart{TDrawingContext})"/>
-        public SizeF GetNameLabelSize(Chart<TDrawingContext> chart)
+        public LvcSize GetNameLabelSize(Chart<TDrawingContext> chart)
         {
-            if (NamePaint is null || string.IsNullOrWhiteSpace(Name)) return new SizeF(0, 0);
+            if (NamePaint is null || string.IsNullOrWhiteSpace(Name)) return new LvcSize(0, 0);
 
             var textGeometry = new TTextGeometry
             {
@@ -502,10 +502,10 @@ namespace LiveChartsCore
         }
 
         /// <inheritdoc cref="IPlane{TDrawingContext}.GetPossibleSize(Chart{TDrawingContext})"/>
-        public virtual SizeF GetPossibleSize(Chart<TDrawingContext> chart)
+        public virtual LvcSize GetPossibleSize(Chart<TDrawingContext> chart)
         {
             if (_dataBounds is null) throw new Exception("DataBounds not found");
-            if (LabelsPaint is null) return new SizeF(0f, 0f);
+            if (LabelsPaint is null) return new LvcSize(0f, 0f);
 
             var ts = (float)TextSize;
             var labeler = Labeler;
@@ -543,7 +543,7 @@ namespace LiveChartsCore
                 if (m.Height > h) h = m.Height;
             }
 
-            return new SizeF(w, h);
+            return new LvcSize(w, h);
         }
 
         /// <inheritdoc cref="ICartesianAxis.Initialize(AxisOrientation)"/>

--- a/src/LiveChartsCore/BarSeries.cs
+++ b/src/LiveChartsCore/BarSeries.cs
@@ -36,10 +36,11 @@ namespace LiveChartsCore
     /// <typeparam name="TDrawingContext">The type of the drawing context.</typeparam>
     /// <seealso cref="CartesianSeries{TModel, TVisual, TLabel, TDrawingContext}" />
     /// <seealso cref="IBarSeries{TDrawingContext}" />
-    public abstract class BarSeries<TModel, TVisual, TLabel, TDrawingContext> : StrokeAndFillCartesianSeries<TModel, TVisual, TLabel, TDrawingContext>, IBarSeries<TDrawingContext>
-        where TVisual : class, ISizedVisualChartPoint<TDrawingContext>, new()
-        where TDrawingContext : DrawingContext
-        where TLabel : class, ILabelGeometry<TDrawingContext>, new()
+    public abstract class BarSeries<TModel, TVisual, TLabel, TDrawingContext>
+        : StrokeAndFillCartesianSeries<TModel, TVisual, TLabel, TDrawingContext>, IBarSeries<TDrawingContext>
+            where TVisual : class, ISizedVisualChartPoint<TDrawingContext>, new()
+            where TDrawingContext : DrawingContext
+            where TLabel : class, ILabelGeometry<TDrawingContext>, new()
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="BarSeries{TModel, TVisual, TLabel, TDrawingContext}"/> class.

--- a/src/LiveChartsCore/CartesianChart.cs
+++ b/src/LiveChartsCore/CartesianChart.cs
@@ -24,7 +24,6 @@ using LiveChartsCore.Kernel;
 using LiveChartsCore.Drawing;
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
 using LiveChartsCore.Measure;
 using LiveChartsCore.Kernel.Sketches;
@@ -144,7 +143,7 @@ namespace LiveChartsCore
         /// </summary>
         /// <param name="pointerPosition">The pointer position.</param>
         /// <returns></returns>
-        public override TooltipPoint[] FindPointsNearTo(PointF pointerPosition)
+        public override TooltipPoint[] FindPointsNearTo(LvcPoint pointerPosition)
         {
             var actualStrategy = TooltipFindingStrategy;
             if (actualStrategy == TooltipFindingStrategy.Automatic)
@@ -196,7 +195,7 @@ namespace LiveChartsCore
         /// <param name="xAxisIndex">Index of the x axis.</param>
         /// <param name="yAxisIndex">Index of the y axis.</param>
         /// <returns></returns>
-        public double[] ScaleUIPoint(PointF point, int xAxisIndex = 0, int yAxisIndex = 0)
+        public double[] ScaleUIPoint(LvcPoint point, int xAxisIndex = 0, int yAxisIndex = 0)
         {
             var xAxis = XAxes[xAxisIndex];
             var yAxis = YAxes[yAxisIndex];
@@ -213,7 +212,7 @@ namespace LiveChartsCore
         /// <param name="pivot">The pivot.</param>
         /// <param name="direction">The direction.</param>
         /// <returns></returns>
-        public void Zoom(PointF pivot, ZoomDirection direction)
+        public void Zoom(LvcPoint pivot, ZoomDirection direction)
         {
             if (YAxes is null || XAxes is null) return;
 
@@ -286,7 +285,7 @@ namespace LiveChartsCore
         /// </summary>
         /// <param name="delta">The delta.</param>
         /// <returns></returns>
-        public void Pan(PointF delta)
+        public void Pan(LvcPoint delta)
         {
             if ((_zoomMode & ZoomAndPanMode.X) == ZoomAndPanMode.X)
             {

--- a/src/LiveChartsCore/CartesianSeries.cs
+++ b/src/LiveChartsCore/CartesianSeries.cs
@@ -24,7 +24,6 @@ using LiveChartsCore.Kernel;
 using LiveChartsCore.Drawing;
 using System;
 using LiveChartsCore.Measure;
-using System.Drawing;
 using LiveChartsCore.Kernel.Sketches;
 using LiveChartsCore.Kernel.Data;
 using System.Collections.Generic;
@@ -132,12 +131,12 @@ namespace LiveChartsCore
         /// <param name="seriesProperties">The series properties.</param>
         /// <param name="isGreaterThanPivot">if set to <c>true</c> [is greater than pivot].</param>
         /// <returns></returns>
-        protected virtual PointF GetLabelPosition(
+        protected virtual LvcPoint GetLabelPosition(
             float x,
             float y,
             float width,
             float height,
-            SizeF labelSize,
+            LvcSize labelSize,
             DataLabelsPosition position,
             SeriesProperties seriesProperties,
             bool isGreaterThanPivot)
@@ -147,27 +146,27 @@ namespace LiveChartsCore
 
             return position switch
             {
-                DataLabelsPosition.Middle => new PointF(middleX, middleY),
-                DataLabelsPosition.Top => new PointF(middleX, y - labelSize.Height * 0.5f),
-                DataLabelsPosition.Bottom => new PointF(middleX, y + height + labelSize.Height * 0.5f),
-                DataLabelsPosition.Left => new PointF(x - labelSize.Width * 0.5f, middleY),
-                DataLabelsPosition.Right => new PointF(x + width + labelSize.Width * 0.5f, middleY),
+                DataLabelsPosition.Middle => new LvcPoint(middleX, middleY),
+                DataLabelsPosition.Top => new LvcPoint(middleX, y - labelSize.Height * 0.5f),
+                DataLabelsPosition.Bottom => new LvcPoint(middleX, y + height + labelSize.Height * 0.5f),
+                DataLabelsPosition.Left => new LvcPoint(x - labelSize.Width * 0.5f, middleY),
+                DataLabelsPosition.Right => new LvcPoint(x + width + labelSize.Width * 0.5f, middleY),
                 DataLabelsPosition.End =>
                 (seriesProperties & SeriesProperties.PrimaryAxisHorizontalOrientation) == SeriesProperties.PrimaryAxisHorizontalOrientation
                     ? (isGreaterThanPivot
-                        ? new PointF(x + width + labelSize.Width * 0.5f, middleY)
-                        : new PointF(x - labelSize.Width * 0.5f, middleY))
+                        ? new LvcPoint(x + width + labelSize.Width * 0.5f, middleY)
+                        : new LvcPoint(x - labelSize.Width * 0.5f, middleY))
                     : (isGreaterThanPivot
-                        ? new PointF(middleX, y - labelSize.Height * 0.5f)
-                        : new PointF(middleX, y + height + labelSize.Height * 0.5f)),
+                        ? new LvcPoint(middleX, y - labelSize.Height * 0.5f)
+                        : new LvcPoint(middleX, y + height + labelSize.Height * 0.5f)),
                 DataLabelsPosition.Start =>
                      (seriesProperties & SeriesProperties.PrimaryAxisHorizontalOrientation) == SeriesProperties.PrimaryAxisHorizontalOrientation
                         ? (isGreaterThanPivot
-                            ? new PointF(x - labelSize.Width * 0.5f, middleY)
-                            : new PointF(x + width + labelSize.Width * 0.5f, middleY))
+                            ? new LvcPoint(x - labelSize.Width * 0.5f, middleY)
+                            : new LvcPoint(x + width + labelSize.Width * 0.5f, middleY))
                         : (isGreaterThanPivot
-                            ? new PointF(middleX, y + height + labelSize.Height * 0.5f)
-                            : new PointF(middleX, y - labelSize.Height * 0.5f)),
+                            ? new LvcPoint(middleX, y + height + labelSize.Height * 0.5f)
+                            : new LvcPoint(middleX, y - labelSize.Height * 0.5f)),
                 _ => throw new Exception("Position not supported"),
             };
         }

--- a/src/LiveChartsCore/Chart.cs
+++ b/src/LiveChartsCore/Chart.cs
@@ -25,7 +25,6 @@ using LiveChartsCore.Drawing;
 using LiveChartsCore.Measure;
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
 using LiveChartsCore.Kernel.Events;
 using LiveChartsCore.Kernel.Sketches;
@@ -52,9 +51,9 @@ namespace LiveChartsCore
         private readonly ActionThrottler _updateThrottler;
         private readonly ActionThrottler _tooltipThrottler;
         private readonly ActionThrottler _panningThrottler;
-        private PointF _pointerPosition = new(-10, -10);
-        private PointF _pointerPanningPosition = new(-10, -10);
-        private PointF _pointerPreviousPanningPosition = new(-10, -10);
+        private LvcPoint _pointerPosition = new(-10, -10);
+        private LvcPoint _pointerPanningPosition = new(-10, -10);
+        private LvcPoint _pointerPreviousPanningPosition = new(-10, -10);
         private bool _isPanning = false;
         private bool _isPointerIn = false;
 
@@ -96,11 +95,11 @@ namespace LiveChartsCore
         /// <inheritdoc cref="IChartView{TDrawingContext}.UpdateFinished" />
         public event ChartEventHandler<TDrawingContext>? UpdateFinished;
 
-        internal event Action<PointF> PointerDown;
+        internal event Action<LvcPoint> PointerDown;
 
-        internal event Action<PointF> PointerMove;
+        internal event Action<LvcPoint> PointerMove;
 
-        internal event Action<PointF> PointerUp;
+        internal event Action<LvcPoint> PointerUp;
 
         internal event Action PointerLeft;
 
@@ -174,7 +173,7 @@ namespace LiveChartsCore
         /// <value>
         /// The size of the control.
         /// </value>
-        public SizeF ControlSize { get; protected set; } = new Size();
+        public LvcSize ControlSize { get; protected set; } = new LvcSize();
 
         /// <summary>
         /// Gets the draw margin location.
@@ -182,7 +181,7 @@ namespace LiveChartsCore
         /// <value>
         /// The draw margin location.
         /// </value>
-        public PointF DrawMarginLocation { get; protected set; } = new PointF();
+        public LvcPoint DrawMarginLocation { get; protected set; } = new LvcPoint();
 
         /// <summary>
         /// Gets the size of the draw margin.
@@ -190,7 +189,7 @@ namespace LiveChartsCore
         /// <value>
         /// The size of the draw margin.
         /// </value>
-        public SizeF DrawMarginSize { get; protected set; } = new SizeF();
+        public LvcSize DrawMarginSize { get; protected set; } = new LvcSize();
 
         /// <summary>
         /// Gets the legend position.
@@ -303,19 +302,19 @@ namespace LiveChartsCore
         /// </summary>
         /// <param name="pointerPosition">The pointer position.</param>
         /// <returns></returns>
-        public abstract TooltipPoint[] FindPointsNearTo(PointF pointerPosition);
+        public abstract TooltipPoint[] FindPointsNearTo(LvcPoint pointerPosition);
 
-        internal void InvokePointerDown(PointF point)
+        internal void InvokePointerDown(LvcPoint point)
         {
             PointerDown?.Invoke(point);
         }
 
-        internal void InvokePointerMove(PointF point)
+        internal void InvokePointerMove(LvcPoint point)
         {
             PointerMove?.Invoke(point);
         }
 
-        internal void InvokePointerUp(PointF point)
+        internal void InvokePointerUp(LvcPoint point)
         {
             PointerUp?.Invoke(point);
         }
@@ -337,15 +336,15 @@ namespace LiveChartsCore
         /// <param name="controlSize">Size of the control.</param>
         /// <param name="margin">The margin.</param>
         /// <returns></returns>
-        protected void SetDrawMargin(SizeF controlSize, Margin margin)
+        protected void SetDrawMargin(LvcSize controlSize, Margin margin)
         {
-            DrawMarginSize = new SizeF
+            DrawMarginSize = new LvcSize
             {
                 Width = controlSize.Width - margin.Left - margin.Right,
                 Height = controlSize.Height - margin.Top - margin.Bottom
             };
 
-            DrawMarginLocation = new PointF(margin.Left, margin.Top);
+            DrawMarginLocation = new LvcPoint(margin.Left, margin.Top);
         }
 
         /// <summary>
@@ -453,21 +452,49 @@ namespace LiveChartsCore
 
         private Task PanningThrottlerUnlocked()
         {
-            return Task.Run(() =>
-                View.InvokeOnUIThread(() =>
+            return Task.Run((Action)(() =>
+                View.InvokeOnUIThread((Action)(() =>
                 {
                     if (this is not CartesianChart<TDrawingContext> cartesianChart) return;
 
                     lock (Canvas.Sync)
                     {
                         cartesianChart.Pan(
-                        new PointF(
+
+/* Unmerged change from project 'LiveChartsCore (netcoreapp2.0)'
+Before:
+                        new LvPoint(
+After:
+                        new Drawing.LvPoint(
+*/
+
+/* Unmerged change from project 'LiveChartsCore (netstandard2.0)'
+Before:
+                        new LvPoint(
+After:
+                        new Drawing.LvPoint(
+*/
+                        (LvcPoint)new LvcPoint(
                         (float)(_pointerPanningPosition.X - _pointerPreviousPanningPosition.X),
                         (float)(_pointerPanningPosition.Y - _pointerPreviousPanningPosition.Y)));
 
-                        _pointerPreviousPanningPosition = new PointF(_pointerPanningPosition.X, _pointerPanningPosition.Y);
+
+/* Unmerged change from project 'LiveChartsCore (netcoreapp2.0)'
+Before:
+                        _pointerPreviousPanningPosition = new LvPoint(_pointerPanningPosition.X, _pointerPanningPosition.Y);
+After:
+                        _pointerPreviousPanningPosition = new Drawing.LvPoint(_pointerPanningPosition.X, _pointerPanningPosition.Y);
+*/
+
+/* Unmerged change from project 'LiveChartsCore (netstandard2.0)'
+Before:
+                        _pointerPreviousPanningPosition = new LvPoint(_pointerPanningPosition.X, _pointerPanningPosition.Y);
+After:
+                        _pointerPreviousPanningPosition = new Drawing.LvPoint(_pointerPanningPosition.X, _pointerPanningPosition.Y);
+*/
+                        _pointerPreviousPanningPosition = new LvcPoint(_pointerPanningPosition.X, _pointerPanningPosition.Y);
                     }
-                }));
+                }))));
         }
 
         private void OnCanvasValidated(MotionCanvas<TDrawingContext> chart)
@@ -475,13 +502,13 @@ namespace LiveChartsCore
             InvokeOnUpdateFinished();
         }
 
-        private void Chart_PointerDown(PointF pointerPosition)
+        private void Chart_PointerDown(LvcPoint pointerPosition)
         {
             _isPanning = true;
             _pointerPreviousPanningPosition = pointerPosition;
         }
 
-        private void Chart_PointerMove(PointF pointerPosition)
+        private void Chart_PointerMove(LvcPoint pointerPosition)
         {
             _pointerPosition = pointerPosition;
             _isPointerIn = true;
@@ -496,7 +523,7 @@ namespace LiveChartsCore
             _isPointerIn = false;
         }
 
-        private void Chart_PointerUp(PointF pointerPosition)
+        private void Chart_PointerUp(LvcPoint pointerPosition)
         {
             if (!_isPanning) return;
             _isPanning = false;

--- a/src/LiveChartsCore/ChartSeries.cs
+++ b/src/LiveChartsCore/ChartSeries.cs
@@ -38,10 +38,11 @@ namespace LiveChartsCore
     /// <typeparam name="TDrawingContext">The type of the drawing context.</typeparam>
     /// <seealso cref="Series{TModel, TVisual, TLabel, TDrawingContext}" />
     /// <seealso cref="IChartSeries{TDrawingContext}" />
-    public abstract class ChartSeries<TModel, TVisual, TLabel, TDrawingContext> : Series<TModel, TVisual, TLabel, TDrawingContext>, IChartSeries<TDrawingContext>
-        where TDrawingContext : DrawingContext
-        where TVisual : class, IVisualChartPoint<TDrawingContext>, new()
-        where TLabel : class, ILabelGeometry<TDrawingContext>, new()
+    public abstract class ChartSeries<TModel, TVisual, TLabel, TDrawingContext>
+        : Series<TModel, TVisual, TLabel, TDrawingContext>, IChartSeries<TDrawingContext>
+            where TDrawingContext : DrawingContext
+            where TVisual : class, IVisualChartPoint<TDrawingContext>, new()
+            where TLabel : class, ILabelGeometry<TDrawingContext>, new()
     {
         private double _legendShapeSize = 15;
         private IPaint<TDrawingContext>? _dataLabelsPaint;

--- a/src/LiveChartsCore/ColumnSeries.cs
+++ b/src/LiveChartsCore/ColumnSeries.cs
@@ -28,7 +28,6 @@ using LiveChartsCore.Kernel.Sketches;
 using LiveChartsCore.Measure;
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 
 namespace LiveChartsCore
 {
@@ -54,7 +53,7 @@ namespace LiveChartsCore
                   SeriesProperties.Bar | SeriesProperties.PrimaryAxisVerticalOrientation |
                   SeriesProperties.Solid | SeriesProperties.PrefersXStrategyTooltips)
         {
-            DataPadding = new PointF(0, 1);
+            DataPadding = new LvcPoint(0, 1);
             _isRounded = typeof(IRoundedRectangleChartPoint<TDrawingContext>).IsAssignableFrom(typeof(TVisual));
         }
 
@@ -86,19 +85,19 @@ namespace LiveChartsCore
             if (Fill is not null)
             {
                 Fill.ZIndex = actualZIndex + 0.1;
-                Fill.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
+                Fill.SetClipRectangle(cartesianChart.Canvas, new LvcRectangle(drawLocation, drawMarginSize));
                 cartesianChart.Canvas.AddDrawableTask(Fill);
             }
             if (Stroke is not null)
             {
                 Stroke.ZIndex = actualZIndex + 0.2;
-                Stroke.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
+                Stroke.SetClipRectangle(cartesianChart.Canvas, new LvcRectangle(drawLocation, drawMarginSize));
                 cartesianChart.Canvas.AddDrawableTask(Stroke);
             }
             if (DataLabelsPaint is not null)
             {
                 DataLabelsPaint.ZIndex = actualZIndex + 0.3;
-                DataLabelsPaint.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
+                DataLabelsPaint.SetClipRectangle(cartesianChart.Canvas, new LvcRectangle(drawLocation, drawMarginSize));
                 cartesianChart.Canvas.AddDrawableTask(DataLabelsPaint);
             }
 

--- a/src/LiveChartsCore/Drawing/IGeometry.cs
+++ b/src/LiveChartsCore/Drawing/IGeometry.cs
@@ -20,8 +20,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Drawing;
-
 namespace LiveChartsCore.Drawing
 {
     /// <summary>
@@ -38,7 +36,7 @@ namespace LiveChartsCore.Drawing
         /// <value>
         /// The translate in coordinates.
         /// </value>
-        PointF TranslateTransform { get; set; }
+        LvcPoint TranslateTransform { get; set; }
 
         /// <summary>
         /// Gets or sets the rotation transform in degrees.
@@ -54,7 +52,7 @@ namespace LiveChartsCore.Drawing
         /// <value>
         /// The scale to use on the X and Y axis.
         /// </value>
-        PointF ScaleTransform { get; set; }
+        LvcPoint ScaleTransform { get; set; }
 
         /// <summary>
         /// Gets or sets the skew transform.
@@ -63,7 +61,7 @@ namespace LiveChartsCore.Drawing
         /// The skew factor to use in the X and Y axis, both axes go from 0 to 1, where 0 is nothing and 1
         /// the length of the shape in the specified axis.
         /// </value>
-        PointF SkewTransform { get; set; }
+        LvcPoint SkewTransform { get; set; }
 
         /// <summary>
         /// Gets or sets the x.
@@ -86,6 +84,6 @@ namespace LiveChartsCore.Drawing
         /// </summary>
         /// <param name="drawableTask">The drawable task.</param>
         /// <returns></returns>
-        SizeF Measure(IPaint<TDrawingContext> drawableTask);
+        LvcSize Measure(IPaint<TDrawingContext> drawableTask);
     }
 }

--- a/src/LiveChartsCore/Drawing/IPaint.cs
+++ b/src/LiveChartsCore/Drawing/IPaint.cs
@@ -22,7 +22,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 
 namespace LiveChartsCore.Drawing
 {
@@ -85,7 +84,7 @@ namespace LiveChartsCore.Drawing
         /// <param name="canvas">The canvas.</param>
         /// The clip rectangle.
         /// </returns>
-        RectangleF GetClipRectangle(MotionCanvas<TDrawingContext> canvas);
+        LvcRectangle GetClipRectangle(MotionCanvas<TDrawingContext> canvas);
 
         /// <summary>
         /// Gets or sets the clip rectangle.
@@ -94,7 +93,7 @@ namespace LiveChartsCore.Drawing
         /// <param name="value">
         /// The clip rectangle.
         /// </param>
-        void SetClipRectangle(MotionCanvas<TDrawingContext> canvas, RectangleF value);
+        void SetClipRectangle(MotionCanvas<TDrawingContext> canvas, LvcRectangle value);
 
         /// <summary>
         /// Initializes the task.

--- a/src/LiveChartsCore/Drawing/ISolidColorGeometry.cs
+++ b/src/LiveChartsCore/Drawing/ISolidColorGeometry.cs
@@ -20,8 +20,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Drawing;
-
 namespace LiveChartsCore.Drawing
 {
     /// <summary>
@@ -33,6 +31,6 @@ namespace LiveChartsCore.Drawing
         /// <summary>
         /// Gets or sets the color.
         /// </summary>
-        Color Color { get; set; }
+        LvcColor Color { get; set; }
     }
 }

--- a/src/LiveChartsCore/Drawing/LvcColor.cs
+++ b/src/LiveChartsCore/Drawing/LvcColor.cs
@@ -1,0 +1,147 @@
+﻿// The MIT License(MIT)
+//
+// Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace LiveChartsCore.Drawing
+{
+    /// <summary>
+    /// Defines a color.
+    /// </summary>
+    public struct LvcColor
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LvcColor"/> struct.
+        /// </summary>
+        /// <param name="red">The red component from 0 to 255.</param>
+        /// <param name="green">The green component from 0 to 255.</param>
+        /// <param name="blue">The blue component from 0 to 255.</param>
+        /// <param name="alpha">The alpha channel component from 0 to 255.</param>
+        public LvcColor(byte red, byte green, byte blue, byte alpha)
+        {
+            R = red;
+            G = green;
+            B = blue;
+            A = alpha;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LvcColor"/> struct.
+        /// </summary>
+        /// <param name="red">The red component from 0 to 255.</param>
+        /// <param name="green">The green component from 0 to 255.</param>
+        /// <param name="blue">The blue component from 0 to 255.</param>
+        public LvcColor(byte red, byte green, byte blue) : this(red, green, blue, 255) { }
+
+        /// <summary>
+        /// Gets or sets the red component.
+        /// </summary>
+        public byte R { get; set; }
+
+        /// <summary>
+        /// Gets or sets the green component.
+        /// </summary>
+        public byte G { get; set; }
+
+        /// <summary>
+        /// Gets or sets the blue component.
+        /// </summary>
+        public byte B { get; set; }
+
+        /// <summary>
+        /// Gets or sets the alpha component.
+        /// </summary>
+        public byte A { get; set; }
+
+        /// <inheritdoc cref="object.Equals(object?)"/>
+        public override bool Equals(object? obj)
+        {
+            return obj is LvcColor color &&
+                   R == color.R &&
+                   G == color.G &&
+                   B == color.B &&
+                   A == color.A;
+        }
+
+        /// <inheritdoc cref="object.GetHashCode()"/>
+        public override int GetHashCode()
+        {
+            var hashCode = 1960784236;
+            hashCode = hashCode * -1521134295 + R.GetHashCode();
+            hashCode = hashCode * -1521134295 + G.GetHashCode();
+            hashCode = hashCode * -1521134295 + B.GetHashCode();
+            hashCode = hashCode * -1521134295 + A.GetHashCode();
+            return hashCode;
+        }
+
+        /// <summary>
+        /// Compares two <see cref="LvcColor"/> instances.
+        /// </summary>
+        /// <param name="left"></param>
+        /// <param name="right"></param>
+        /// <returns></returns>
+        public static bool operator ==(LvcColor left, LvcColor right) => left.Equals(right);
+
+        /// <summary>
+        /// Compares two <see cref="LvcColor"/> instances.
+        /// </summary>
+        /// <param name="left"></param>
+        /// <param name="right"></param>
+        /// <returns></returns>
+        public static bool operator !=(LvcColor left, LvcColor right) => !(left == right);
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="LvcColor"/> class with the given components.
+        /// </summary>
+        /// <param name="red">The red component from 0 to 255.</param>
+        /// <param name="green">The green component from 0 to 255.</param>
+        /// <param name="blue">The blue component from 0 to 255.</param>
+        /// <returns></returns>
+        public static LvcColor FromRGB(byte red, byte green, byte blue)
+        {
+            return new LvcColor(red, green, blue);
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="LvcColor"/> class with the given components.
+        /// </summary>
+        /// <param name="alpha">The alpha channel component from 0 to 255.</param>
+        /// <param name="red">The red component from 0 to 255.</param>
+        /// <param name="green">The green component from 0 to 255.</param>
+        /// <param name="blue">The blue component from 0 to 255.</param>
+        /// <returns></returns>
+        public static LvcColor FromArgb(byte alpha, byte red, byte green, byte blue)
+        {
+            return new LvcColor(red, green, blue, alpha);
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="LvcColor"/> class with the given components.
+        /// </summary>
+        /// <param name="alpha">The alpha channel component from 0 to 255.</param>
+        /// <param name="color">The red color.</param>
+        /// <returns></returns>
+        public static LvcColor FromArgb(byte alpha, LvcColor color)
+        {
+            return new LvcColor(color.R, color.G, color.B, alpha);
+        }
+    }
+}
+

--- a/src/LiveChartsCore/Drawing/LvcPoint.cs
+++ b/src/LiveChartsCore/Drawing/LvcPoint.cs
@@ -1,0 +1,84 @@
+﻿// The MIT License(MIT)
+//
+// Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace LiveChartsCore.Drawing
+{
+    /// <summary>
+    /// Defines a point.
+    /// </summary>
+    public struct LvcPoint
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LvcPoint"/> struct.
+        /// </summary>
+        /// <param name="x">The x coordinate.</param>
+        /// <param name="y">The y coordinate.</param>
+        public LvcPoint(float x, float y)
+        {
+            X = x;
+            Y = y;
+        }
+
+        /// <summary>
+        /// Gets or sets the X coordinate.
+        /// </summary>
+        public float X { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Y coordinate.
+        /// </summary>
+        public float Y { get; set; }
+
+        /// <inheritdoc cref="object.Equals(object?)"/>
+        public override bool Equals(object? obj)
+        {
+            return obj is LvcPoint point &&
+                X == point.X &&
+                Y == point.Y;
+        }
+
+        /// <inheritdoc cref="object.GetHashCode()"/>
+        public override int GetHashCode()
+        {
+            var hashCode = 1861411795;
+            hashCode = hashCode * -1521134295 + X.GetHashCode();
+            hashCode = hashCode * -1521134295 + Y.GetHashCode();
+            return hashCode;
+        }
+
+        /// <summary>
+        /// Compares two <see cref="LvcPoint"/> instances.
+        /// </summary>
+        /// <param name="l"></param>
+        /// <param name="r"></param>
+        /// <returns></returns>
+        public static bool operator ==(LvcPoint l, LvcPoint r) => l.Equals(r);
+
+        /// <summary>
+        /// Compares two <see cref="LvcPoint"/> instances.
+        /// </summary>
+        /// <param name="l"></param>
+        /// <param name="r"></param>
+        /// <returns></returns>
+        public static bool operator !=(LvcPoint l, LvcPoint r) => !(l == r);
+    }
+}

--- a/src/LiveChartsCore/Drawing/LvcRectangle.cs
+++ b/src/LiveChartsCore/Drawing/LvcRectangle.cs
@@ -1,0 +1,123 @@
+﻿// The MIT License(MIT)
+//
+// Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace LiveChartsCore.Drawing
+{
+    /// <summary>
+    /// Defines  a rectangle.
+    /// </summary>
+    public struct LvcRectangle
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LvcRectangle"/> struct.
+        /// </summary>
+        /// <param name="location"></param>
+        /// <param name="size"></param>
+        public LvcRectangle(LvcPoint location, LvcSize size)
+        {
+            Location = location;
+            Size = size;
+            IsEmpty = false;
+        }
+
+        private LvcRectangle(bool empty)
+        {
+            Location = new LvcPoint();
+            Size = new LvcSize();
+            IsEmpty = empty;
+        }
+
+        /// <summary>
+        /// Gets an empty rectangle instance.
+        /// </summary>
+        public static LvcRectangle Empty = new(true);
+
+        /// <summary>
+        /// Gets or sets the location.
+        /// </summary>
+        public LvcPoint Location { get; set; }
+
+        /// <summary>
+        /// Gets the X location coordinate.
+        /// </summary>
+        public float X => Location.X;
+
+        /// <summary>
+        /// Gets the Y location coordinate.
+        /// </summary>
+        public float Y => Location.Y;
+
+        /// <summary>
+        /// Gets or sets the size.
+        /// </summary>
+        public LvcSize Size { get; set; }
+
+        /// <summary>
+        /// Gets the width.
+        /// </summary>
+        public float Width => Size.Width;
+
+        /// <summary>
+        /// Gets the height.
+        /// </summary>
+        public float Height => Size.Height;
+
+        /// <summary>
+        /// Gets or sets whether the instance is empty.
+        /// </summary>
+        private bool IsEmpty { get; set; }
+
+        /// <inheritdoc cref="object.Equals(object?)"/>
+        public override bool Equals(object? obj)
+        {
+            return obj is LvcRectangle rectangle
+                && ((IsEmpty && rectangle.IsEmpty) ||
+                    (Location == rectangle.Location && Size == rectangle.Size));
+        }
+
+        /// <inheritdoc cref="object.GetHashCode()"/>
+        public override int GetHashCode()
+        {
+            var hashCode = 574998336;
+            hashCode = hashCode * -1521134295 + Location.GetHashCode();
+            hashCode = hashCode * -1521134295 + Size.GetHashCode();
+            hashCode = hashCode * -1521134295 + IsEmpty.GetHashCode();
+            return hashCode;
+        }
+
+        /// <summary>
+        /// Compares 2 <see cref="LvcRectangle"/> instances.
+        /// </summary>
+        /// <param name="left"></param>
+        /// <param name="right"></param>
+        /// <returns></returns>
+        public static bool operator ==(LvcRectangle left, LvcRectangle right) => left.Equals(right);
+
+        /// <summary>
+        /// Compares 2 <see cref="LvcRectangle"/> instances.
+        /// </summary>
+        /// <param name="left"></param>
+        /// <param name="right"></param>
+        /// <returns></returns>
+        public static bool operator !=(LvcRectangle left, LvcRectangle right) => !(left == right);
+    }
+}

--- a/src/LiveChartsCore/Drawing/LvcSize.cs
+++ b/src/LiveChartsCore/Drawing/LvcSize.cs
@@ -1,0 +1,84 @@
+﻿// The MIT License(MIT)
+//
+// Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace LiveChartsCore.Drawing
+{
+    /// <summary>
+    /// Defines a size.
+    /// </summary>
+    public struct LvcSize
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LvcSize"/> struct.
+        /// </summary>
+        /// <param name="width">The width.</param>
+        /// <param name="height">The height.</param>
+        public LvcSize(float width, float height)
+        {
+            Width = width;
+            Height = height;
+        }
+
+        /// <summary>
+        /// Gets or sets the width.
+        /// </summary>
+        public float Width { get; set; }
+
+        /// <summary>
+        /// Gets or sets the height.
+        /// </summary>
+        public float Height { get; set; }
+
+        /// <inheritdoc cref="object.Equals(object?)"/>
+        public override bool Equals(object? obj)
+        {
+            return obj is LvcSize size &&
+                Width == size.Width &&
+                Height == size.Height;
+        }
+
+        /// <inheritdoc cref="object.GetHashCode()"/>
+        public override int GetHashCode()
+        {
+            var hashCode = 859600377;
+            hashCode = hashCode * -1521134295 + Width.GetHashCode();
+            hashCode = hashCode * -1521134295 + Height.GetHashCode();
+            return hashCode;
+        }
+
+        /// <summary>
+        /// Compares two <see cref="LvcSize"/> instances.
+        /// </summary>
+        /// <param name="left"></param>
+        /// <param name="right"></param>
+        /// <returns></returns>
+        public static bool operator ==(LvcSize left, LvcSize right) => left.Equals(right);
+
+        /// <summary>
+        /// Compares two <see cref="LvcSize"/> instances.
+        /// </summary>
+        /// <param name="left"></param>
+        /// <param name="right"></param>
+        /// <returns></returns>
+        public static bool operator !=(LvcSize left, LvcSize right) => !(left == right);
+    }
+}

--- a/src/LiveChartsCore/FinancialSeries.cs
+++ b/src/LiveChartsCore/FinancialSeries.cs
@@ -22,7 +22,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using LiveChartsCore.Drawing;
 using LiveChartsCore.Kernel;
 using LiveChartsCore.Kernel.Data;
@@ -42,10 +41,11 @@ namespace LiveChartsCore
     /// <seealso cref="CartesianSeries{TModel, TVisual, TLabel, TDrawingContext}" />
     /// <seealso cref="ICartesianSeries{TDrawingContext}" />
     /// <seealso cref="IHeatSeries{TDrawingContext}" />
-    public abstract class FinancialSeries<TModel, TVisual, TLabel, TDrawingContext> : CartesianSeries<TModel, TVisual, TLabel, TDrawingContext>, IFinancialSeries<TDrawingContext>
-        where TVisual : class, IFinancialVisualChartPoint<TDrawingContext>, new()
-        where TDrawingContext : DrawingContext
-        where TLabel : class, ILabelGeometry<TDrawingContext>, new()
+    public abstract class FinancialSeries<TModel, TVisual, TLabel, TDrawingContext>
+        : CartesianSeries<TModel, TVisual, TLabel, TDrawingContext>, IFinancialSeries<TDrawingContext>
+            where TVisual : class, IFinancialVisualChartPoint<TDrawingContext>, new()
+            where TDrawingContext : DrawingContext
+            where TLabel : class, ILabelGeometry<TDrawingContext>, new()
     {
         private IPaint<TDrawingContext>? _upStroke = null;
         private IPaint<TDrawingContext>? _upFill = null;
@@ -127,31 +127,31 @@ namespace LiveChartsCore
             if (UpFill is not null)
             {
                 UpFill.ZIndex = actualZIndex + 0.1;
-                UpFill.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
+                UpFill.SetClipRectangle(cartesianChart.Canvas, new LvcRectangle(drawLocation, drawMarginSize));
                 cartesianChart.Canvas.AddDrawableTask(UpFill);
             }
             if (DownFill is not null)
             {
                 DownFill.ZIndex = actualZIndex + 0.1;
-                DownFill.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
+                DownFill.SetClipRectangle(cartesianChart.Canvas, new LvcRectangle(drawLocation, drawMarginSize));
                 cartesianChart.Canvas.AddDrawableTask(DownFill);
             }
             if (UpStroke is not null)
             {
                 UpStroke.ZIndex = actualZIndex + 0.2;
-                UpStroke.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
+                UpStroke.SetClipRectangle(cartesianChart.Canvas, new LvcRectangle(drawLocation, drawMarginSize));
                 cartesianChart.Canvas.AddDrawableTask(UpStroke);
             }
             if (DownStroke is not null)
             {
                 DownStroke.ZIndex = actualZIndex + 0.2;
-                DownStroke.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
+                DownStroke.SetClipRectangle(cartesianChart.Canvas, new LvcRectangle(drawLocation, drawMarginSize));
                 cartesianChart.Canvas.AddDrawableTask(DownStroke);
             }
             if (DataLabelsPaint is not null)
             {
                 DataLabelsPaint.ZIndex = actualZIndex + 0.3;
-                DataLabelsPaint.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
+                DataLabelsPaint.SetClipRectangle(cartesianChart.Canvas, new LvcRectangle(drawLocation, drawMarginSize));
                 cartesianChart.Canvas.AddDrawableTask(DataLabelsPaint);
             }
 

--- a/src/LiveChartsCore/Geo/IGeoMap.cs
+++ b/src/LiveChartsCore/Geo/IGeoMap.cs
@@ -21,7 +21,7 @@
 // SOFTWARE.
 
 using System.Collections.Generic;
-using System.Drawing;
+using LiveChartsCore.Drawing;
 
 namespace LiveChartsCore.Geo
 {
@@ -38,7 +38,7 @@ namespace LiveChartsCore.Geo
         /// <summary>
         /// Gets or sets the heat map.
         /// </summary>
-        Color[] HeatMap { get; set; }
+        LvcColor[] HeatMap { get; set; }
 
         /// <summary>
         /// Gets or sets the color stops.
@@ -48,7 +48,7 @@ namespace LiveChartsCore.Geo
         /// <summary>
         /// Gets or sets the color stops.
         /// </summary>
-        Color StrokeColor { get; set; }
+        LvcColor StrokeColor { get; set; }
 
         /// <summary>
         /// Gets or sets the color stops.
@@ -58,7 +58,7 @@ namespace LiveChartsCore.Geo
         /// <summary>
         /// Gets or sets the color stops.
         /// </summary>
-        Color FillColor { get; set; }
+        LvcColor FillColor { get; set; }
 
         /// <summary>
         /// Gets or sets the values.

--- a/src/LiveChartsCore/HeatFunctions.cs
+++ b/src/LiveChartsCore/HeatFunctions.cs
@@ -20,10 +20,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using LiveChartsCore.Drawing;
 using LiveChartsCore.Measure;
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 
 namespace LiveChartsCore
 {
@@ -43,7 +43,7 @@ namespace LiveChartsCore
         /// or
         /// At least 2 colors are required in a heat map.
         /// </exception>
-        public static List<Tuple<double, Color>> BuildColorStops(Color[] heatMap, double[]? colorStops)
+        public static List<Tuple<double, LvcColor>> BuildColorStops(LvcColor[] heatMap, double[]? colorStops)
         {
             if (heatMap.Length < 2) throw new Exception("At least 2 colors are required in a heat map.");
 
@@ -62,10 +62,10 @@ namespace LiveChartsCore
             if (colorStops.Length != heatMap.Length)
                 throw new Exception($"ColorStops and HeatMap must have the same length.");
 
-            var heatStops = new List<Tuple<double, Color>>();
+            var heatStops = new List<Tuple<double, LvcColor>>();
             for (var i = 0; i < colorStops.Length; i++)
             {
-                heatStops.Add(new Tuple<double, Color>(colorStops[i], heatMap[i]));
+                heatStops.Add(new Tuple<double, LvcColor>(colorStops[i], heatMap[i]));
             }
 
             return heatStops;
@@ -79,7 +79,7 @@ namespace LiveChartsCore
         /// <param name="heatMap">The heat map.</param>
         /// <param name="heatStops">The heat stops.</param>
         /// <returns></returns>
-        public static Color InterpolateColor(float weight, Bounds weightBounds, Color[] heatMap, List<Tuple<double, Color>> heatStops)
+        public static LvcColor InterpolateColor(float weight, Bounds weightBounds, LvcColor[] heatMap, List<Tuple<double, LvcColor>> heatStops)
         {
             var p = (weight - weightBounds.Min) / (weightBounds.Max - weightBounds.Min);
             if (p < 0) p = 0;
@@ -99,11 +99,11 @@ namespace LiveChartsCore
 
                 var px = (p - previous.Item1) / (next.Item1 - previous.Item1);
 
-                return Color.FromArgb(
-                    (int)(previous.Item2.A + px * (next.Item2.A - previous.Item2.A)),
-                    (int)(previous.Item2.R + px * (next.Item2.R - previous.Item2.R)),
-                    (int)(previous.Item2.G + px * (next.Item2.G - previous.Item2.G)),
-                    (int)(previous.Item2.B + px * (next.Item2.B - previous.Item2.B)));
+                return LvcColor.FromArgb(
+                    (byte)(previous.Item2.A + px * (next.Item2.A - previous.Item2.A)),
+                    (byte)(previous.Item2.R + px * (next.Item2.R - previous.Item2.R)),
+                    (byte)(previous.Item2.G + px * (next.Item2.G - previous.Item2.G)),
+                    (byte)(previous.Item2.B + px * (next.Item2.B - previous.Item2.B)));
             }
 
             return heatMap[heatMap.Length - 1];

--- a/src/LiveChartsCore/HeatSeries.cs
+++ b/src/LiveChartsCore/HeatSeries.cs
@@ -29,7 +29,6 @@ using LiveChartsCore.Kernel.Sketches;
 using LiveChartsCore.Measure;
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 
 namespace LiveChartsCore
 {
@@ -40,19 +39,20 @@ namespace LiveChartsCore
     /// <typeparam name="TVisual"></typeparam>
     /// <typeparam name="TLabel"></typeparam>
     /// <typeparam name="TDrawingContext"></typeparam>
-    public abstract class HeatSeries<TModel, TVisual, TLabel, TDrawingContext> : CartesianSeries<TModel, TVisual, TLabel, TDrawingContext>, IHeatSeries<TDrawingContext>
-        where TVisual : class, ISolidColorChartPoint<TDrawingContext>, new()
-        where TDrawingContext : DrawingContext
-        where TLabel : class, ILabelGeometry<TDrawingContext>, new()
+    public abstract class HeatSeries<TModel, TVisual, TLabel, TDrawingContext>
+        : CartesianSeries<TModel, TVisual, TLabel, TDrawingContext>, IHeatSeries<TDrawingContext>
+            where TVisual : class, ISolidColorChartPoint<TDrawingContext>, new()
+            where TDrawingContext : DrawingContext
+            where TLabel : class, ILabelGeometry<TDrawingContext>, new()
     {
         private IPaint<TDrawingContext>? _paintTaks;
         private Bounds _weightBounds = new();
         private int _heatKnownLength = 0;
-        private List<Tuple<double, Color>> _heatStops = new();
-        private Color[] _heatMap = new[]
+        private List<Tuple<double, LvcColor>> _heatStops = new();
+        private LvcColor[] _heatMap = new[]
         {
-            Color.FromArgb(255, 87, 103, 222), // cold (min value)
-            Color.FromArgb(255, 95, 207, 249) // hot (max value)
+            LvcColor.FromArgb(255, 87, 103, 222), // cold (min value)
+            LvcColor.FromArgb(255, 95, 207, 249) // hot (max value)
         };
         private double[]? _colorStops;
         private Padding _pointPadding = new(4);
@@ -66,12 +66,12 @@ namespace LiveChartsCore
                  SeriesProperties.Solid | SeriesProperties.PrefersXYStrategyTooltips)
         {
             HoverState = LiveCharts.HeatSeriesHoverState;
-            DataPadding = new PointF(0, 0);
+            DataPadding = new LvcPoint(0, 0);
             TooltipLabelFormatter = (point) => $"{Name}: {point.TertiaryValue:N}";
         }
 
         /// <inheritdoc cref="IHeatSeries{TDrawingContext}.HeatMap"/>
-        public Color[] HeatMap { get => _heatMap; set { _heatMap = value; OnPropertyChanged(); OnSeriesMiniatureChanged(); } }
+        public LvcColor[] HeatMap { get => _heatMap; set { _heatMap = value; OnPropertyChanged(); OnSeriesMiniatureChanged(); } }
 
         /// <inheritdoc cref="IHeatSeries{TDrawingContext}.ColorStops"/>
         public double[]? ColorStops { get => _colorStops; set { _colorStops = value; OnPropertyChanged(); } }
@@ -104,13 +104,13 @@ namespace LiveChartsCore
             if (_paintTaks is not null)
             {
                 _paintTaks.ZIndex = actualZIndex + 0.2;
-                _paintTaks.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
+                _paintTaks.SetClipRectangle(cartesianChart.Canvas, new LvcRectangle(drawLocation, drawMarginSize));
                 cartesianChart.Canvas.AddDrawableTask(_paintTaks);
             }
             if (DataLabelsPaint is not null)
             {
                 DataLabelsPaint.ZIndex = actualZIndex + 0.3;
-                DataLabelsPaint.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
+                DataLabelsPaint.SetClipRectangle(cartesianChart.Canvas, new LvcRectangle(drawLocation, drawMarginSize));
                 cartesianChart.Canvas.AddDrawableTask(DataLabelsPaint);
             }
 
@@ -143,7 +143,7 @@ namespace LiveChartsCore
                         visual.Width = uws;
                         visual.Height = uwp;
                         visual.RemoveOnCompleted = true;
-                        visual.Color = Color.FromArgb(0, visual.Color);
+                        visual.Color = LvcColor.FromArgb(0, visual.Color);
                         point.Context.Visual = null;
                     }
                     continue;
@@ -171,7 +171,7 @@ namespace LiveChartsCore
                         Y = yi + p.Top,
                         Width = uws - p.Left - p.Right,
                         Height = uwp - p.Top - p.Bottom,
-                        Color = Color.FromArgb(0, baseColor.R, baseColor.G, baseColor.B)
+                        Color = LvcColor.FromArgb(0, baseColor.R, baseColor.G, baseColor.B)
                     };
 
                     visual = r;
@@ -188,7 +188,7 @@ namespace LiveChartsCore
                 visual.Y = primary - uwp * 0.5f + p.Top;
                 visual.Width = uws - p.Left - p.Right;
                 visual.Height = uwp - p.Top - p.Bottom;
-                visual.Color = Color.FromArgb(baseColor.A, baseColor.R, baseColor.G, baseColor.B);
+                visual.Color = LvcColor.FromArgb(baseColor.A, baseColor.R, baseColor.G, baseColor.B);
                 visual.RemoveOnCompleted = false;
 
                 var ha = new RectangleHoverArea().SetDimensions(secondary - uws * 0.5f, primary - uwp * 0.5f, uws, uwp);
@@ -318,7 +318,7 @@ namespace LiveChartsCore
                         .WithEasingFunction(EasingFunction ?? chart.EasingFunction));
         }
 
-        /// <inheritdoc cref="Series{TModel, TVisual, TLabel, TDrawingContext}.SoftDeletePoint(ChartPoint, Scaler, Scaler)"/>
+        /// <inheritdoc cref="CartesianSeries{TModel, TVisual, TLabel, TDrawingContext}.SoftDeletePoint(ChartPoint, Scaler, Scaler)"/>
         protected override void SoftDeletePoint(ChartPoint point, Scaler primaryScale, Scaler secondaryScale)
         {
             var visual = (TVisual?)point.Context.Visual;
@@ -334,7 +334,7 @@ namespace LiveChartsCore
                 return;
             }
 
-            visual.Color = Color.FromArgb(255, visual.Color);
+            visual.Color = LvcColor.FromArgb(255, visual.Color);
             visual.RemoveOnCompleted = true;
 
             var label = (TLabel?)point.Context.Label;

--- a/src/LiveChartsCore/ISeries.cs
+++ b/src/LiveChartsCore/ISeries.cs
@@ -20,13 +20,13 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using LiveChartsCore.Drawing;
 using LiveChartsCore.Kernel;
 using LiveChartsCore.Kernel.Sketches;
 using LiveChartsCore.Measure;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Drawing;
 
 namespace LiveChartsCore
 {
@@ -79,7 +79,7 @@ namespace LiveChartsCore
         /// <value>
         /// The data padding.
         /// </value>
-        PointF DataPadding { get; set; }
+        LvcPoint DataPadding { get; set; }
 
         /// <summary>
         /// Gets or sets the z index position.
@@ -155,7 +155,7 @@ namespace LiveChartsCore
         /// <param name="pointerPosition">the pointer position</param>
         /// <param name="automaticStategy">the already resolved strategy when strategy is set to automatic.</param>
         /// <returns></returns>
-        TooltipPoint[] FindPointsNearTo(IChart chart, PointF pointerPosition, TooltipFindingStrategy automaticStategy);
+        TooltipPoint[] FindPointsNearTo(IChart chart, LvcPoint pointerPosition, TooltipFindingStrategy automaticStategy);
 
         /// <summary>
         /// Marks a given point as a given state.
@@ -169,7 +169,7 @@ namespace LiveChartsCore
         /// </summary>
         /// <param name="chartPoint"></param>
         /// <param name="state"></param>
-        void RemovePointFromState(ChartPoint chartPoint, string state);
+        void RemoveLvPointromState(ChartPoint chartPoint, string state);
 
         /// <summary>
         /// Clears the visuals in the cache and re-starts animations.

--- a/src/LiveChartsCore/Kernel/Drawing/DefaultPaintTask.cs
+++ b/src/LiveChartsCore/Kernel/Drawing/DefaultPaintTask.cs
@@ -24,7 +24,6 @@ using LiveChartsCore.Drawing;
 using LiveChartsCore.Motion;
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
 
 namespace LiveChartsCore.Kernel.Drawing
@@ -239,13 +238,13 @@ namespace LiveChartsCore.Kernel.Drawing
         }
 
         /// <inheritdoc cref="IPaint{TDrawingContext}.GetClipRectangle(MotionCanvas{TDrawingContext})" />
-        public RectangleF GetClipRectangle(MotionCanvas<TDrawingContext> canvas)
+        public LvcRectangle GetClipRectangle(MotionCanvas<TDrawingContext> canvas)
         {
-            return RectangleF.Empty;
+            return LvcRectangle.Empty;
         }
 
-        /// <inheritdoc cref="IPaint{TDrawingContext}.SetClipRectangle(MotionCanvas{TDrawingContext}, RectangleF)" />
-        public void SetClipRectangle(MotionCanvas<TDrawingContext> canvas, RectangleF value)
+        /// <inheritdoc cref="IPaint{TDrawingContext}.SetClipRectangle(MotionCanvas{TDrawingContext}, LvcRectangle)" />
+        public void SetClipRectangle(MotionCanvas<TDrawingContext> canvas, LvcRectangle value)
         {
         }
     }

--- a/src/LiveChartsCore/Kernel/Drawing/HoverArea.cs
+++ b/src/LiveChartsCore/Kernel/Drawing/HoverArea.cs
@@ -20,8 +20,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using LiveChartsCore.Drawing;
 using LiveChartsCore.Measure;
-using System.Drawing;
 
 namespace LiveChartsCore.Kernel.Drawing
 {
@@ -38,7 +38,7 @@ namespace LiveChartsCore.Kernel.Drawing
         /// <returns>
         ///   <c>true</c> if [is trigger by] [the specified point]; otherwise, <c>false</c>.
         /// </returns>
-        public abstract float GetDistanceToPoint(PointF point, TooltipFindingStrategy strategy);
+        public abstract float GetDistanceToPoint(LvcPoint point, TooltipFindingStrategy strategy);
 
         /// <summary>
         /// Suggests the tooltip placement.

--- a/src/LiveChartsCore/Kernel/Drawing/RectangleHoverArea.cs
+++ b/src/LiveChartsCore/Kernel/Drawing/RectangleHoverArea.cs
@@ -20,9 +20,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using LiveChartsCore.Drawing;
 using LiveChartsCore.Measure;
 using System;
-using System.Drawing;
 
 namespace LiveChartsCore.Kernel.Drawing
 {
@@ -82,8 +82,8 @@ namespace LiveChartsCore.Kernel.Drawing
             return this;
         }
 
-        /// <inheritdoc cref="GetDistanceToPoint(PointF, TooltipFindingStrategy)"/>
-        public override float GetDistanceToPoint(PointF point, TooltipFindingStrategy strategy)
+        /// <inheritdoc cref="GetDistanceToPoint(LvcPoint, TooltipFindingStrategy)"/>
+        public override float GetDistanceToPoint(LvcPoint point, TooltipFindingStrategy strategy)
         {
             var dx = point.X - (X + Width * 0.5f);
             var dy = point.Y - (Y + Height * 0.5f);

--- a/src/LiveChartsCore/Kernel/Drawing/SemicircleHoverArea.cs
+++ b/src/LiveChartsCore/Kernel/Drawing/SemicircleHoverArea.cs
@@ -20,9 +20,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using LiveChartsCore.Drawing;
 using LiveChartsCore.Measure;
 using System;
-using System.Drawing;
 
 namespace LiveChartsCore.Kernel.Drawing
 {
@@ -85,8 +85,8 @@ namespace LiveChartsCore.Kernel.Drawing
             return this;
         }
 
-        /// <inheritdoc cref="GetDistanceToPoint(PointF, TooltipFindingStrategy)"/>
-        public override float GetDistanceToPoint(PointF point, TooltipFindingStrategy strategy)
+        /// <inheritdoc cref="GetDistanceToPoint(LvcPoint, TooltipFindingStrategy)"/>
+        public override float GetDistanceToPoint(LvcPoint point, TooltipFindingStrategy strategy)
         {
             var startAngle = StartAngle % 360;
             // -0.01 is a work around to avoid the case where the last slice (360) would be converted to 0 also
@@ -96,7 +96,7 @@ namespace LiveChartsCore.Kernel.Drawing
             var dy = CenterY - point.Y;
             var beta = Math.Atan(dy / dx) * (180 / Math.PI);
 
-            if (dx > 0 && dy < 0 || dx > 0 && dy > 0) beta += 180;
+            if ((dx > 0 && dy < 0) || (dx > 0 && dy > 0)) beta += 180;
             if (dx < 0 && dy > 0) beta += 360;
 
             var r = Math.Sqrt(Math.Pow(dx, 2) + Math.Pow(dy, 2));

--- a/src/LiveChartsCore/Kernel/Events/PanGestureEventArgs.cs
+++ b/src/LiveChartsCore/Kernel/Events/PanGestureEventArgs.cs
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Drawing;
+using LiveChartsCore.Drawing;
 
 namespace LiveChartsCore.Kernel.Events
 {
@@ -32,7 +32,7 @@ namespace LiveChartsCore.Kernel.Events
         /// <summary>
         /// Initializes a new instance of the <see cref="PanGestureEventArgs"/> class.
         /// </summary>
-        public PanGestureEventArgs(PointF delta)
+        public PanGestureEventArgs(LvcPoint delta)
         {
             Delta = delta;
             Handled = false;
@@ -44,7 +44,7 @@ namespace LiveChartsCore.Kernel.Events
         /// <value>
         /// The delta.
         /// </value>
-        public PointF Delta { get; set; }
+        public LvcPoint Delta { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether this <see cref="PanGestureEventArgs"/> is handled.

--- a/src/LiveChartsCore/Kernel/Extensions.cs
+++ b/src/LiveChartsCore/Kernel/Extensions.cs
@@ -26,7 +26,6 @@ using LiveChartsCore.Kernel.Sketches;
 using LiveChartsCore.Measure;
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 
 namespace LiveChartsCore.Kernel
 {
@@ -45,8 +44,8 @@ namespace LiveChartsCore.Kernel
         /// <param name="tooltipSize"></param>
         /// <param name="chartSize"></param>
         /// <returns></returns>
-        public static PointF? GetCartesianTooltipLocation(
-            this IEnumerable<TooltipPoint> foundPoints, TooltipPosition position, SizeF tooltipSize, SizeF chartSize)
+        public static LvcPoint? GetCartesianTooltipLocation(
+            this IEnumerable<TooltipPoint> foundPoints, TooltipPosition position, LvcSize tooltipSize, LvcSize chartSize)
         {
             var count = 0f;
 
@@ -70,13 +69,13 @@ namespace LiveChartsCore.Kernel
 
             return position switch
             {
-                TooltipPosition.Top => new PointF(avrgX, placementContext.MostTop - tooltipSize.Height),
-                TooltipPosition.Bottom => new PointF(avrgX, placementContext.MostBottom),
-                TooltipPosition.Left => new PointF(placementContext.MostLeft - tooltipSize.Width, avrgY),
-                TooltipPosition.Right => new PointF(placementContext.MostRight, avrgY),
-                TooltipPosition.Center => new PointF(avrgX, avrgY),
-                TooltipPosition.Hidden => new PointF(),
-                _ => new PointF(),
+                TooltipPosition.Top => new LvcPoint(avrgX, placementContext.MostTop - tooltipSize.Height),
+                TooltipPosition.Bottom => new LvcPoint(avrgX, placementContext.MostBottom),
+                TooltipPosition.Left => new LvcPoint(placementContext.MostLeft - tooltipSize.Width, avrgY),
+                TooltipPosition.Right => new LvcPoint(placementContext.MostRight, avrgY),
+                TooltipPosition.Center => new LvcPoint(avrgX, avrgY),
+                TooltipPosition.Hidden => new LvcPoint(),
+                _ => new LvcPoint(),
             };
         }
 
@@ -87,8 +86,8 @@ namespace LiveChartsCore.Kernel
         /// <param name="position">The position.</param>
         /// <param name="tooltipSize">Size of the tooltip.</param>
         /// <returns></returns>
-        public static PointF? GetPieTooltipLocation(
-            this IEnumerable<TooltipPoint> foundPoints, TooltipPosition position, SizeF tooltipSize)
+        public static LvcPoint? GetPieTooltipLocation(
+            this IEnumerable<TooltipPoint> foundPoints, TooltipPosition position, LvcSize tooltipSize)
         {
             var placementContext = new TooltipPlacementContext();
             var found = false;
@@ -101,7 +100,7 @@ namespace LiveChartsCore.Kernel
                 break; // we only care about the first one.
             }
 
-            return found ? new PointF(placementContext.PieX, placementContext.PieY) : null;
+            return found ? new LvcPoint(placementContext.PieX, placementContext.PieY) : null;
         }
 
         /// <summary>
@@ -110,7 +109,7 @@ namespace LiveChartsCore.Kernel
         /// <param name="axis">The axis.</param>
         /// <param name="controlSize">Size of the control.</param>
         /// <returns></returns>
-        public static AxisTick GetTick(this ICartesianAxis axis, SizeF controlSize)
+        public static AxisTick GetTick(this ICartesianAxis axis, LvcSize controlSize)
         {
             return GetTick(axis, controlSize, axis.VisibleDataBounds);
         }
@@ -121,7 +120,7 @@ namespace LiveChartsCore.Kernel
         /// <param name="axis">The axis.</param>
         /// <param name="controlSize">Size of the control.</param>
         /// <returns></returns>
-        public static AxisTick GetTick(this IPolarAxis axis, SizeF controlSize)
+        public static AxisTick GetTick(this IPolarAxis axis, LvcSize controlSize)
         {
             return GetTick(axis, controlSize, axis.VisibleDataBounds);
         }
@@ -133,7 +132,7 @@ namespace LiveChartsCore.Kernel
         /// <param name="controlSize">Size of the control.</param>
         /// <param name="bounds">The bounds.</param>
         /// <returns></returns>
-        public static AxisTick GetTick(this ICartesianAxis axis, SizeF controlSize, Bounds bounds)
+        public static AxisTick GetTick(this ICartesianAxis axis, LvcSize controlSize, Bounds bounds)
         {
             var max = axis.MaxLimit is null ? bounds.Max : axis.MaxLimit.Value;
             var min = axis.MinLimit is null ? bounds.Min : axis.MinLimit.Value;
@@ -158,7 +157,7 @@ namespace LiveChartsCore.Kernel
         /// <param name="controlSize">Size of the control.</param>
         /// <param name="bounds">The bounds.</param>
         /// <returns></returns> 
-        public static AxisTick GetTick(this IPolarAxis axis, SizeF controlSize, Bounds bounds)
+        public static AxisTick GetTick(this IPolarAxis axis, LvcSize controlSize, Bounds bounds)
         {
             var max = axis.MaxLimit is null ? bounds.Max : axis.MaxLimit.Value;
             var min = axis.MinLimit is null ? bounds.Min : axis.MinLimit.Value;
@@ -289,7 +288,7 @@ namespace LiveChartsCore.Kernel
         /// <param name="state">The state.</param>
         public static void RemoveFromState(this ChartPoint chartPoint, string state)
         {
-            chartPoint.Context.Series.RemovePointFromState(chartPoint, state);
+            chartPoint.Context.Series.RemoveLvPointromState(chartPoint, state);
         }
 
         /// <summary>
@@ -307,7 +306,7 @@ namespace LiveChartsCore.Kernel
         /// <param name="chartPoint">The chart point.</param>
         public static void RemoveFromHoverState(this ChartPoint chartPoint)
         {
-            chartPoint.Context.Series.RemovePointFromState(chartPoint, chartPoint.Context.Series.HoverState);
+            chartPoint.Context.Series.RemoveLvPointromState(chartPoint, chartPoint.Context.Series.HoverState);
         }
     }
 }

--- a/src/LiveChartsCore/Kernel/Sketches/ICartesianChartView.cs
+++ b/src/LiveChartsCore/Kernel/Sketches/ICartesianChartView.cs
@@ -23,7 +23,6 @@
 using LiveChartsCore.Drawing;
 using LiveChartsCore.Measure;
 using System.Collections.Generic;
-using System.Drawing;
 
 namespace LiveChartsCore.Kernel.Sketches
 {
@@ -115,6 +114,6 @@ namespace LiveChartsCore.Kernel.Sketches
         /// <param name="xAxisIndex">Index of the x axis.</param>
         /// <param name="yAxisIndex">Index of the y axis.</param>
         /// <returns></returns>
-        double[] ScaleUIPoint(PointF point, int xAxisIndex = 0, int yAxisIndex = 0);
+        double[] ScaleUIPoint(LvcPoint point, int xAxisIndex = 0, int yAxisIndex = 0);
     }
 }

--- a/src/LiveChartsCore/Kernel/Sketches/IChartSeries.cs
+++ b/src/LiveChartsCore/Kernel/Sketches/IChartSeries.cs
@@ -23,7 +23,6 @@
 using LiveChartsCore.Drawing;
 using LiveChartsCore.Drawing.Common;
 using LiveChartsCore.Kernel.Drawing;
-using System;
 
 namespace LiveChartsCore.Kernel.Sketches
 {
@@ -35,12 +34,6 @@ namespace LiveChartsCore.Kernel.Sketches
     public interface IChartSeries<TDrawingContext> : ISeries, IChartElement<TDrawingContext>
          where TDrawingContext : DrawingContext
     {
-        /// <summary>
-        /// Gets or sets the data labels  drawable task.
-        /// </summary>
-        [Obsolete("Renamed to DataLabelsPaint")]
-        IPaint<TDrawingContext>? DataLabelsDrawableTask { get; set; }
-
         /// <summary>
         /// Gets or sets the data labels paint.
         /// </summary>

--- a/src/LiveChartsCore/Kernel/Sketches/IChartView.cs
+++ b/src/LiveChartsCore/Kernel/Sketches/IChartView.cs
@@ -25,7 +25,6 @@ using LiveChartsCore.Kernel.Events;
 using LiveChartsCore.Measure;
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 
 namespace LiveChartsCore.Kernel.Sketches
 {
@@ -53,7 +52,7 @@ namespace LiveChartsCore.Kernel.Sketches
         /// <value>
         /// The color of the back.
         /// </value>
-        Color BackColor { get; set; }
+        LvcColor BackColor { get; set; }
 
         /// <summary>
         /// Gets the size of the control.
@@ -61,7 +60,7 @@ namespace LiveChartsCore.Kernel.Sketches
         /// <value>
         /// The size of the control.
         /// </value>
-        SizeF ControlSize { get; }
+        LvcSize ControlSize { get; }
 
         /// <summary>
         /// Gets or sets the draw margin, if this property is null, the library will calculate a margin, this margin is the distance 
@@ -132,7 +131,7 @@ namespace LiveChartsCore.Kernel.Sketches
         /// </summary>
         /// <param name="background">The background.</param>
         /// <param name="textColor">Color of the text.</param>
-        void SetTooltipStyle(Color background, Color textColor);
+        void SetTooltipStyle(LvcColor background, LvcColor textColor);
 
         /// <summary>
         /// Invokes an action in the UI thread.

--- a/src/LiveChartsCore/Kernel/Sketches/IHeatSeries.cs
+++ b/src/LiveChartsCore/Kernel/Sketches/IHeatSeries.cs
@@ -20,7 +20,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Drawing;
 using LiveChartsCore.Drawing;
 using LiveChartsCore.Drawing.Common;
 
@@ -40,7 +39,7 @@ namespace LiveChartsCore.Kernel.Sketches
         /// <value>
         /// The heat map.
         /// </value>
-        Color[] HeatMap { get; set; }
+        LvcColor[] HeatMap { get; set; }
 
         /// <summary>
         /// Gets or sets the color stops.

--- a/src/LiveChartsCore/Kernel/Sketches/IPlane.cs
+++ b/src/LiveChartsCore/Kernel/Sketches/IPlane.cs
@@ -25,7 +25,6 @@ using LiveChartsCore.Measure;
 using System.Collections.Generic;
 using LiveChartsCore.Drawing.Common;
 using LiveChartsCore.Drawing;
-using System.Drawing;
 
 namespace LiveChartsCore.Kernel.Sketches
 {
@@ -266,13 +265,13 @@ namespace LiveChartsCore.Kernel.Sketches
         /// </summary>
         /// <param name="chart">The chart.</param>
         /// <returns></returns>
-        SizeF GetPossibleSize(Chart<TDrawingContext> chart);
+        LvcSize GetPossibleSize(Chart<TDrawingContext> chart);
 
         /// <summary>
         /// Gets the size of the axis name label.
         /// </summary>
         /// <param name="chart">the chart.</param>
         /// <returns></returns>
-        SizeF GetNameLabelSize(Chart<TDrawingContext> chart);
+        LvcSize GetNameLabelSize(Chart<TDrawingContext> chart);
     }
 }

--- a/src/LiveChartsCore/Kernel/Sketches/IPolarChartView.cs
+++ b/src/LiveChartsCore/Kernel/Sketches/IPolarChartView.cs
@@ -22,7 +22,6 @@
 
 using LiveChartsCore.Drawing;
 using System.Collections.Generic;
-using System.Drawing;
 
 namespace LiveChartsCore.Kernel.Sketches
 {
@@ -97,6 +96,6 @@ namespace LiveChartsCore.Kernel.Sketches
         /// <param name="angleAxisIndex">Index of the angle axis.</param>
         /// <param name="radiusAxisIndex">Index of the radius axis.</param>
         /// <returns></returns>
-        double[] ScaleUIPoint(PointF point, int angleAxisIndex = 0, int radiusAxisIndex = 0);
+        double[] ScaleUIPoint(LvcPoint point, int angleAxisIndex = 0, int radiusAxisIndex = 0);
     }
 }

--- a/src/LiveChartsCore/Kernel/Stacker.cs
+++ b/src/LiveChartsCore/Kernel/Stacker.cs
@@ -22,7 +22,6 @@
 
 using LiveChartsCore.Drawing;
 using LiveChartsCore.Kernel.Sketches;
-using System;
 using System.Collections.Generic;
 
 namespace LiveChartsCore.Kernel

--- a/src/LiveChartsCore/LineSeries.cs
+++ b/src/LiveChartsCore/LineSeries.cs
@@ -26,7 +26,6 @@ using LiveChartsCore.Measure;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Drawing;
 using LiveChartsCore.Kernel.Drawing;
 using LiveChartsCore.Kernel.Sketches;
 using LiveChartsCore.Kernel.Data;
@@ -38,13 +37,13 @@ namespace LiveChartsCore
     /// </summary>
     public class LineSeries<TModel, TVisual, TLabel, TDrawingContext, TPathGeometry, TLineSegment, TBezierSegment, TMoveToCommand, TPathArgs>
         : StrokeAndFillCartesianSeries<TModel, LineBezierVisualPoint<TDrawingContext, TVisual, TBezierSegment, TPathArgs>, TLabel, TDrawingContext>, ILineSeries<TDrawingContext>
-        where TPathGeometry : IPathGeometry<TDrawingContext, TPathArgs>, new()
-        where TLineSegment : ILinePathSegment<TPathArgs>, new()
-        where TBezierSegment : IBezierSegment<TPathArgs>, new()
-        where TMoveToCommand : IMoveToPathCommand<TPathArgs>, new()
-        where TVisual : class, ISizedVisualChartPoint<TDrawingContext>, new()
-        where TLabel : class, ILabelGeometry<TDrawingContext>, new()
-        where TDrawingContext : DrawingContext
+            where TPathGeometry : IPathGeometry<TDrawingContext, TPathArgs>, new()
+            where TLineSegment : ILinePathSegment<TPathArgs>, new()
+            where TBezierSegment : IBezierSegment<TPathArgs>, new()
+            where TMoveToCommand : IMoveToPathCommand<TPathArgs>, new()
+            where TVisual : class, ISizedVisualChartPoint<TDrawingContext>, new()
+            where TLabel : class, ILabelGeometry<TDrawingContext>, new()
+            where TDrawingContext : DrawingContext
     {
         private readonly Dictionary<object, List<AreaHelper<TDrawingContext, TPathGeometry, TLineSegment, TMoveToCommand, TPathArgs>>> _fillPathHelperDictionary = new();
         private readonly Dictionary<object, List<AreaHelper<TDrawingContext, TPathGeometry, TLineSegment, TMoveToCommand, TPathArgs>>> _strokePathHelperDictionary = new();
@@ -63,7 +62,7 @@ namespace LiveChartsCore
                   SeriesProperties.Line | SeriesProperties.PrimaryAxisVerticalOrientation |
                   (isStacked ? SeriesProperties.Stacked : 0) | SeriesProperties.Sketch | SeriesProperties.PrefersXStrategyTooltips)
         {
-            DataPadding = new PointF(0.5f, 1f);
+            DataPadding = new LvcPoint(0.5f, 1f);
             HoverState = LiveCharts.LineSeriesHoverKey;
         }
 
@@ -194,7 +193,7 @@ namespace LiveChartsCore
                     Fill.AddGeometryToPaintTask(cartesianChart.Canvas, fillPathHelper.Path);
                     cartesianChart.Canvas.AddDrawableTask(Fill);
                     Fill.ZIndex = actualZIndex + 0.1;
-                    Fill.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
+                    Fill.SetClipRectangle(cartesianChart.Canvas, new LvcRectangle(drawLocation, drawMarginSize));
                 }
                 if (Stroke is not null)
                 {
@@ -202,7 +201,7 @@ namespace LiveChartsCore
                     Stroke.AddGeometryToPaintTask(cartesianChart.Canvas, strokePathHelper.Path);
                     cartesianChart.Canvas.AddDrawableTask(Stroke);
                     Stroke.ZIndex = actualZIndex + 0.2;
-                    Stroke.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
+                    Stroke.SetClipRectangle(cartesianChart.Canvas, new LvcRectangle(drawLocation, drawMarginSize));
                 }
 
                 foreach (var data in GetSpline(segment, secondaryScale, primaryScale, stacker))
@@ -410,13 +409,13 @@ namespace LiveChartsCore
                 if (GeometryFill is not null)
                 {
                     cartesianChart.Canvas.AddDrawableTask(GeometryFill);
-                    GeometryFill.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
+                    GeometryFill.SetClipRectangle(cartesianChart.Canvas, new LvcRectangle(drawLocation, drawMarginSize));
                     GeometryFill.ZIndex = actualZIndex + 0.3;
                 }
                 if (GeometryStroke is not null)
                 {
                     cartesianChart.Canvas.AddDrawableTask(GeometryStroke);
-                    GeometryStroke.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
+                    GeometryStroke.SetClipRectangle(cartesianChart.Canvas, new LvcRectangle(drawLocation, drawMarginSize));
                     GeometryStroke.ZIndex = actualZIndex + 0.4;
                 }
                 segmentI++;
@@ -438,7 +437,7 @@ namespace LiveChartsCore
             if (DataLabelsPaint is not null)
             {
                 cartesianChart.Canvas.AddDrawableTask(DataLabelsPaint);
-                DataLabelsPaint.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
+                DataLabelsPaint.SetClipRectangle(cartesianChart.Canvas, new LvcRectangle(drawLocation, drawMarginSize));
                 DataLabelsPaint.ZIndex = actualZIndex + 0.5;
             }
 

--- a/src/LiveChartsCore/Measure/PolarScaler.cs
+++ b/src/LiveChartsCore/Measure/PolarScaler.cs
@@ -21,7 +21,7 @@
 // SOFTWARE.
 
 using System;
-using System.Drawing;
+using LiveChartsCore.Drawing;
 using LiveChartsCore.Kernel;
 using LiveChartsCore.Kernel.Sketches;
 
@@ -47,8 +47,8 @@ namespace LiveChartsCore.Measure
         /// <param name="usePreviousScale">Indicates if the scaler should be built based on the previous known data.</param>
         /// <exception cref="Exception">The axis is not ready to be scaled.</exception>
         public PolarScaler(
-            PointF drawMagrinLocation,
-            SizeF drawMarginSize,
+            LvcPoint drawMagrinLocation,
+            LvcSize drawMarginSize,
             IPolarAxis angleAxis,
             IPolarAxis radiusAxis,
             float innerRadius,
@@ -114,7 +114,7 @@ namespace LiveChartsCore.Measure
         /// </summary>
         /// <param name="polarPoint">The polar point.</param>
         /// <returns></returns>
-        public PointF ToPixels(ChartPoint polarPoint)
+        public LvcPoint ToPixels(ChartPoint polarPoint)
         {
             return ToPixels(polarPoint.SecondaryValue, polarPoint.PrimaryValue);
         }
@@ -125,7 +125,7 @@ namespace LiveChartsCore.Measure
         /// <param name="angle">The angle in chart values scale.</param>
         /// <param name="radius">The radius.</param>
         /// <returns></returns>
-        public PointF ToPixels(double angle, double radius)
+        public LvcPoint ToPixels(double angle, double radius)
         {
             var p = (radius - MinRadius) / _deltaRadius;
             var r = _innerRadius + _scalableRadius * p;
@@ -134,7 +134,7 @@ namespace LiveChartsCore.Measure
 
             unchecked
             {
-                return new PointF(
+                return new LvcPoint(
                     CenterX + (float)(Math.Cos(a) * r),
                     CenterY + (float)(Math.Sin(a) * r));
             }

--- a/src/LiveChartsCore/Measure/Scaler.cs
+++ b/src/LiveChartsCore/Measure/Scaler.cs
@@ -21,7 +21,7 @@
 // SOFTWARE.
 
 using System;
-using System.Drawing;
+using LiveChartsCore.Drawing;
 using LiveChartsCore.Kernel.Sketches;
 
 namespace LiveChartsCore.Measure
@@ -44,7 +44,7 @@ namespace LiveChartsCore.Measure
         /// <param name="bounds">Indicates the bounds to use.</param>
         /// <exception cref="Exception">The axis is not ready to be scaled.</exception>
         public Scaler(
-            PointF drawMagrinLocation, SizeF drawMarginSize, ICartesianAxis axis, bool usePreviousScale = false, Bounds? bounds = null)
+            LvcPoint drawMagrinLocation, LvcSize drawMarginSize, ICartesianAxis axis, bool usePreviousScale = false, Bounds? bounds = null)
         {
             if (axis.Orientation == AxisOrientation.Unknown) throw new Exception("The axis is not ready to be scaled.");
 

--- a/src/LiveChartsCore/Motion/ColorMotionProperty.cs
+++ b/src/LiveChartsCore/Motion/ColorMotionProperty.cs
@@ -20,14 +20,14 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Drawing;
+using LiveChartsCore.Drawing;
 
 namespace LiveChartsCore.Motion
 {
     /// <summary>
     /// Defines the color motion property class.
     /// </summary>
-    public class ColorMotionProperty : MotionProperty<Color>
+    public class ColorMotionProperty : MotionProperty<LvcColor>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ColorMotionProperty"/> class.
@@ -36,8 +36,8 @@ namespace LiveChartsCore.Motion
         public ColorMotionProperty(string propertyName)
             : base(propertyName)
         {
-            fromValue = Color.FromArgb(0, 0, 0, 0);
-            toValue = Color.FromArgb(0, 0, 0, 0);
+            fromValue = LvcColor.FromArgb(0, 0, 0, 0);
+            toValue = LvcColor.FromArgb(0, 0, 0, 0);
         }
 
         /// <summary>
@@ -45,7 +45,7 @@ namespace LiveChartsCore.Motion
         /// </summary>
         /// <param name="propertyName">Name of the property.</param>
         /// <param name="value">The value.</param>
-        public ColorMotionProperty(string propertyName, Color value)
+        public ColorMotionProperty(string propertyName, LvcColor value)
             : base(propertyName)
         {
             fromValue = value;
@@ -53,13 +53,13 @@ namespace LiveChartsCore.Motion
         }
 
         /// <inheritdoc cref="MotionProperty{T}.OnGetMovement(float)" />
-        protected override Color OnGetMovement(float progress)
+        protected override LvcColor OnGetMovement(float progress)
         {
-            return Color.FromArgb(
-                (int)(fromValue.A + progress * (toValue.A - fromValue.A)),
-                (int)(fromValue.R + progress * (toValue.R - fromValue.R)),
-                (int)(fromValue.G + progress * (toValue.G - fromValue.G)),
-                (int)(fromValue.B + progress * (toValue.B - fromValue.B)));
+            return LvcColor.FromArgb(
+                (byte)(fromValue.A + progress * (toValue.A - fromValue.A)),
+                (byte)(fromValue.R + progress * (toValue.R - fromValue.R)),
+                (byte)(fromValue.G + progress * (toValue.G - fromValue.G)),
+                (byte)(fromValue.B + progress * (toValue.B - fromValue.B)));
         }
     }
 }

--- a/src/LiveChartsCore/Motion/PointFMotionProperty.cs
+++ b/src/LiveChartsCore/Motion/PointFMotionProperty.cs
@@ -20,20 +20,20 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Drawing;
+using LiveChartsCore.Drawing;
 
 namespace LiveChartsCore.Motion
 {
     /// <summary>
-    /// Defines the <see cref="PointF"/> motion property class.
+    /// Defines the <see cref="LvcPoint"/> motion property class.
     /// </summary>
-    public class PointFMotionProperty : MotionProperty<PointF>
+    public class LvPointMotionProperty : MotionProperty<LvcPoint>
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="PointFMotionProperty"/> class.
+        /// Initializes a new instance of the <see cref="LvPointMotionProperty"/> class.
         /// </summary>
         /// <param name="propertyName">Name of the property.</param>
-        public PointFMotionProperty(string propertyName)
+        public LvPointMotionProperty(string propertyName)
             : base(propertyName)
         {
 
@@ -44,7 +44,7 @@ namespace LiveChartsCore.Motion
         /// </summary>
         /// <param name="propertyName">Name of the property.</param>
         /// <param name="value">The value.</param>
-        public PointFMotionProperty(string propertyName, PointF value)
+        public LvPointMotionProperty(string propertyName, LvcPoint value)
             : base(propertyName)
         {
             fromValue = value;
@@ -52,9 +52,9 @@ namespace LiveChartsCore.Motion
         }
 
         /// <inheritdoc cref="MotionProperty{T}.OnGetMovement(float)" />
-        protected override PointF OnGetMovement(float progress)
+        protected override LvcPoint OnGetMovement(float progress)
         {
-            return new PointF(
+            return new LvcPoint(
                 fromValue.X + progress * (toValue.X - fromValue.X),
                 fromValue.Y + progress * (toValue.Y - fromValue.Y));
         }

--- a/src/LiveChartsCore/Motion/PointMotionProperty.cs
+++ b/src/LiveChartsCore/Motion/PointMotionProperty.cs
@@ -27,13 +27,13 @@ namespace LiveChartsCore.Motion
     /// <summary>
     /// Defines the <see cref="LvcPoint"/> motion property class.
     /// </summary>
-    public class LvPointMotionProperty : MotionProperty<LvcPoint>
+    public class PointMotionProperty : MotionProperty<LvcPoint>
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="LvPointMotionProperty"/> class.
+        /// Initializes a new instance of the <see cref="PointMotionProperty"/> class.
         /// </summary>
         /// <param name="propertyName">Name of the property.</param>
-        public LvPointMotionProperty(string propertyName)
+        public PointMotionProperty(string propertyName)
             : base(propertyName)
         {
 
@@ -44,7 +44,7 @@ namespace LiveChartsCore.Motion
         /// </summary>
         /// <param name="propertyName">Name of the property.</param>
         /// <param name="value">The value.</param>
-        public LvPointMotionProperty(string propertyName, LvcPoint value)
+        public PointMotionProperty(string propertyName, LvcPoint value)
             : base(propertyName)
         {
             fromValue = value;

--- a/src/LiveChartsCore/PieChart.cs
+++ b/src/LiveChartsCore/PieChart.cs
@@ -24,7 +24,6 @@ using LiveChartsCore.Kernel;
 using LiveChartsCore.Drawing;
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
 using LiveChartsCore.Measure;
 using LiveChartsCore.Kernel.Sketches;
@@ -131,7 +130,7 @@ namespace LiveChartsCore
         /// </summary>
         /// <param name="pointerPosition">The pointer position.</param>
         /// <returns></returns>
-        public override TooltipPoint[] FindPointsNearTo(PointF pointerPosition)
+        public override TooltipPoint[] FindPointsNearTo(LvcPoint pointerPosition)
         {
             return _chartView.Series.SelectMany(
                 series => series.FindPointsNearTo(this, pointerPosition, TooltipFindingStrategy.CompareAll)).ToArray();

--- a/src/LiveChartsCore/PieSeries.cs
+++ b/src/LiveChartsCore/PieSeries.cs
@@ -25,7 +25,6 @@ using LiveChartsCore.Drawing;
 using System;
 using System.Collections.Generic;
 using LiveChartsCore.Measure;
-using System.Drawing;
 using System.Linq;
 using LiveChartsCore.Kernel.Sketches;
 using LiveChartsCore.Kernel.Drawing;
@@ -35,9 +34,9 @@ namespace LiveChartsCore
     /// <inheritdoc cref="IPieSeries{TDrawingContext}" />
     public abstract class PieSeries<TModel, TVisual, TLabel, TDrawingContext>
         : ChartSeries<TModel, TVisual, TLabel, TDrawingContext>, IPieSeries<TDrawingContext>
-        where TDrawingContext : DrawingContext
-        where TVisual : class, IDoughnutVisualChartPoint<TDrawingContext>, new()
-        where TLabel : class, ILabelGeometry<TDrawingContext>, new()
+            where TDrawingContext : DrawingContext
+            where TVisual : class, IDoughnutVisualChartPoint<TDrawingContext>, new()
+            where TLabel : class, ILabelGeometry<TDrawingContext>, new()
     {
         private IPaint<TDrawingContext>? _stroke = null;
         private IPaint<TDrawingContext>? _fill = null;
@@ -154,19 +153,19 @@ namespace LiveChartsCore
             if (Fill is not null)
             {
                 Fill.ZIndex = actualZIndex + 0.1;
-                Fill.SetClipRectangle(pieChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
+                Fill.SetClipRectangle(pieChart.Canvas, new LvcRectangle(drawLocation, drawMarginSize));
                 pieChart.Canvas.AddDrawableTask(Fill);
             }
             if (Stroke is not null)
             {
                 Stroke.ZIndex = actualZIndex + 0.2;
-                Stroke.SetClipRectangle(pieChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
+                Stroke.SetClipRectangle(pieChart.Canvas, new LvcRectangle(drawLocation, drawMarginSize));
                 pieChart.Canvas.AddDrawableTask(Stroke);
             }
             if (DataLabelsPaint is not null)
             {
                 DataLabelsPaint.ZIndex = 1000 + actualZIndex + 0.3;
-                DataLabelsPaint.SetClipRectangle(pieChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
+                DataLabelsPaint.SetClipRectangle(pieChart.Canvas, new LvcRectangle(drawLocation, drawMarginSize));
                 pieChart.Canvas.AddDrawableTask(DataLabelsPaint);
             }
 
@@ -580,13 +579,13 @@ namespace LiveChartsCore
         /// <param name="labelSize">Size of the label.</param>
         /// <param name="position">The position.</param>
         /// <returns></returns>
-        protected virtual PointF GetLabelPolarPosition(
+        protected virtual LvcPoint GetLabelPolarPosition(
             float centerX,
             float centerY,
             float radius,
             float startAngle,
             float sweepAngle,
-            SizeF labelSize,
+            LvcSize labelSize,
             PolarLabelsPosition position)
         {
             const float toRadians = (float)(Math.PI / 180);
@@ -604,7 +603,7 @@ namespace LiveChartsCore
                     angle = startAngle + sweepAngle * 0.5f;
                     break;
                 case PolarLabelsPosition.ChartCenter:
-                    return new PointF(centerX, centerY);
+                    return new LvcPoint(centerX, centerY);
                 default:
                     break;
             }
@@ -613,7 +612,7 @@ namespace LiveChartsCore
             if (angle < 0) angle += 360;
             angle *= toRadians;
 
-            return new PointF(
+            return new LvcPoint(
                  (float)(centerX + Math.Cos(angle) * radius),
                  (float)(centerY + Math.Sin(angle) * radius));
         }

--- a/src/LiveChartsCore/PolarAxis.cs
+++ b/src/LiveChartsCore/PolarAxis.cs
@@ -29,7 +29,6 @@ using LiveChartsCore.Measure;
 using System;
 using LiveChartsCore.Drawing.Common;
 using System.Runtime.CompilerServices;
-using System.Drawing;
 using LiveChartsCore.Kernel.Helpers;
 using System.Linq;
 
@@ -42,11 +41,12 @@ namespace LiveChartsCore
     /// <typeparam name="TTextGeometry">The type of the text geometry.</typeparam>
     /// <typeparam name="TCircleGeometry">The type of the circle geometry.</typeparam>
     /// /// <typeparam name="TLineGeometry">The type of the line geometry.</typeparam>
-    public abstract class PolarAxis<TDrawingContext, TTextGeometry, TLineGeometry, TCircleGeometry> : ChartElement<TDrawingContext>, IPolarAxis, IPlane<TDrawingContext>
-        where TDrawingContext : DrawingContext
-        where TTextGeometry : ILabelGeometry<TDrawingContext>, new()
-        where TLineGeometry : ILineGeometry<TDrawingContext>, new()
-        where TCircleGeometry : ISizedGeometry<TDrawingContext>, new()
+    public abstract class PolarAxis<TDrawingContext, TTextGeometry, TLineGeometry, TCircleGeometry>
+        : ChartElement<TDrawingContext>, IPolarAxis, IPlane<TDrawingContext>
+            where TDrawingContext : DrawingContext
+            where TTextGeometry : ILabelGeometry<TDrawingContext>, new()
+            where TLineGeometry : ILineGeometry<TDrawingContext>, new()
+            where TCircleGeometry : ISizedGeometry<TDrawingContext>, new()
     {
         #region fields
 
@@ -220,7 +220,7 @@ namespace LiveChartsCore
             if (SeparatorsPaint is not null)
             {
                 SeparatorsPaint.ZIndex = -1;
-                SeparatorsPaint.SetClipRectangle(polarChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
+                SeparatorsPaint.SetClipRectangle(polarChart.Canvas, new LvcRectangle(drawLocation, drawMarginSize));
                 polarChart.Canvas.AddDrawableTask(SeparatorsPaint);
             }
 
@@ -430,9 +430,9 @@ namespace LiveChartsCore
         }
 
         /// <inheritdoc cref="IPlane{TDrawingContext}.GetNameLabelSize(Chart{TDrawingContext})"/>
-        public SizeF GetNameLabelSize(Chart<TDrawingContext> chart)
+        public LvcSize GetNameLabelSize(Chart<TDrawingContext> chart)
         {
-            if (NamePaint is null || string.IsNullOrWhiteSpace(Name)) return new SizeF(0, 0);
+            if (NamePaint is null || string.IsNullOrWhiteSpace(Name)) return new LvcSize(0, 0);
 
             var textGeometry = new TTextGeometry
             {
@@ -446,10 +446,10 @@ namespace LiveChartsCore
         }
 
         /// <inheritdoc cref="IPlane{TDrawingContext}.GetPossibleSize(Chart{TDrawingContext})"/>
-        public virtual SizeF GetPossibleSize(Chart<TDrawingContext> chart)
+        public virtual LvcSize GetPossibleSize(Chart<TDrawingContext> chart)
         {
             if (_dataBounds is null) throw new Exception("DataBounds not found");
-            if (LabelsPaint is null) return new SizeF(0f, 0f);
+            if (LabelsPaint is null) return new LvcSize(0f, 0f);
 
             var ts = (float)TextSize;
             var labeler = Labeler;
@@ -487,7 +487,7 @@ namespace LiveChartsCore
                 if (m.Height > h) h = m.Height;
             }
 
-            return new SizeF(w, h);
+            return new LvcSize(w, h);
         }
 
         /// <inheritdoc cref="IPolarAxis.Initialize(PolarAxisOrientation)"/>

--- a/src/LiveChartsCore/PolarChart.cs
+++ b/src/LiveChartsCore/PolarChart.cs
@@ -25,7 +25,6 @@ using System.Collections.Generic;
 using LiveChartsCore.Kernel.Sketches;
 using System;
 using LiveChartsCore.Kernel;
-using System.Drawing;
 using System.Linq;
 using System.Diagnostics;
 using System.Threading;
@@ -125,7 +124,7 @@ namespace LiveChartsCore
         /// </summary>
         /// <param name="pointerPosition">The pointer position.</param>
         /// <returns></returns>
-        public override TooltipPoint[] FindPointsNearTo(PointF pointerPosition)
+        public override TooltipPoint[] FindPointsNearTo(LvcPoint pointerPosition)
         {
             return _chartView.Series.SelectMany(
                 series => series.FindPointsNearTo(this, pointerPosition, TooltipFindingStrategy.CompareAll))

--- a/src/LiveChartsCore/PolarLineSeries.cs
+++ b/src/LiveChartsCore/PolarLineSeries.cs
@@ -26,7 +26,6 @@ using LiveChartsCore.Measure;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Drawing;
 using LiveChartsCore.Kernel.Drawing;
 using LiveChartsCore.Kernel.Sketches;
 using LiveChartsCore.Kernel.Data;
@@ -38,13 +37,13 @@ namespace LiveChartsCore
     /// </summary>
     public class PolarLineSeries<TModel, TVisual, TLabel, TDrawingContext, TPathGeometry, TLineSegment, TBezierSegment, TMoveToCommand, TPathArgs>
         : ChartSeries<TModel, LineBezierVisualPoint<TDrawingContext, TVisual, TBezierSegment, TPathArgs>, TLabel, TDrawingContext>, ILineSeries<TDrawingContext>, IPolarSeries<TDrawingContext>
-        where TPathGeometry : IPathGeometry<TDrawingContext, TPathArgs>, new()
-        where TLineSegment : ILinePathSegment<TPathArgs>, new()
-        where TBezierSegment : IBezierSegment<TPathArgs>, new()
-        where TMoveToCommand : IMoveToPathCommand<TPathArgs>, new()
-        where TVisual : class, ISizedVisualChartPoint<TDrawingContext>, new()
-        where TLabel : class, ILabelGeometry<TDrawingContext>, new()
-        where TDrawingContext : DrawingContext
+            where TPathGeometry : IPathGeometry<TDrawingContext, TPathArgs>, new()
+            where TLineSegment : ILinePathSegment<TPathArgs>, new()
+            where TBezierSegment : IBezierSegment<TPathArgs>, new()
+            where TMoveToCommand : IMoveToPathCommand<TPathArgs>, new()
+            where TVisual : class, ISizedVisualChartPoint<TDrawingContext>, new()
+            where TLabel : class, ILabelGeometry<TDrawingContext>, new()
+            where TDrawingContext : DrawingContext
     {
         private readonly Dictionary<object, List<AreaHelper<TDrawingContext, TPathGeometry, TLineSegment, TMoveToCommand, TPathArgs>>> _fillPathHelperDictionary = new();
         private readonly Dictionary<object, List<AreaHelper<TDrawingContext, TPathGeometry, TLineSegment, TMoveToCommand, TPathArgs>>> _strokePathHelperDictionary = new();
@@ -67,7 +66,7 @@ namespace LiveChartsCore
                   SeriesProperties.Line | SeriesProperties.PrimaryAxisVerticalOrientation |
                   (isStacked ? SeriesProperties.Stacked : 0) | SeriesProperties.Sketch | SeriesProperties.PrefersXStrategyTooltips)
         {
-            DataPadding = new PointF(0.5f, 1f);
+            DataPadding = new LvcPoint(0.5f, 1f);
             HoverState = LiveCharts.LineSeriesHoverKey;
         }
 
@@ -223,7 +222,7 @@ namespace LiveChartsCore
                     Fill.AddGeometryToPaintTask(polarChart.Canvas, fillPathHelper.Path);
                     polarChart.Canvas.AddDrawableTask(Fill);
                     Fill.ZIndex = actualZIndex + 0.1;
-                    Fill.SetClipRectangle(polarChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
+                    Fill.SetClipRectangle(polarChart.Canvas, new LvcRectangle(drawLocation, drawMarginSize));
                 }
                 if (Stroke is not null)
                 {
@@ -231,7 +230,7 @@ namespace LiveChartsCore
                     Stroke.AddGeometryToPaintTask(polarChart.Canvas, strokePathHelper.Path);
                     polarChart.Canvas.AddDrawableTask(Stroke);
                     Stroke.ZIndex = actualZIndex + 0.2;
-                    Stroke.SetClipRectangle(polarChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
+                    Stroke.SetClipRectangle(polarChart.Canvas, new LvcRectangle(drawLocation, drawMarginSize));
                 }
 
                 foreach (var data in GetSpline(segment, scaler, stacker))
@@ -400,13 +399,13 @@ namespace LiveChartsCore
                 if (GeometryFill is not null)
                 {
                     polarChart.Canvas.AddDrawableTask(GeometryFill);
-                    GeometryFill.SetClipRectangle(polarChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
+                    GeometryFill.SetClipRectangle(polarChart.Canvas, new LvcRectangle(drawLocation, drawMarginSize));
                     GeometryFill.ZIndex = actualZIndex + 0.3;
                 }
                 if (GeometryStroke is not null)
                 {
                     polarChart.Canvas.AddDrawableTask(GeometryStroke);
-                    GeometryStroke.SetClipRectangle(polarChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
+                    GeometryStroke.SetClipRectangle(polarChart.Canvas, new LvcRectangle(drawLocation, drawMarginSize));
                     GeometryStroke.ZIndex = actualZIndex + 0.4;
                 }
                 segmentI++;
@@ -428,7 +427,7 @@ namespace LiveChartsCore
             if (DataLabelsPaint is not null)
             {
                 polarChart.Canvas.AddDrawableTask(DataLabelsPaint);
-                DataLabelsPaint.SetClipRectangle(polarChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
+                DataLabelsPaint.SetClipRectangle(polarChart.Canvas, new LvcRectangle(drawLocation, drawMarginSize));
                 DataLabelsPaint.ZIndex = actualZIndex + 0.5;
             }
 
@@ -526,12 +525,12 @@ namespace LiveChartsCore
         /// <param name="seriesProperties">The series properties.</param>
         /// <param name="isGreaterThanPivot">if set to <c>true</c> [is greater than pivot].</param>
         /// <returns></returns>
-        protected virtual PointF GetLabelPosition(
+        protected virtual LvcPoint GetLabelPosition(
             float x,
             float y,
             float width,
             float height,
-            SizeF labelSize,
+            LvcSize labelSize,
             DataLabelsPosition position,
             SeriesProperties seriesProperties,
             bool isGreaterThanPivot)
@@ -541,27 +540,27 @@ namespace LiveChartsCore
 
             return position switch
             {
-                DataLabelsPosition.Middle => new PointF(middleX, middleY),
-                DataLabelsPosition.Top => new PointF(middleX, y - labelSize.Height * 0.5f),
-                DataLabelsPosition.Bottom => new PointF(middleX, y + height + labelSize.Height * 0.5f),
-                DataLabelsPosition.Left => new PointF(x - labelSize.Width * 0.5f, middleY),
-                DataLabelsPosition.Right => new PointF(x + width + labelSize.Width * 0.5f, middleY),
+                DataLabelsPosition.Middle => new LvcPoint(middleX, middleY),
+                DataLabelsPosition.Top => new LvcPoint(middleX, y - labelSize.Height * 0.5f),
+                DataLabelsPosition.Bottom => new LvcPoint(middleX, y + height + labelSize.Height * 0.5f),
+                DataLabelsPosition.Left => new LvcPoint(x - labelSize.Width * 0.5f, middleY),
+                DataLabelsPosition.Right => new LvcPoint(x + width + labelSize.Width * 0.5f, middleY),
                 DataLabelsPosition.End =>
                 (seriesProperties & SeriesProperties.PrimaryAxisHorizontalOrientation) == SeriesProperties.PrimaryAxisHorizontalOrientation
                     ? (isGreaterThanPivot
-                        ? new PointF(x + width + labelSize.Width * 0.5f, middleY)
-                        : new PointF(x - labelSize.Width * 0.5f, middleY))
+                        ? new LvcPoint(x + width + labelSize.Width * 0.5f, middleY)
+                        : new LvcPoint(x - labelSize.Width * 0.5f, middleY))
                     : (isGreaterThanPivot
-                        ? new PointF(middleX, y - labelSize.Height * 0.5f)
-                        : new PointF(middleX, y + height + labelSize.Height * 0.5f)),
+                        ? new LvcPoint(middleX, y - labelSize.Height * 0.5f)
+                        : new LvcPoint(middleX, y + height + labelSize.Height * 0.5f)),
                 DataLabelsPosition.Start =>
                      (seriesProperties & SeriesProperties.PrimaryAxisHorizontalOrientation) == SeriesProperties.PrimaryAxisHorizontalOrientation
                         ? (isGreaterThanPivot
-                            ? new PointF(x - labelSize.Width * 0.5f, middleY)
-                            : new PointF(x + width + labelSize.Width * 0.5f, middleY))
+                            ? new LvcPoint(x - labelSize.Width * 0.5f, middleY)
+                            : new LvcPoint(x + width + labelSize.Width * 0.5f, middleY))
                         : (isGreaterThanPivot
-                            ? new PointF(middleX, y + height + labelSize.Height * 0.5f)
-                            : new PointF(middleX, y - labelSize.Height * 0.5f)),
+                            ? new LvcPoint(middleX, y + height + labelSize.Height * 0.5f)
+                            : new LvcPoint(middleX, y - labelSize.Height * 0.5f)),
                 _ => throw new Exception("Position not supported"),
             };
         }

--- a/src/LiveChartsCore/RowSeries.cs
+++ b/src/LiveChartsCore/RowSeries.cs
@@ -25,7 +25,6 @@ using LiveChartsCore.Drawing;
 using System;
 using LiveChartsCore.Measure;
 using System.Collections.Generic;
-using System.Drawing;
 using LiveChartsCore.Kernel.Sketches;
 using LiveChartsCore.Kernel.Drawing;
 using LiveChartsCore.Kernel.Data;
@@ -104,19 +103,19 @@ namespace LiveChartsCore
             if (Fill is not null)
             {
                 Fill.ZIndex = actualZIndex + 0.1;
-                Fill.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
+                Fill.SetClipRectangle(cartesianChart.Canvas, new LvcRectangle(drawLocation, drawMarginSize));
                 cartesianChart.Canvas.AddDrawableTask(Fill);
             }
             if (Stroke is not null)
             {
                 Stroke.ZIndex = actualZIndex + 0.1;
-                Stroke.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
+                Stroke.SetClipRectangle(cartesianChart.Canvas, new LvcRectangle(drawLocation, drawMarginSize));
                 cartesianChart.Canvas.AddDrawableTask(Stroke);
             }
             if (DataLabelsPaint is not null)
             {
                 DataLabelsPaint.ZIndex = actualZIndex + 0.1;
-                DataLabelsPaint.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
+                DataLabelsPaint.SetClipRectangle(cartesianChart.Canvas, new LvcRectangle(drawLocation, drawMarginSize));
                 cartesianChart.Canvas.AddDrawableTask(DataLabelsPaint);
             }
 

--- a/src/LiveChartsCore/ScatterSeries.cs
+++ b/src/LiveChartsCore/ScatterSeries.cs
@@ -25,7 +25,6 @@ using LiveChartsCore.Drawing;
 using System;
 using LiveChartsCore.Measure;
 using System.Collections.Generic;
-using System.Drawing;
 using LiveChartsCore.Kernel.Sketches;
 using LiveChartsCore.Kernel.Drawing;
 using LiveChartsCore.Kernel.Data;
@@ -41,10 +40,11 @@ namespace LiveChartsCore
     /// <typeparam name="TDrawingContext">The type of the drawing context.</typeparam>
     /// <seealso cref="CartesianSeries{TModel, TVisual, TLabel, TDrawingContext}" />
     /// <seealso cref="IScatterSeries{TDrawingContext}" />
-    public class ScatterSeries<TModel, TVisual, TLabel, TDrawingContext> : StrokeAndFillCartesianSeries<TModel, TVisual, TLabel, TDrawingContext>, IScatterSeries<TDrawingContext>
-        where TVisual : class, ISizedVisualChartPoint<TDrawingContext>, new()
-        where TLabel : class, ILabelGeometry<TDrawingContext>, new()
-        where TDrawingContext : DrawingContext
+    public class ScatterSeries<TModel, TVisual, TLabel, TDrawingContext>
+        : StrokeAndFillCartesianSeries<TModel, TVisual, TLabel, TDrawingContext>, IScatterSeries<TDrawingContext>
+            where TVisual : class, ISizedVisualChartPoint<TDrawingContext>, new()
+            where TLabel : class, ILabelGeometry<TDrawingContext>, new()
+            where TDrawingContext : DrawingContext
     {
         private Bounds _weightBounds = new();
 
@@ -54,7 +54,7 @@ namespace LiveChartsCore
         public ScatterSeries()
             : base(SeriesProperties.Scatter | SeriesProperties.Solid | SeriesProperties.PrefersXYStrategyTooltips)
         {
-            DataPadding = new PointF(1, 1);
+            DataPadding = new LvcPoint(1, 1);
 
             HoverState = LiveCharts.ScatterSeriesHoverKey;
 
@@ -94,19 +94,19 @@ namespace LiveChartsCore
             if (Fill is not null)
             {
                 Fill.ZIndex = actualZIndex + 0.1;
-                Fill.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
+                Fill.SetClipRectangle(cartesianChart.Canvas, new LvcRectangle(drawLocation, drawMarginSize));
                 cartesianChart.Canvas.AddDrawableTask(Fill);
             }
             if (Stroke is not null)
             {
                 Stroke.ZIndex = actualZIndex + 0.2;
-                Stroke.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
+                Stroke.SetClipRectangle(cartesianChart.Canvas, new LvcRectangle(drawLocation, drawMarginSize));
                 cartesianChart.Canvas.AddDrawableTask(Stroke);
             }
             if (DataLabelsPaint is not null)
             {
                 DataLabelsPaint.ZIndex = actualZIndex + 0.3;
-                DataLabelsPaint.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
+                DataLabelsPaint.SetClipRectangle(cartesianChart.Canvas, new LvcRectangle(drawLocation, drawMarginSize));
                 cartesianChart.Canvas.AddDrawableTask(DataLabelsPaint);
             }
 

--- a/src/LiveChartsCore/Section.cs
+++ b/src/LiveChartsCore/Section.cs
@@ -21,7 +21,6 @@
 // SOFTWARE.
 
 using System.ComponentModel;
-using System.Drawing;
 using System.Runtime.CompilerServices;
 using LiveChartsCore.Drawing;
 using LiveChartsCore.Kernel;
@@ -244,7 +243,7 @@ namespace LiveChartsCore
                 _fillSizedGeometry.Width = xj - xi;
                 _fillSizedGeometry.Height = yj - yi;
 
-                Fill.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
+                Fill.SetClipRectangle(cartesianChart.Canvas, new LvcRectangle(drawLocation, drawMarginSize));
                 Fill.AddGeometryToPaintTask(chart.Canvas, _fillSizedGeometry);
                 chart.Canvas.AddDrawableTask(Fill);
             }
@@ -282,7 +281,7 @@ namespace LiveChartsCore
                 _strokeSizedGeometry.Width = xj - xi;
                 _strokeSizedGeometry.Height = yj - yi;
 
-                Stroke.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
+                Stroke.SetClipRectangle(cartesianChart.Canvas, new LvcRectangle(drawLocation, drawMarginSize));
                 Stroke.AddGeometryToPaintTask(chart.Canvas, _strokeSizedGeometry);
                 chart.Canvas.AddDrawableTask(Stroke);
             }

--- a/src/LiveChartsCore/Series.cs
+++ b/src/LiveChartsCore/Series.cs
@@ -25,7 +25,6 @@ using LiveChartsCore.Drawing;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Drawing;
 using LiveChartsCore.Measure;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
@@ -46,10 +45,11 @@ namespace LiveChartsCore
     /// <seealso cref="ISeries{TModel}" />
     /// <seealso cref="IDisposable" />
     /// <seealso cref="INotifyPropertyChanged" />
-    public abstract class Series<TModel, TVisual, TLabel, TDrawingContext> : ChartElement<TDrawingContext>, ISeries, ISeries<TModel>, INotifyPropertyChanged
-        where TDrawingContext : DrawingContext
-        where TVisual : class, IVisualChartPoint<TDrawingContext>, new()
-        where TLabel : class, ILabelGeometry<TDrawingContext>, new()
+    public abstract class Series<TModel, TVisual, TLabel, TDrawingContext>
+        : ChartElement<TDrawingContext>, ISeries, ISeries<TModel>, INotifyPropertyChanged
+            where TDrawingContext : DrawingContext
+            where TVisual : class, IVisualChartPoint<TDrawingContext>, new()
+            where TLabel : class, ILabelGeometry<TDrawingContext>, new()
     {
         /// <summary>
         /// The subscribed to
@@ -88,7 +88,7 @@ namespace LiveChartsCore
         private Func<TypedChartPoint<TModel, TVisual, TLabel, TDrawingContext>, string> _tooltipLabelFormatter = (point) => $"{point.Context.Series.Name} {point.PrimaryValue}";
         private Func<TypedChartPoint<TModel, TVisual, TLabel, TDrawingContext>, string> _dataLabelsFormatter = (point) => $"{point.PrimaryValue}";
         private bool _isVisible = true;
-        private PointF _dataPadding = new(0.5f, 0.5f);
+        private LvcPoint _dataPadding = new(0.5f, 0.5f);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Series{TModel, TVisual, TLabel, TDrawingContext}"/> class.
@@ -211,7 +211,7 @@ namespace LiveChartsCore
         }
 
         /// <inheritdoc cref="ISeries.DataPadding" />
-        public PointF DataPadding { get => _dataPadding; set { _dataPadding = value; OnPropertyChanged(); } }
+        public LvcPoint DataPadding { get => _dataPadding; set { _dataPadding = value; OnPropertyChanged(); } }
 
         /// <inheritdoc cref="ISeries.AnimationsSpeed" />
         public TimeSpan? AnimationsSpeed { get; set; }
@@ -244,7 +244,7 @@ namespace LiveChartsCore
             return Fetch(chart);
         }
 
-        TooltipPoint[] ISeries.FindPointsNearTo(IChart chart, PointF pointerPosition, TooltipFindingStrategy automaticStategy)
+        TooltipPoint[] ISeries.FindPointsNearTo(IChart chart, LvcPoint pointerPosition, TooltipFindingStrategy automaticStategy)
         {
             return this switch
             {
@@ -290,20 +290,20 @@ namespace LiveChartsCore
             {
                 s.Fill.SetClipRectangle(
                     core.Canvas,
-                    new RectangleF(core.DrawMarginLocation, core.DrawMarginSize));
+                    new LvcRectangle(core.DrawMarginLocation, core.DrawMarginSize));
                 s.Fill.AddGeometryToPaintTask(chart.CoreCanvas, highlitable);
             }
             if (s.Stroke is not null)
             {
                 s.Stroke.SetClipRectangle(
                     core.Canvas,
-                    new RectangleF(core.DrawMarginLocation, core.DrawMarginSize));
+                    new LvcRectangle(core.DrawMarginLocation, core.DrawMarginSize));
                 s.Stroke.AddGeometryToPaintTask(chart.CoreCanvas, highlitable);
             }
         }
 
-        /// <inheritdoc cref="ISeries.RemovePointFromState(ChartPoint, string)" />
-        public virtual void RemovePointFromState(ChartPoint chartPoint, string state)
+        /// <inheritdoc cref="ISeries.RemoveLvPointromState(ChartPoint, string)" />
+        public virtual void RemoveLvPointromState(ChartPoint chartPoint, string state)
         {
             var chart = (IChartView<TDrawingContext>)chartPoint.Context.Chart;
             var s = chart.PointStates[state];
@@ -423,7 +423,7 @@ namespace LiveChartsCore
         }
 
         private TooltipPoint[] FilterTooltipPoints(
-            IEnumerable<ChartPoint>? points, IChart chart, PointF pointerPosition, TooltipFindingStrategy automaticStategy)
+            IEnumerable<ChartPoint>? points, IChart chart, LvcPoint pointerPosition, TooltipFindingStrategy automaticStategy)
         {
             if (points is null) return new TooltipPoint[0];
             var tolerance = float.MaxValue;

--- a/src/LiveChartsCore/StackedAreaSeries.cs
+++ b/src/LiveChartsCore/StackedAreaSeries.cs
@@ -39,13 +39,13 @@ namespace LiveChartsCore
     /// <seealso cref="LineSeries{TModel, TVisual, TLabel, TDrawingContext, TPathGeometry, TLineSegment, TBezierSegment, TMoveToCommand, TPathArgs}" />
     public class StackedAreaSeries<TModel, TVisual, TLabel, TDrawingContext, TPathGeometry, TLineSegment, TBezierSegment, TMoveToCommand, TPathArgs>
         : LineSeries<TModel, TVisual, TLabel, TDrawingContext, TPathGeometry, TLineSegment, TBezierSegment, TMoveToCommand, TPathArgs>
-        where TPathGeometry : IPathGeometry<TDrawingContext, TPathArgs>, new()
-        where TLineSegment : ILinePathSegment<TPathArgs>, new()
-        where TBezierSegment : IBezierSegment<TPathArgs>, new()
-        where TMoveToCommand : IMoveToPathCommand<TPathArgs>, new()
-        where TVisual : class, ISizedVisualChartPoint<TDrawingContext>, new()
-        where TLabel : class, ILabelGeometry<TDrawingContext>, new()
-        where TDrawingContext : DrawingContext
+            where TPathGeometry : IPathGeometry<TDrawingContext, TPathArgs>, new()
+            where TLineSegment : ILinePathSegment<TPathArgs>, new()
+            where TBezierSegment : IBezierSegment<TPathArgs>, new()
+            where TMoveToCommand : IMoveToPathCommand<TPathArgs>, new()
+            where TVisual : class, ISizedVisualChartPoint<TDrawingContext>, new()
+            where TLabel : class, ILabelGeometry<TDrawingContext>, new()
+            where TDrawingContext : DrawingContext
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="StackedAreaSeries{TModel, TVisual, TLabel, TDrawingContext, TPathGeometry, TLineSegment, TBezierSegment, TMoveToCommand, TPathArgs}"/> class.

--- a/src/LiveChartsCore/StackedBarSeries.cs
+++ b/src/LiveChartsCore/StackedBarSeries.cs
@@ -38,9 +38,9 @@ namespace LiveChartsCore
     /// <seealso cref="IStackedBarSeries{TDrawingContext}" />
     public abstract class StackedBarSeries<TModel, TVisual, TLabel, TDrawingContext>
         : StrokeAndFillCartesianSeries<TModel, TVisual, TLabel, TDrawingContext>, IStackedBarSeries<TDrawingContext>
-        where TVisual : class, IRoundedRectangleChartPoint<TDrawingContext>, new()
-        where TDrawingContext : DrawingContext
-        where TLabel : class, ILabelGeometry<TDrawingContext>, new()
+            where TVisual : class, IRoundedRectangleChartPoint<TDrawingContext>, new()
+            where TDrawingContext : DrawingContext
+            where TLabel : class, ILabelGeometry<TDrawingContext>, new()
     {
         /// <summary>
         /// The stack group

--- a/src/LiveChartsCore/StackedColumnSeries.cs
+++ b/src/LiveChartsCore/StackedColumnSeries.cs
@@ -25,7 +25,6 @@ using LiveChartsCore.Drawing;
 using System;
 using LiveChartsCore.Measure;
 using System.Collections.Generic;
-using System.Drawing;
 using LiveChartsCore.Kernel.Sketches;
 using LiveChartsCore.Kernel.Drawing;
 using LiveChartsCore.Kernel.Data;
@@ -53,7 +52,7 @@ namespace LiveChartsCore
                   SeriesProperties.Bar | SeriesProperties.PrimaryAxisVerticalOrientation | SeriesProperties.Stacked |
                   SeriesProperties.Solid | SeriesProperties.PrefersXStrategyTooltips)
         {
-            DataPadding = new PointF(0, 1);
+            DataPadding = new LvcPoint(0, 1);
         }
 
         /// <inheritdoc cref="ChartElement{TDrawingContext}.Measure(Chart{TDrawingContext})"/>
@@ -100,19 +99,19 @@ namespace LiveChartsCore
             if (Fill is not null)
             {
                 Fill.ZIndex = actualZIndex + 0.1;
-                Fill.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
+                Fill.SetClipRectangle(cartesianChart.Canvas, new LvcRectangle(drawLocation, drawMarginSize));
                 cartesianChart.Canvas.AddDrawableTask(Fill);
             }
             if (Stroke is not null)
             {
                 Stroke.ZIndex = actualZIndex + 0.2;
-                Stroke.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
+                Stroke.SetClipRectangle(cartesianChart.Canvas, new LvcRectangle(drawLocation, drawMarginSize));
                 cartesianChart.Canvas.AddDrawableTask(Stroke);
             }
             if (DataLabelsPaint is not null)
             {
                 DataLabelsPaint.ZIndex = actualZIndex + 0.3;
-                DataLabelsPaint.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
+                DataLabelsPaint.SetClipRectangle(cartesianChart.Canvas, new LvcRectangle(drawLocation, drawMarginSize));
                 cartesianChart.Canvas.AddDrawableTask(DataLabelsPaint);
             }
 

--- a/src/LiveChartsCore/StackedRowSeries.cs
+++ b/src/LiveChartsCore/StackedRowSeries.cs
@@ -25,7 +25,6 @@ using LiveChartsCore.Drawing;
 using System;
 using LiveChartsCore.Measure;
 using System.Collections.Generic;
-using System.Drawing;
 using LiveChartsCore.Kernel.Sketches;
 using LiveChartsCore.Kernel.Drawing;
 using LiveChartsCore.Kernel.Data;
@@ -96,19 +95,19 @@ namespace LiveChartsCore
             if (Fill is not null)
             {
                 Fill.ZIndex = actualZIndex + 0.1;
-                Fill.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
+                Fill.SetClipRectangle(cartesianChart.Canvas, new LvcRectangle(drawLocation, drawMarginSize));
                 cartesianChart.Canvas.AddDrawableTask(Fill);
             }
             if (Stroke is not null)
             {
                 Stroke.ZIndex = actualZIndex + 0.2;
-                Stroke.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
+                Stroke.SetClipRectangle(cartesianChart.Canvas, new LvcRectangle(drawLocation, drawMarginSize));
                 cartesianChart.Canvas.AddDrawableTask(Stroke);
             }
             if (DataLabelsPaint is not null)
             {
                 DataLabelsPaint.ZIndex = actualZIndex + 0.3;
-                DataLabelsPaint.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
+                DataLabelsPaint.SetClipRectangle(cartesianChart.Canvas, new LvcRectangle(drawLocation, drawMarginSize));
                 cartesianChart.Canvas.AddDrawableTask(DataLabelsPaint);
             }
             var dls = (float)DataLabelsSize;

--- a/src/LiveChartsCore/StackedStepAreaSeries.cs
+++ b/src/LiveChartsCore/StackedStepAreaSeries.cs
@@ -39,13 +39,13 @@ namespace LiveChartsCore
     /// <seealso cref="LineSeries{TModel, TVisual, TLabel, TDrawingContext, TPathGeometry, TLineSegment, TBezierSegment, TMoveToCommand, TPathArgs}" />
     public class StackedStepAreaSeries<TModel, TVisual, TLabel, TDrawingContext, TPathGeometry, TLineSegment, TStepLineSegment, TMoveToCommand, TPathArgs>
         : StepLineSeries<TModel, TVisual, TLabel, TDrawingContext, TPathGeometry, TLineSegment, TStepLineSegment, TMoveToCommand, TPathArgs>
-        where TPathGeometry : IPathGeometry<TDrawingContext, TPathArgs>, new()
-        where TLineSegment : ILinePathSegment<TPathArgs>, new()
-        where TStepLineSegment : IStepLineSegment<TPathArgs>, new()
-        where TMoveToCommand : IMoveToPathCommand<TPathArgs>, new()
-        where TVisual : class, ISizedVisualChartPoint<TDrawingContext>, new()
-        where TLabel : class, ILabelGeometry<TDrawingContext>, new()
-        where TDrawingContext : DrawingContext
+            where TPathGeometry : IPathGeometry<TDrawingContext, TPathArgs>, new()
+            where TLineSegment : ILinePathSegment<TPathArgs>, new()
+            where TStepLineSegment : IStepLineSegment<TPathArgs>, new()
+            where TMoveToCommand : IMoveToPathCommand<TPathArgs>, new()
+            where TVisual : class, ISizedVisualChartPoint<TDrawingContext>, new()
+            where TLabel : class, ILabelGeometry<TDrawingContext>, new()
+            where TDrawingContext : DrawingContext
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="StackedAreaSeries{TModel, TVisual, TLabel, TDrawingContext, TPathGeometry, TLineSegment, TBezierSegment, TMoveToCommand, TPathArgs}"/> class.

--- a/src/LiveChartsCore/StepLineSeries.cs
+++ b/src/LiveChartsCore/StepLineSeries.cs
@@ -26,7 +26,6 @@ using LiveChartsCore.Measure;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Drawing;
 using LiveChartsCore.Kernel.Drawing;
 using LiveChartsCore.Kernel.Sketches;
 using LiveChartsCore.Kernel.Data;
@@ -47,13 +46,13 @@ namespace LiveChartsCore
     /// <typeparam name="TPathArgs">The type of the path arguments.</typeparam>
     public class StepLineSeries<TModel, TVisual, TLabel, TDrawingContext, TPathGeometry, TLineSegment, TStepLineSegment, TMoveToCommand, TPathArgs>
         : StrokeAndFillCartesianSeries<TModel, StepLineVisualPoint<TDrawingContext, TVisual, TStepLineSegment, TPathArgs>, TLabel, TDrawingContext>, IStepLineSeries<TDrawingContext>
-        where TPathGeometry : IPathGeometry<TDrawingContext, TPathArgs>, new()
-        where TLineSegment : ILinePathSegment<TPathArgs>, new()
-        where TStepLineSegment : IStepLineSegment<TPathArgs>, new()
-        where TMoveToCommand : IMoveToPathCommand<TPathArgs>, new()
-        where TVisual : class, ISizedVisualChartPoint<TDrawingContext>, new()
-        where TLabel : class, ILabelGeometry<TDrawingContext>, new()
-        where TDrawingContext : DrawingContext
+            where TPathGeometry : IPathGeometry<TDrawingContext, TPathArgs>, new()
+            where TLineSegment : ILinePathSegment<TPathArgs>, new()
+            where TStepLineSegment : IStepLineSegment<TPathArgs>, new()
+            where TMoveToCommand : IMoveToPathCommand<TPathArgs>, new()
+            where TVisual : class, ISizedVisualChartPoint<TDrawingContext>, new()
+            where TLabel : class, ILabelGeometry<TDrawingContext>, new()
+            where TDrawingContext : DrawingContext
     {
         private readonly Dictionary<object, List<AreaHelper<TDrawingContext, TPathGeometry, TLineSegment, TMoveToCommand, TPathArgs>>> _fillPathHelperDictionary = new();
         private readonly Dictionary<object, List<AreaHelper<TDrawingContext, TPathGeometry, TLineSegment, TMoveToCommand, TPathArgs>>> _strokePathHelperDictionary = new();
@@ -71,7 +70,7 @@ namespace LiveChartsCore
                   SeriesProperties.StepLine | SeriesProperties.PrimaryAxisVerticalOrientation |
                   (isStacked ? SeriesProperties.Stacked : 0) | SeriesProperties.Sketch | SeriesProperties.PrefersXStrategyTooltips)
         {
-            DataPadding = new PointF(0.5f, 1f);
+            DataPadding = new LvcPoint(0.5f, 1f);
             HoverState = LiveCharts.StepLineSeriesHoverKey;
         }
 
@@ -185,7 +184,7 @@ namespace LiveChartsCore
                     Fill.AddGeometryToPaintTask(cartesianChart.Canvas, fillPathHelper.Path);
                     cartesianChart.Canvas.AddDrawableTask(Fill);
                     Fill.ZIndex = actualZIndex + 0.1;
-                    Fill.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
+                    Fill.SetClipRectangle(cartesianChart.Canvas, new LvcRectangle(drawLocation, drawMarginSize));
                 }
                 if (Stroke is not null)
                 {
@@ -193,7 +192,7 @@ namespace LiveChartsCore
                     Stroke.AddGeometryToPaintTask(cartesianChart.Canvas, strokePathHelper.Path);
                     cartesianChart.Canvas.AddDrawableTask(Stroke);
                     Stroke.ZIndex = actualZIndex + 0.2;
-                    Stroke.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
+                    Stroke.SetClipRectangle(cartesianChart.Canvas, new LvcRectangle(drawLocation, drawMarginSize));
                 }
 
                 foreach (var data in GetStepLine(segment, secondaryScale, primaryScale, stacker))
@@ -396,13 +395,13 @@ namespace LiveChartsCore
                 if (GeometryFill is not null)
                 {
                     cartesianChart.Canvas.AddDrawableTask(GeometryFill);
-                    GeometryFill.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
+                    GeometryFill.SetClipRectangle(cartesianChart.Canvas, new LvcRectangle(drawLocation, drawMarginSize));
                     GeometryFill.ZIndex = actualZIndex + 0.3;
                 }
                 if (GeometryStroke is not null)
                 {
                     cartesianChart.Canvas.AddDrawableTask(GeometryStroke);
-                    GeometryStroke.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
+                    GeometryStroke.SetClipRectangle(cartesianChart.Canvas, new LvcRectangle(drawLocation, drawMarginSize));
                     GeometryStroke.ZIndex = actualZIndex + 0.4;
                 }
                 segmentI++;
@@ -424,7 +423,7 @@ namespace LiveChartsCore
             if (DataLabelsPaint is not null)
             {
                 cartesianChart.Canvas.AddDrawableTask(DataLabelsPaint);
-                DataLabelsPaint.SetClipRectangle(cartesianChart.Canvas, new RectangleF(drawLocation, drawMarginSize));
+                DataLabelsPaint.SetClipRectangle(cartesianChart.Canvas, new LvcRectangle(drawLocation, drawMarginSize));
                 DataLabelsPaint.ZIndex = actualZIndex + 0.5;
             }
 

--- a/src/LiveChartsCore/StrokeAndFillCartesianSeries.cs
+++ b/src/LiveChartsCore/StrokeAndFillCartesianSeries.cs
@@ -34,10 +34,11 @@ namespace LiveChartsCore
     /// <typeparam name="TVisual">The type of the visual.</typeparam>
     /// <typeparam name="TLabel">The type of the label.</typeparam>
     /// <typeparam name="TDrawingContext">The type of the drawing context.</typeparam>
-    public abstract class StrokeAndFillCartesianSeries<TModel, TVisual, TLabel, TDrawingContext> : CartesianSeries<TModel, TVisual, TLabel, TDrawingContext>
-        where TDrawingContext : DrawingContext
-        where TVisual : class, IVisualChartPoint<TDrawingContext>, new()
-        where TLabel : class, ILabelGeometry<TDrawingContext>, new()
+    public abstract class StrokeAndFillCartesianSeries<TModel, TVisual, TLabel, TDrawingContext>
+        : CartesianSeries<TModel, TVisual, TLabel, TDrawingContext>
+            where TDrawingContext : DrawingContext
+            where TVisual : class, IVisualChartPoint<TDrawingContext>, new()
+            where TLabel : class, ILabelGeometry<TDrawingContext>, new()
     {
         private IPaint<TDrawingContext>? _stroke = null;
         private IPaint<TDrawingContext>? _fill = null;

--- a/src/LiveChartsCore/Themes/ColorPalletes.cs
+++ b/src/LiveChartsCore/Themes/ColorPalletes.cs
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Drawing;
+using LiveChartsCore.Drawing;
 
 namespace LiveChartsCore.Themes
 {
@@ -35,7 +35,7 @@ namespace LiveChartsCore.Themes
         /// <value>
         /// The fluent design.
         /// </value>
-        public static Color[] FluentDesign => new Color[]
+        public static LvcColor[] FluentDesign => new LvcColor[]
         {
             RGB(116,77,169),
             RGB(231,72,86),
@@ -54,7 +54,7 @@ namespace LiveChartsCore.Themes
         /// <value>
         /// The material design500.
         /// </value>
-        public static Color[] MaterialDesign500 => new Color[]
+        public static LvcColor[] MaterialDesign500 => new LvcColor[]
         {
             RGB(33,150,243),    // blue
             RGB(244,67,54),     // red
@@ -73,7 +73,7 @@ namespace LiveChartsCore.Themes
         /// <value>
         /// The material design200.
         /// </value>
-        public static Color[] MaterialDesign200 => new Color[]
+        public static LvcColor[] MaterialDesign200 => new LvcColor[]
         {
             RGB(144,202,249),   // blue
             RGB(239,154,154),   // red
@@ -92,7 +92,7 @@ namespace LiveChartsCore.Themes
         /// <value>
         /// The material design800.
         /// </value>
-        public static Color[] MaterialDesign800 => new Color[]
+        public static LvcColor[] MaterialDesign800 => new LvcColor[]
         {
             RGB(21,101,192),    // blue
             RGB(198,40,40),     // red
@@ -105,9 +105,9 @@ namespace LiveChartsCore.Themes
             RGB(55,71,79),      // blue gray
         };
 
-        private static Color RGB(byte r, byte g, byte b)
+        private static LvcColor RGB(byte r, byte g, byte b)
         {
-            return Color.FromArgb(255, r, g, b);
+            return LvcColor.FromArgb(255, r, g, b);
         }
     }
 }

--- a/src/LiveChartsCore/Themes/Theme.cs
+++ b/src/LiveChartsCore/Themes/Theme.cs
@@ -23,7 +23,6 @@
 using LiveChartsCore.Drawing;
 using LiveChartsCore.Kernel.Sketches;
 using System;
-using System.Drawing;
 
 namespace LiveChartsCore.Themes
 {
@@ -42,7 +41,7 @@ namespace LiveChartsCore.Themes
         /// <value>
         /// The current colors.
         /// </value>
-        public Color[]? CurrentColors { get; private set; }
+        public LvcColor[]? CurrentColors { get; private set; }
 
         /// <summary>
         /// Gets the style.
@@ -62,7 +61,7 @@ namespace LiveChartsCore.Themes
         /// <value>
         /// The series default resolver.
         /// </value>
-        public Action<Color[], IChartSeries<TDrawingContext>, bool>? SeriesDefaultsResolver { get; set; }
+        public Action<LvcColor[], IChartSeries<TDrawingContext>, bool>? SeriesDefaultsResolver { get; set; }
 
         /// <summary>
         /// Gets or sets the plane default resolver.
@@ -77,7 +76,7 @@ namespace LiveChartsCore.Themes
         /// </summary>
         /// <param name="colors">The colors.</param>
         /// <returns>The current theme instance</returns>
-        public Theme<TDrawingContext> WithColors(params Color[] colors)
+        public Theme<TDrawingContext> WithColors(params LvcColor[] colors)
         {
             CurrentColors = colors;
             return this;
@@ -99,7 +98,7 @@ namespace LiveChartsCore.Themes
         /// </summary>
         /// <param name="resolver">The resolver.</param>
         /// <returns></returns>
-        public Theme<TDrawingContext> WithSeriesDefaultsResolver(Action<Color[], IChartSeries<TDrawingContext>, bool> resolver)
+        public Theme<TDrawingContext> WithSeriesDefaultsResolver(Action<LvcColor[], IChartSeries<TDrawingContext>, bool> resolver)
         {
             SeriesDefaultsResolver = resolver;
             return this;
@@ -133,7 +132,7 @@ namespace LiveChartsCore.Themes
         /// <param name="colors">The colors.</param>
         /// <param name="series">The series.</param>
         /// <param name="forceApply">Forces the apply of the theme.</param>
-        public virtual void ResolveSeriesDefaults(Color[] colors, IChartSeries<TDrawingContext> series, bool forceApply)
+        public virtual void ResolveSeriesDefaults(LvcColor[] colors, IChartSeries<TDrawingContext> series, bool forceApply)
         {
             SeriesDefaultsResolver?.Invoke(colors, series, forceApply);
         }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/CartesianChart.axaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/CartesianChart.axaml.cs
@@ -765,8 +765,8 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
             {
                 var canvas = this.FindControl<MotionCanvas>("canvas");
                 var color = Background is not ISolidColorBrush b
-                    ? new System.Drawing.Color()
-                    : System.Drawing.Color.FromArgb(b.Color.A, b.Color.R, b.Color.G, b.Color.B);
+                    ? new LvcColor()
+                    :  LvcColor.FromArgb(b.Color.A, b.Color.R, b.Color.G, b.Color.B);
                 canvas.BackColor = new SkiaSharp.SKColor(color.R, color.G, color.B, color.A);
             }
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/CartesianChart.axaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/CartesianChart.axaml.cs
@@ -32,10 +32,8 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
-using System.Drawing;
 using System.Collections.ObjectModel;
 using Avalonia.Media;
-using A = Avalonia;
 using Avalonia.Input;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml.Templates;
@@ -83,7 +81,7 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
 
             // workaround to detect mouse events.
             // Avalonia do not seem to detect pointer events if background is not set.
-            ((IChartView)this).BackColor = System.Drawing.Color.FromArgb(0, 0, 0, 0);
+            ((IChartView)this).BackColor = LvcColor.FromArgb(0, 0, 0, 0);
 
             if (!LiveCharts.IsConfigured) LiveCharts.Configure(LiveChartsSkiaSharp.DefaultPlatformBuilder);
 
@@ -209,9 +207,9 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
         /// <summary>
         /// The tool tip font family property
         /// </summary>
-        public static readonly AvaloniaProperty<A.Media.FontFamily> TooltipFontFamilyProperty =
-            AvaloniaProperty.Register<CartesianChart, A.Media.FontFamily>(
-                nameof(TooltipFontFamily), new A.Media.FontFamily("Arial"), inherits: true);
+        public static readonly AvaloniaProperty<FontFamily> TooltipFontFamilyProperty =
+            AvaloniaProperty.Register<CartesianChart, FontFamily>(
+                nameof(TooltipFontFamily), new FontFamily("Arial"), inherits: true);
 
         /// <summary>
         /// The tool tip font size property
@@ -228,23 +226,23 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
         /// <summary>
         /// The tool tip font style property
         /// </summary>
-        public static readonly AvaloniaProperty<A.Media.FontStyle> TooltipFontStyleProperty =
-            AvaloniaProperty.Register<CartesianChart, A.Media.FontStyle>(
-                nameof(TooltipFontStyle), A.Media.FontStyle.Normal, inherits: true);
+        public static readonly AvaloniaProperty<FontStyle> TooltipFontStyleProperty =
+            AvaloniaProperty.Register<CartesianChart, FontStyle>(
+                nameof(TooltipFontStyle), FontStyle.Normal, inherits: true);
 
         /// <summary>
         /// The tool tip text brush property
         /// </summary>
         public static readonly AvaloniaProperty<SolidColorBrush> TooltipTextBrushProperty =
             AvaloniaProperty.Register<CartesianChart, SolidColorBrush>(
-                nameof(TooltipTextBrush), new SolidColorBrush(new A.Media.Color(255, 35, 35, 35)), inherits: true);
+                nameof(TooltipTextBrush), new SolidColorBrush(new Color(255, 35, 35, 35)), inherits: true);
 
         /// <summary>
         /// The tool tip background property
         /// </summary>
         public static readonly AvaloniaProperty<IBrush> TooltipBackgroundProperty =
             AvaloniaProperty.Register<CartesianChart, IBrush>(nameof(TooltipBackground),
-                new SolidColorBrush(new A.Media.Color(255, 250, 250, 250)), inherits: true);
+                new SolidColorBrush(new Color(255, 250, 250, 250)), inherits: true);
 
         /// <summary>
         /// The legend position property
@@ -269,9 +267,9 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
         /// <summary>
         /// The legend font family property
         /// </summary>
-        public static readonly AvaloniaProperty<A.Media.FontFamily> LegendFontFamilyProperty =
-           AvaloniaProperty.Register<CartesianChart, A.Media.FontFamily>(
-               nameof(LegendFontFamily), new A.Media.FontFamily("Arial"), inherits: true);
+        public static readonly AvaloniaProperty<FontFamily> LegendFontFamilyProperty =
+           AvaloniaProperty.Register<CartesianChart, FontFamily>(
+               nameof(LegendFontFamily), new FontFamily("Arial"), inherits: true);
 
         /// <summary>
         /// The legend font size property
@@ -288,23 +286,23 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
         /// <summary>
         /// The legend font style property
         /// </summary>
-        public static readonly AvaloniaProperty<A.Media.FontStyle> LegendFontStyleProperty =
-            AvaloniaProperty.Register<CartesianChart, A.Media.FontStyle>(
-                nameof(LegendFontStyle), A.Media.FontStyle.Normal, inherits: true);
+        public static readonly AvaloniaProperty<FontStyle> LegendFontStyleProperty =
+            AvaloniaProperty.Register<CartesianChart, FontStyle>(
+                nameof(LegendFontStyle), FontStyle.Normal, inherits: true);
 
         /// <summary>
         /// The legend text brush property
         /// </summary>
         public static readonly AvaloniaProperty<SolidColorBrush> LegendTextBrushProperty =
             AvaloniaProperty.Register<CartesianChart, SolidColorBrush>(
-                nameof(LegendTextBrush), new SolidColorBrush(new A.Media.Color(255, 35, 35, 35)), inherits: true);
+                nameof(LegendTextBrush), new SolidColorBrush(new Color(255, 35, 35, 35)), inherits: true);
 
         /// <summary>
         /// The legend background property
         /// </summary>
         public static readonly AvaloniaProperty<IBrush> LegendBackgroundProperty =
             AvaloniaProperty.Register<CartesianChart, IBrush>(nameof(LegendBackground),
-                new SolidColorBrush(new A.Media.Color(255, 255, 255, 255)), inherits: true);
+                new SolidColorBrush(new Color(255, 255, 255, 255)), inherits: true);
 
         #endregion
 
@@ -335,20 +333,20 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
         CartesianChart<SkiaSharpDrawingContext> ICartesianChartView<SkiaSharpDrawingContext>.Core =>
             core is null ? throw new Exception("core not found") : (CartesianChart<SkiaSharpDrawingContext>)core;
 
-        System.Drawing.Color IChartView.BackColor
+        LvcColor IChartView.BackColor
         {
             get => Background is not ISolidColorBrush b
-                    ? new System.Drawing.Color()
-                    : System.Drawing.Color.FromArgb(b.Color.A, b.Color.R, b.Color.G, b.Color.B);
+                    ? new LvcColor()
+                    : LvcColor.FromArgb(b.Color.A, b.Color.R, b.Color.G, b.Color.B);
             set
             {
-                Background = new SolidColorBrush(new A.Media.Color(value.R, value.G, value.B, value.A));
+                Background = new SolidColorBrush(new Color(value.R, value.G, value.B, value.A));
                 var canvas = this.FindControl<MotionCanvas>("canvas");
                 canvas.BackColor = new SkiaSharp.SKColor(value.R, value.G, value.B, value.A);
             }
         }
 
-        SizeF IChartView.ControlSize => _avaloniaCanvas is null
+        LvcSize IChartView.ControlSize => _avaloniaCanvas is null
             ? new()
             : new()
             {
@@ -465,9 +463,9 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
         /// <value>
         /// The tool tip font family.
         /// </value>
-        public A.Media.FontFamily TooltipFontFamily
+        public FontFamily TooltipFontFamily
         {
-            get => (A.Media.FontFamily)GetValue(TooltipFontFamilyProperty);
+            get => (FontFamily)GetValue(TooltipFontFamilyProperty);
             set => SetValue(TooltipFontFamilyProperty, value);
         }
 
@@ -501,9 +499,9 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
         /// <value>
         /// The tool tip font style.
         /// </value>
-        public A.Media.FontStyle TooltipFontStyle
+        public FontStyle TooltipFontStyle
         {
-            get => (A.Media.FontStyle)GetValue(TooltipFontStyleProperty);
+            get => (FontStyle)GetValue(TooltipFontStyleProperty);
             set => SetValue(TooltipFontStyleProperty, value);
         }
 
@@ -566,9 +564,9 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
         /// <value>
         /// The legend font family.
         /// </value>
-        public A.Media.FontFamily LegendFontFamily
+        public FontFamily LegendFontFamily
         {
-            get => (A.Media.FontFamily)GetValue(LegendFontFamilyProperty);
+            get => (FontFamily)GetValue(LegendFontFamilyProperty);
             set => SetValue(LegendFontFamilyProperty, value);
         }
 
@@ -602,9 +600,9 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
         /// <value>
         /// The legend font style.
         /// </value>
-        public A.Media.FontStyle LegendFontStyle
+        public FontStyle LegendFontStyle
         {
-            get => (A.Media.FontStyle)GetValue(LegendFontStyleProperty);
+            get => (FontStyle)GetValue(LegendFontStyleProperty);
             set => SetValue(LegendFontStyleProperty, value);
         }
 
@@ -654,8 +652,8 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
 
         #endregion
 
-        /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.ScaleUIPoint(PointF, int, int)" />
-        public double[] ScaleUIPoint(PointF point, int xAxisIndex = 0, int yAxisIndex = 0)
+        /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.ScaleUIPoint(LvcPoint, int, int)" />
+        public double[] ScaleUIPoint(LvcPoint point, int xAxisIndex = 0, int yAxisIndex = 0)
         {
             if (core is null) throw new Exception("core not found");
             var cartesianCore = (CartesianChart<SkiaSharpDrawingContext>)core;
@@ -685,11 +683,11 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
             tooltip.Hide();
         }
 
-        /// <inheritdoc cref="IChartView.SetTooltipStyle(System.Drawing.Color, System.Drawing.Color)"/>
-        public void SetTooltipStyle(System.Drawing.Color background, System.Drawing.Color textColor)
+        /// <inheritdoc cref="IChartView.SetTooltipStyle(LvcColor, LvcColor)"/>
+        public void SetTooltipStyle(LvcColor background, LvcColor textColor)
         {
-            TooltipBackground = new SolidColorBrush(new A.Media.Color(background.A, background.R, background.G, background.B));
-            TooltipTextBrush = new SolidColorBrush(new A.Media.Color(textColor.A, textColor.R, textColor.G, textColor.B));
+            TooltipBackground = new SolidColorBrush(new Color(background.A, background.R, background.G, background.B));
+            TooltipTextBrush = new SolidColorBrush(new Color(textColor.A, textColor.R, textColor.G, textColor.B));
         }
 
         void IChartView.InvokeOnUIThread(Action action)
@@ -801,7 +799,7 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
             var c = (CartesianChart<SkiaSharpDrawingContext>)core;
             var p = e.GetPosition(this);
 
-            c.Zoom(new PointF((float)p.X, (float)p.Y), e.Delta.Y > 0 ? ZoomDirection.ZoomIn : ZoomDirection.ZoomOut);
+            c.Zoom(new LvcPoint((float)p.X, (float)p.Y), e.Delta.Y > 0 ? ZoomDirection.ZoomIn : ZoomDirection.ZoomOut);
         }
 
         private void CartesianChart_PointerPressed(object? sender, PointerPressedEventArgs e)
@@ -809,13 +807,13 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
             if (Application.Current.ApplicationLifetime is not IClassicDesktopStyleApplicationLifetime desktop) return;
             var p = e.GetPosition(this);
             foreach (var w in desktop.Windows) w.PointerReleased += Window_PointerReleased;
-            core?.InvokePointerDown(new PointF((float)p.X, (float)p.Y));
+            core?.InvokePointerDown(new LvcPoint((float)p.X, (float)p.Y));
         }
 
         private void CartesianChart_PointerMoved(object? sender, PointerEventArgs e)
         {
             var p = e.GetPosition(this);
-            core?.InvokePointerMove(new PointF((float)p.X, (float)p.Y));
+            core?.InvokePointerMove(new LvcPoint((float)p.X, (float)p.Y));
         }
 
         private void Window_PointerReleased(object? sender, PointerReleasedEventArgs e)
@@ -823,7 +821,7 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
             if (Application.Current.ApplicationLifetime is not IClassicDesktopStyleApplicationLifetime desktop) return;
             foreach (var w in desktop.Windows) w.PointerReleased -= Window_PointerReleased;
             var p = e.GetPosition(this);
-            core?.InvokePointerUp(new PointF((float)p.X, (float)p.Y));
+            core?.InvokePointerUp(new LvcPoint((float)p.X, (float)p.Y));
         }
 
         private void OnCoreUpdateFinished(IChartView<SkiaSharpDrawingContext> chart)

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/DefaultTooltip.axaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/DefaultTooltip.axaml.cs
@@ -26,6 +26,7 @@ using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 using Avalonia.Markup.Xaml.Templates;
 using Avalonia.Media;
+using LiveChartsCore.Drawing;
 using LiveChartsCore.Kernel;
 using LiveChartsCore.Kernel.Sketches;
 using LiveChartsCore.SkiaSharpView.Drawing;
@@ -146,17 +147,17 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
                 return;
             }
 
-            System.Drawing.PointF? location = null;
+            LvcPoint? location = null;
 
             if (chart is CartesianChart<SkiaSharpDrawingContext> or PolarChart<SkiaSharpDrawingContext>)
             {
                 location = tooltipPoints.GetCartesianTooltipLocation(
-                    chart.TooltipPosition, new System.Drawing.SizeF((float)Bounds.Width, (float)Bounds.Height), chart.ControlSize);
+                    chart.TooltipPosition, new LvcSize((float)Bounds.Width, (float)Bounds.Height), chart.ControlSize);
             }
             if (chart is PieChart<SkiaSharpDrawingContext>)
             {
                 location = tooltipPoints.GetPieTooltipLocation(
-                    chart.TooltipPosition, new System.Drawing.SizeF((float)Bounds.Width, (float)Bounds.Height));
+                    chart.TooltipPosition, new LvcSize((float)Bounds.Width, (float)Bounds.Height));
             }
 
             if (location is null) throw new Exception("location not found");

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/GeoMap.axaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/GeoMap.axaml.cs
@@ -40,7 +40,7 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
     {
         private static GeoJsonFile? s_map = null;
         private int _heatKnownLength = 0;
-        private List<Tuple<double, System.Drawing.Color>> _heatStops = new();
+        private List<Tuple<double, LvcColor>> _heatStops = new();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="GeoMap"/> class.
@@ -111,9 +111,9 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
             set => SetValue(HeatMapProperty, value);
         }
 
-        System.Drawing.Color[] IGeoMap.HeatMap
+        LvcColor[] IGeoMap.HeatMap
         {
-            get => HeatMap.Select(x => System.Drawing.Color.FromArgb(x.A, x.R, x.G, x.B)).ToArray();
+            get => HeatMap.Select(x => LvcColor.FromArgb(x.A, x.R, x.G, x.B)).ToArray();
             set => HeatMap = value.Select(x => new Color(x.A, x.R, x.G, x.B)).ToArray();
         }
 
@@ -131,9 +131,9 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
             set => SetValue(StrokeColorProperty, value);
         }
 
-        System.Drawing.Color IGeoMap.StrokeColor
+        LvcColor IGeoMap.StrokeColor
         {
-            get => System.Drawing.Color.FromArgb(StrokeColor.A, StrokeColor.R, StrokeColor.G, StrokeColor.B);
+            get => LvcColor.FromArgb(StrokeColor.A, StrokeColor.R, StrokeColor.G, StrokeColor.B);
             set => StrokeColor = new Color(value.A, value.R, value.G, value.B);
         }
 
@@ -151,9 +151,9 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
             set => SetValue(FillColorProperty, value);
         }
 
-        System.Drawing.Color IGeoMap.FillColor
+        LvcColor IGeoMap.FillColor
         {
-            get => System.Drawing.Color.FromArgb(FillColor.A, FillColor.R, FillColor.G, FillColor.B);
+            get => LvcColor.FromArgb(FillColor.A, FillColor.R, FillColor.G, FillColor.B);
             set => FillColor = new Color(value.A, value.R, value.G, value.B);
         }
 
@@ -184,10 +184,10 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
             var paint = new SolidColorPaint();
 
             var thickness = (float)StrokeThickness;
-            var stroke = System.Drawing.Color.FromArgb(255, StrokeColor.R, StrokeColor.G, StrokeColor.B);
-            var fill = System.Drawing.Color.FromArgb(255, FillColor.R, FillColor.G, FillColor.B);
+            var stroke = LvcColor.FromArgb(255, StrokeColor.R, StrokeColor.G, StrokeColor.B);
+            var fill = LvcColor.FromArgb(255, FillColor.R, FillColor.G, FillColor.B);
 
-            var hm = HeatMap.Select(x => System.Drawing.Color.FromArgb(x.A, x.R, x.G, x.B)).ToArray();
+            var hm = HeatMap.Select(x => LvcColor.FromArgb(x.A, x.R, x.G, x.B)).ToArray();
 
             if (_heatKnownLength != HeatMap.Length)
             {

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/LiveChartsCore.SkiaSharp.Avalonia.xml
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/LiveChartsCore.SkiaSharp.Avalonia.xml
@@ -694,8 +694,8 @@
             The canvas core.
             </value>
         </member>
-        <member name="M:LiveChartsCore.SkiaSharpView.Avalonia.MotionCanvas.Render(Avalonia.Media.DrawingContext)">
-            <inheritdoc cref="M:LiveChartsCore.SkiaSharpView.Avalonia.MotionCanvas.Render(Avalonia.Media.DrawingContext)" />
+        <member name="M:LiveChartsCore.SkiaSharpView.Avalonia.MotionCanvas.Render(AvaloniDrawingContext)">
+            <inheritdoc cref="M:LiveChartsCore.SkiaSharpView.Avalonia.MotionCanvas.Render(AvaloniDrawingContext)" />
         </member>
         <member name="M:LiveChartsCore.SkiaSharpView.Avalonia.MotionCanvas.OnPropertyChanged``1(Avalonia.AvaloniaPropertyChangedEventArgs{``0})">
             <inheritdoc cref="M:LiveChartsCore.SkiaSharpView.Avalonia.MotionCanvas.OnPropertyChanged``1(Avalonia.AvaloniaPropertyChangedEventArgs{``0})" />

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/LiveChartsCore.SkiaSharpView.Avalonia.xml
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/LiveChartsCore.SkiaSharpView.Avalonia.xml
@@ -714,8 +714,8 @@
             The canvas core.
             </value>
         </member>
-        <member name="M:LiveChartsCore.SkiaSharpView.Avalonia.MotionCanvas.Render(Avalonia.Media.DrawingContext)">
-            <inheritdoc cref="M:LiveChartsCore.SkiaSharpView.Avalonia.MotionCanvas.Render(Avalonia.Media.DrawingContext)" />
+        <member name="M:LiveChartsCore.SkiaSharpView.Avalonia.MotionCanvas.Render(AvaloniDrawingContext)">
+            <inheritdoc cref="M:LiveChartsCore.SkiaSharpView.Avalonia.MotionCanvas.Render(AvaloniDrawingContext)" />
         </member>
         <member name="M:LiveChartsCore.SkiaSharpView.Avalonia.MotionCanvas.OnPropertyChanged``1(Avalonia.AvaloniaPropertyChangedEventArgs{``0})">
             <inheritdoc cref="M:LiveChartsCore.SkiaSharpView.Avalonia.MotionCanvas.OnPropertyChanged``1(Avalonia.AvaloniaPropertyChangedEventArgs{``0})" />

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/PieChart.axaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/PieChart.axaml.cs
@@ -32,11 +32,9 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
-using System.Drawing;
 using System.Collections.ObjectModel;
 using Avalonia.Markup.Xaml.Templates;
 using Avalonia.Media;
-using A = Avalonia;
 using Avalonia.Input;
 using LiveChartsCore.Kernel.Events;
 using LiveChartsCore.Kernel.Sketches;
@@ -175,9 +173,9 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
         /// <summary>
         /// The tool tip font family property
         /// </summary>
-        public static readonly AvaloniaProperty<A.Media.FontFamily> TooltipFontFamilyProperty =
-            AvaloniaProperty.Register<CartesianChart, A.Media.FontFamily>(
-                nameof(TooltipFontFamily), new A.Media.FontFamily("Arial"), inherits: true);
+        public static readonly AvaloniaProperty<FontFamily> TooltipFontFamilyProperty =
+            AvaloniaProperty.Register<CartesianChart, FontFamily>(
+                nameof(TooltipFontFamily), new FontFamily("Arial"), inherits: true);
 
         /// <summary>
         /// The tool tip font size property
@@ -194,23 +192,23 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
         /// <summary>
         /// The tool tip font style property
         /// </summary>
-        public static readonly AvaloniaProperty<A.Media.FontStyle> TooltipFontStyleProperty =
-            AvaloniaProperty.Register<CartesianChart, A.Media.FontStyle>(
-                nameof(TooltipFontStyle), A.Media.FontStyle.Normal, inherits: true);
+        public static readonly AvaloniaProperty<FontStyle> TooltipFontStyleProperty =
+            AvaloniaProperty.Register<CartesianChart, FontStyle>(
+                nameof(TooltipFontStyle), FontStyle.Normal, inherits: true);
 
         /// <summary>
         /// The tool tip text brush property
         /// </summary>
         public static readonly AvaloniaProperty<SolidColorBrush> TooltipTextBrushProperty =
             AvaloniaProperty.Register<CartesianChart, SolidColorBrush>(
-                nameof(TooltipTextBrush), new SolidColorBrush(new A.Media.Color(255, 35, 35, 35)), inherits: true);
+                nameof(TooltipTextBrush), new SolidColorBrush(new Color(255, 35, 35, 35)), inherits: true);
 
         /// <summary>
         /// The tool tip background property
         /// </summary>
         public static readonly AvaloniaProperty<IBrush> TooltipBackgroundProperty =
             AvaloniaProperty.Register<CartesianChart, IBrush>(nameof(TooltipBackground),
-                new SolidColorBrush(new A.Media.Color(255, 250, 250, 250)), inherits: true);
+                new SolidColorBrush(new Color(255, 250, 250, 250)), inherits: true);
 
         /// <summary>
         /// The legend position property
@@ -235,9 +233,9 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
         /// <summary>
         /// The legend font family property
         /// </summary>
-        public static readonly AvaloniaProperty<A.Media.FontFamily> LegendFontFamilyProperty =
-           AvaloniaProperty.Register<CartesianChart, A.Media.FontFamily>(
-               nameof(LegendFontFamily), new A.Media.FontFamily("Arial"), inherits: true);
+        public static readonly AvaloniaProperty<FontFamily> LegendFontFamilyProperty =
+           AvaloniaProperty.Register<CartesianChart, FontFamily>(
+               nameof(LegendFontFamily), new FontFamily("Arial"), inherits: true);
 
         /// <summary>
         /// The legend font size property
@@ -254,23 +252,23 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
         /// <summary>
         /// The legend font style property
         /// </summary>
-        public static readonly AvaloniaProperty<A.Media.FontStyle> LegendFontStyleProperty =
-            AvaloniaProperty.Register<CartesianChart, A.Media.FontStyle>(
-                nameof(LegendFontStyle), A.Media.FontStyle.Normal, inherits: true);
+        public static readonly AvaloniaProperty<FontStyle> LegendFontStyleProperty =
+            AvaloniaProperty.Register<CartesianChart, FontStyle>(
+                nameof(LegendFontStyle), FontStyle.Normal, inherits: true);
 
         /// <summary>
         /// The legend text brush property
         /// </summary>
         public static readonly AvaloniaProperty<SolidColorBrush> LegendTextBrushProperty =
             AvaloniaProperty.Register<CartesianChart, SolidColorBrush>(
-                nameof(LegendTextBrush), new SolidColorBrush(new A.Media.Color(255, 35, 35, 35)), inherits: true);
+                nameof(LegendTextBrush), new SolidColorBrush(new Color(255, 35, 35, 35)), inherits: true);
 
         /// <summary>
         /// The legend background property
         /// </summary>
         public static readonly AvaloniaProperty<IBrush> LegendBackgroundProperty =
             AvaloniaProperty.Register<CartesianChart, IBrush>(nameof(LegendBackground),
-                new SolidColorBrush(new A.Media.Color(255, 255, 255, 255)), inherits: true);
+                new SolidColorBrush(new Color(255, 255, 255, 255)), inherits: true);
 
         #endregion
 
@@ -295,20 +293,20 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
         /// <inheritdoc cref="IChartView.CoreChart" />
         public IChart CoreChart => core ?? throw new Exception("Core not set yet.");
 
-        System.Drawing.Color IChartView.BackColor
+        LvcColor IChartView.BackColor
         {
             get => Background is not ISolidColorBrush b
-                    ? new System.Drawing.Color()
-                    : System.Drawing.Color.FromArgb(b.Color.A, b.Color.R, b.Color.G, b.Color.B);
+                    ? new LvcColor()
+                    : LvcColor.FromArgb(b.Color.A, b.Color.R, b.Color.G, b.Color.B);
             set
             {
-                Background = new SolidColorBrush(new A.Media.Color(value.R, value.G, value.B, value.A));
+                Background = new SolidColorBrush(new Color(value.R, value.G, value.B, value.A));
                 var canvas = this.FindControl<MotionCanvas>("canvas");
                 canvas.BackColor = new SkiaSharp.SKColor(value.R, value.G, value.B, value.A);
             }
         }
 
-        SizeF IChartView.ControlSize => new()
+        LvcSize IChartView.ControlSize => new()
         {
             Width = (float)Bounds.Width,
             Height = (float)Bounds.Height
@@ -400,9 +398,9 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
         /// <value>
         /// The tool tip font family.
         /// </value>
-        public A.Media.FontFamily TooltipFontFamily
+        public FontFamily TooltipFontFamily
         {
-            get => (A.Media.FontFamily)GetValue(TooltipFontFamilyProperty);
+            get => (FontFamily)GetValue(TooltipFontFamilyProperty);
             set => SetValue(TooltipFontFamilyProperty, value);
         }
 
@@ -436,9 +434,9 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
         /// <value>
         /// The tool tip font style.
         /// </value>
-        public A.Media.FontStyle TooltipFontStyle
+        public FontStyle TooltipFontStyle
         {
-            get => (A.Media.FontStyle)GetValue(TooltipFontStyleProperty);
+            get => (FontStyle)GetValue(TooltipFontStyleProperty);
             set => SetValue(TooltipFontStyleProperty, value);
         }
 
@@ -501,9 +499,9 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
         /// <value>
         /// The legend font family.
         /// </value>
-        public A.Media.FontFamily LegendFontFamily
+        public FontFamily LegendFontFamily
         {
-            get => (A.Media.FontFamily)GetValue(LegendFontFamilyProperty);
+            get => (FontFamily)GetValue(LegendFontFamilyProperty);
             set => SetValue(LegendFontFamilyProperty, value);
         }
 
@@ -537,9 +535,9 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
         /// <value>
         /// The legend font style.
         /// </value>
-        public A.Media.FontStyle LegendFontStyle
+        public FontStyle LegendFontStyle
         {
-            get => (A.Media.FontStyle)GetValue(LegendFontStyleProperty);
+            get => (FontStyle)GetValue(LegendFontStyleProperty);
             set => SetValue(LegendFontStyleProperty, value);
         }
 
@@ -612,11 +610,11 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
             tooltip.Hide();
         }
 
-        /// <inheritdoc cref="IChartView.SetTooltipStyle(System.Drawing.Color, System.Drawing.Color)"/>
-        public void SetTooltipStyle(System.Drawing.Color background, System.Drawing.Color textColor)
+        /// <inheritdoc cref="IChartView.SetTooltipStyle(LvcColor, LvcColor)"/>
+        public void SetTooltipStyle(LvcColor background, LvcColor textColor)
         {
-            TooltipBackground = new SolidColorBrush(new A.Media.Color(background.A, background.R, background.G, background.B));
-            TooltipTextBrush = new SolidColorBrush(new A.Media.Color(textColor.A, textColor.R, textColor.G, textColor.B));
+            TooltipBackground = new SolidColorBrush(new Color(background.A, background.R, background.G, background.B));
+            TooltipTextBrush = new SolidColorBrush(new Color(textColor.A, textColor.R, textColor.G, textColor.B));
         }
 
         void IChartView.InvokeOnUIThread(Action action)
@@ -675,8 +673,8 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
             {
                 var canvas = this.FindControl<MotionCanvas>("canvas");
                 var color = Background is not ISolidColorBrush b
-                    ? new System.Drawing.Color()
-                    : System.Drawing.Color.FromArgb(b.Color.A, b.Color.R, b.Color.G, b.Color.B);
+                    ? new LvcColor()
+                    : LvcColor.FromArgb(b.Color.A, b.Color.R, b.Color.G, b.Color.B);
                 canvas.BackColor = new SkiaSharp.SKColor(color.R, color.G, color.B, color.A);
             }
 
@@ -691,7 +689,7 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
         private void CartesianChart_PointerMoved(object? sender, PointerEventArgs e)
         {
             var p = e.GetPosition(this);
-            core?.InvokePointerMove(new PointF((float)p.X, (float)p.Y));
+            core?.InvokePointerMove(new LvcPoint((float)p.X, (float)p.Y));
         }
 
         private void OnCoreUpdateFinished(IChartView<SkiaSharpDrawingContext> chart)

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/PolarChart.axaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/PolarChart.axaml.cs
@@ -684,8 +684,8 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
             {
                 var canvas = this.FindControl<MotionCanvas>("canvas");
                 var color = Background is not ISolidColorBrush b
-                    ? new System.Drawing.Color()
-                    : System.Drawing.Color.FromArgb(b.Color.A, b.Color.R, b.Color.G, b.Color.B);
+                    ? new LvcColor()
+                    : LvcColor.FromArgb(b.Color.A, b.Color.R, b.Color.G, b.Color.B);
                 canvas.BackColor = new SkiaSharp.SKColor(color.R, color.G, color.B, color.A);
             }
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/PolarChart.axaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/PolarChart.axaml.cs
@@ -32,10 +32,8 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
-using System.Drawing;
 using System.Collections.ObjectModel;
 using Avalonia.Media;
-using A = Avalonia;
 using Avalonia.Input;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml.Templates;
@@ -82,7 +80,7 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
 
             // workaround to detect mouse events.
             // Avalonia do not seem to detect pointer events if background is not set.
-            ((IChartView)this).BackColor = System.Drawing.Color.FromArgb(0, 0, 0, 0);
+            ((IChartView)this).BackColor = LvcColor.FromArgb(0, 0, 0, 0);
 
             if (!LiveCharts.IsConfigured) LiveCharts.Configure(LiveChartsSkiaSharp.DefaultPlatformBuilder);
 
@@ -172,9 +170,9 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
         /// <summary>
         /// The tool tip font family property
         /// </summary>
-        public static readonly AvaloniaProperty<A.Media.FontFamily> TooltipFontFamilyProperty =
-            AvaloniaProperty.Register<PolarChart, A.Media.FontFamily>(
-                nameof(TooltipFontFamily), new A.Media.FontFamily("Arial"), inherits: true);
+        public static readonly AvaloniaProperty<FontFamily> TooltipFontFamilyProperty =
+            AvaloniaProperty.Register<PolarChart, FontFamily>(
+                nameof(TooltipFontFamily), new FontFamily("Arial"), inherits: true);
 
         /// <summary>
         /// The tool tip font size property
@@ -191,23 +189,23 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
         /// <summary>
         /// The tool tip font style property
         /// </summary>
-        public static readonly AvaloniaProperty<A.Media.FontStyle> TooltipFontStyleProperty =
-            AvaloniaProperty.Register<PolarChart, A.Media.FontStyle>(
-                nameof(TooltipFontStyle), A.Media.FontStyle.Normal, inherits: true);
+        public static readonly AvaloniaProperty<FontStyle> TooltipFontStyleProperty =
+            AvaloniaProperty.Register<PolarChart, FontStyle>(
+                nameof(TooltipFontStyle), FontStyle.Normal, inherits: true);
 
         /// <summary>
         /// The tool tip text brush property
         /// </summary>
         public static readonly AvaloniaProperty<SolidColorBrush> TooltipTextBrushProperty =
             AvaloniaProperty.Register<PolarChart, SolidColorBrush>(
-                nameof(TooltipTextBrush), new SolidColorBrush(new A.Media.Color(255, 35, 35, 35)), inherits: true);
+                nameof(TooltipTextBrush), new SolidColorBrush(new Color(255, 35, 35, 35)), inherits: true);
 
         /// <summary>
         /// The tool tip background property
         /// </summary>
         public static readonly AvaloniaProperty<IBrush> TooltipBackgroundProperty =
             AvaloniaProperty.Register<PolarChart, IBrush>(nameof(TooltipBackground),
-                new SolidColorBrush(new A.Media.Color(255, 250, 250, 250)), inherits: true);
+                new SolidColorBrush(new Color(255, 250, 250, 250)), inherits: true);
 
         /// <summary>
         /// The legend position property
@@ -232,9 +230,9 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
         /// <summary>
         /// The legend font family property
         /// </summary>
-        public static readonly AvaloniaProperty<A.Media.FontFamily> LegendFontFamilyProperty =
-           AvaloniaProperty.Register<PolarChart, A.Media.FontFamily>(
-               nameof(LegendFontFamily), new A.Media.FontFamily("Arial"), inherits: true);
+        public static readonly AvaloniaProperty<FontFamily> LegendFontFamilyProperty =
+           AvaloniaProperty.Register<PolarChart, FontFamily>(
+               nameof(LegendFontFamily), new FontFamily("Arial"), inherits: true);
 
         /// <summary>
         /// The legend font size property
@@ -251,23 +249,23 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
         /// <summary>
         /// The legend font style property
         /// </summary>
-        public static readonly AvaloniaProperty<A.Media.FontStyle> LegendFontStyleProperty =
-            AvaloniaProperty.Register<PolarChart, A.Media.FontStyle>(
-                nameof(LegendFontStyle), A.Media.FontStyle.Normal, inherits: true);
+        public static readonly AvaloniaProperty<FontStyle> LegendFontStyleProperty =
+            AvaloniaProperty.Register<PolarChart, FontStyle>(
+                nameof(LegendFontStyle), FontStyle.Normal, inherits: true);
 
         /// <summary>
         /// The legend text brush property
         /// </summary>
         public static readonly AvaloniaProperty<SolidColorBrush> LegendTextBrushProperty =
             AvaloniaProperty.Register<PolarChart, SolidColorBrush>(
-                nameof(LegendTextBrush), new SolidColorBrush(new A.Media.Color(255, 35, 35, 35)), inherits: true);
+                nameof(LegendTextBrush), new SolidColorBrush(new Color(255, 35, 35, 35)), inherits: true);
 
         /// <summary>
         /// The legend background property
         /// </summary>
         public static readonly AvaloniaProperty<IBrush> LegendBackgroundProperty =
             AvaloniaProperty.Register<PolarChart, IBrush>(nameof(LegendBackground),
-                new SolidColorBrush(new A.Media.Color(255, 255, 255, 255)), inherits: true);
+                new SolidColorBrush(new Color(255, 255, 255, 255)), inherits: true);
 
         #endregion
 
@@ -298,20 +296,20 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
         PolarChart<SkiaSharpDrawingContext> IPolarChartView<SkiaSharpDrawingContext>.Core =>
             core is null ? throw new Exception("core not found") : (PolarChart<SkiaSharpDrawingContext>)core;
 
-        System.Drawing.Color IChartView.BackColor
+        LvcColor IChartView.BackColor
         {
             get => Background is not ISolidColorBrush b
-                    ? new System.Drawing.Color()
-                    : System.Drawing.Color.FromArgb(b.Color.A, b.Color.R, b.Color.G, b.Color.B);
+                    ? new LvcColor()
+                    : LvcColor.FromArgb(b.Color.A, b.Color.R, b.Color.G, b.Color.B);
             set
             {
-                Background = new SolidColorBrush(new A.Media.Color(value.R, value.G, value.B, value.A));
+                Background = new SolidColorBrush(new Color(value.R, value.G, value.B, value.A));
                 var canvas = this.FindControl<MotionCanvas>("canvas");
                 canvas.BackColor = new SkiaSharp.SKColor(value.R, value.G, value.B, value.A);
             }
         }
 
-        SizeF IChartView.ControlSize => _avaloniaCanvas is null
+        LvcSize IChartView.ControlSize => _avaloniaCanvas is null
             ? new()
             : new()
             {
@@ -389,9 +387,9 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
         /// <value>
         /// The tool tip font family.
         /// </value>
-        public A.Media.FontFamily TooltipFontFamily
+        public FontFamily TooltipFontFamily
         {
-            get => (A.Media.FontFamily)GetValue(TooltipFontFamilyProperty);
+            get => (FontFamily)GetValue(TooltipFontFamilyProperty);
             set => SetValue(TooltipFontFamilyProperty, value);
         }
 
@@ -425,9 +423,9 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
         /// <value>
         /// The tool tip font style.
         /// </value>
-        public A.Media.FontStyle TooltipFontStyle
+        public FontStyle TooltipFontStyle
         {
-            get => (A.Media.FontStyle)GetValue(TooltipFontStyleProperty);
+            get => (FontStyle)GetValue(TooltipFontStyleProperty);
             set => SetValue(TooltipFontStyleProperty, value);
         }
 
@@ -490,9 +488,9 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
         /// <value>
         /// The legend font family.
         /// </value>
-        public A.Media.FontFamily LegendFontFamily
+        public FontFamily LegendFontFamily
         {
-            get => (A.Media.FontFamily)GetValue(LegendFontFamilyProperty);
+            get => (FontFamily)GetValue(LegendFontFamilyProperty);
             set => SetValue(LegendFontFamilyProperty, value);
         }
 
@@ -526,9 +524,9 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
         /// <value>
         /// The legend font style.
         /// </value>
-        public A.Media.FontStyle LegendFontStyle
+        public FontStyle LegendFontStyle
         {
-            get => (A.Media.FontStyle)GetValue(LegendFontStyleProperty);
+            get => (FontStyle)GetValue(LegendFontStyleProperty);
             set => SetValue(LegendFontStyleProperty, value);
         }
 
@@ -578,8 +576,8 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
 
         #endregion
 
-        /// <inheritdoc cref="IPolarChartView{TDrawingContext}.ScaleUIPoint(PointF, int, int)" />
-        public double[] ScaleUIPoint(PointF point, int xAxisIndex = 0, int yAxisIndex = 0)
+        /// <inheritdoc cref="IPolarChartView{TDrawingContext}.ScaleUIPoint(LvcPoint, int, int)" />
+        public double[] ScaleUIPoint(LvcPoint point, int xAxisIndex = 0, int yAxisIndex = 0)
         {
             return new double[0];
             //if (core is null) throw new Exception("core not found");
@@ -610,11 +608,11 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
             tooltip.Hide();
         }
 
-        /// <inheritdoc cref="IChartView.SetTooltipStyle(System.Drawing.Color, System.Drawing.Color)"/>
-        public void SetTooltipStyle(System.Drawing.Color background, System.Drawing.Color textColor)
+        /// <inheritdoc cref="IChartView.SetTooltipStyle(LvcColor, LvcColor)"/>
+        public void SetTooltipStyle(LvcColor background, LvcColor textColor)
         {
-            TooltipBackground = new SolidColorBrush(new A.Media.Color(background.A, background.R, background.G, background.B));
-            TooltipTextBrush = new SolidColorBrush(new A.Media.Color(textColor.A, textColor.R, textColor.G, textColor.B));
+            TooltipBackground = new SolidColorBrush(new Color(background.A, background.R, background.G, background.B));
+            TooltipTextBrush = new SolidColorBrush(new Color(textColor.A, textColor.R, textColor.G, textColor.B));
         }
 
         void IChartView.InvokeOnUIThread(Action action)
@@ -728,13 +726,13 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
             if (Application.Current.ApplicationLifetime is not IClassicDesktopStyleApplicationLifetime desktop) return;
             var p = e.GetPosition(this);
             foreach (var w in desktop.Windows) w.PointerReleased += Window_PointerReleased;
-            core?.InvokePointerDown(new PointF((float)p.X, (float)p.Y));
+            core?.InvokePointerDown(new LvcPoint((float)p.X, (float)p.Y));
         }
 
         private void PolarChart_PointerMoved(object? sender, PointerEventArgs e)
         {
             var p = e.GetPosition(this);
-            core?.InvokePointerMove(new PointF((float)p.X, (float)p.Y));
+            core?.InvokePointerMove(new LvcPoint((float)p.X, (float)p.Y));
         }
 
         private void Window_PointerReleased(object? sender, PointerReleasedEventArgs e)
@@ -742,7 +740,7 @@ namespace LiveChartsCore.SkiaSharpView.Avalonia
             if (Application.Current.ApplicationLifetime is not IClassicDesktopStyleApplicationLifetime desktop) return;
             foreach (var w in desktop.Windows) w.PointerReleased -= Window_PointerReleased;
             var p = e.GetPosition(this);
-            core?.InvokePointerUp(new PointF((float)p.X, (float)p.Y));
+            core?.InvokePointerUp(new LvcPoint((float)p.X, (float)p.Y));
         }
 
         private void OnCoreUpdateFinished(IChartView<SkiaSharpDrawingContext> chart)

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/CartesianChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/CartesianChart.cs
@@ -20,6 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using LiveChartsCore.Drawing;
 using LiveChartsCore.Kernel;
 using LiveChartsCore.Kernel.Sketches;
 using LiveChartsCore.Measure;
@@ -29,7 +30,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
-using System.Drawing;
 using System.Windows;
 
 namespace LiveChartsCore.SkiaSharpView.WPF
@@ -265,8 +265,8 @@ namespace LiveChartsCore.SkiaSharpView.WPF
 
         #endregion
 
-        /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.ScaleUIPoint(PointF, int, int)" />
-        public double[] ScaleUIPoint(PointF point, int xAxisIndex = 0, int yAxisIndex = 0)
+        /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.ScaleUIPoint(LvcPoint, int, int)" />
+        public double[] ScaleUIPoint(LvcPoint point, int xAxisIndex = 0, int yAxisIndex = 0)
         {
             if (core is null) throw new Exception("core not found");
             var cartesianCore = (CartesianChart<SkiaSharpDrawingContext>)core;
@@ -304,20 +304,20 @@ namespace LiveChartsCore.SkiaSharpView.WPF
             if (core is null) throw new Exception("core not found");
             var c = (CartesianChart<SkiaSharpDrawingContext>)core;
             var p = e.GetPosition(this);
-            c.Zoom(new PointF((float)p.X, (float)p.Y), e.Delta > 0 ? ZoomDirection.ZoomIn : ZoomDirection.ZoomOut);
+            c.Zoom(new LvcPoint((float)p.X, (float)p.Y), e.Delta > 0 ? ZoomDirection.ZoomIn : ZoomDirection.ZoomOut);
         }
 
         private void OnMouseDown(object sender, System.Windows.Input.MouseButtonEventArgs e)
         {
             _ = CaptureMouse();
             var p = e.GetPosition(this);
-            core?.InvokePointerDown(new PointF((float)p.X, (float)p.Y));
+            core?.InvokePointerDown(new LvcPoint((float)p.X, (float)p.Y));
         }
 
         private void OnMouseUp(object sender, System.Windows.Input.MouseButtonEventArgs e)
         {
             var p = e.GetPosition(this);
-            core?.InvokePointerUp(new PointF((float)p.X, (float)p.Y));
+            core?.InvokePointerUp(new LvcPoint((float)p.X, (float)p.Y));
             ReleaseMouseCapture();
         }
     }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/Chart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/Chart.cs
@@ -25,14 +25,10 @@ using LiveChartsCore.Drawing;
 using LiveChartsCore.Measure;
 using LiveChartsCore.SkiaSharpView.Drawing;
 using System;
-using System.Drawing;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
 using System.Collections.Generic;
-using Brush = System.Windows.Media.Brush;
-using FontFamily = System.Windows.Media.FontFamily;
-using FontStyle = System.Windows.FontStyle;
 using LiveChartsCore.Kernel.Events;
 using LiveChartsCore.Kernel.Sketches;
 using System.ComponentModel;
@@ -295,12 +291,12 @@ namespace LiveChartsCore.SkiaSharpView.WPF
         /// <inheritdoc cref="IChartView.CoreChart" />
         public IChart CoreChart => core ?? throw new Exception("Core not set yet.");
 
-        System.Drawing.Color IChartView.BackColor
+        LvcColor IChartView.BackColor
         {
             get => Background is not SolidColorBrush b
-                    ? new System.Drawing.Color()
-                    : System.Drawing.Color.FromArgb(b.Color.A, b.Color.R, b.Color.G, b.Color.B);
-            set => SetValueOrCurrentValue(BackgroundProperty, new SolidColorBrush(System.Windows.Media.Color.FromArgb(value.A, value.R, value.G, value.B)));
+                ? new LvcColor()
+                : LvcColor.FromArgb(b.Color.A, b.Color.R, b.Color.G, b.Color.B);
+            set => SetValueOrCurrentValue(BackgroundProperty, new SolidColorBrush(Color.FromArgb(value.A, value.R, value.G, value.B)));
         }
 
         /// <inheritdoc cref="IChartView.SyncContext" />
@@ -323,9 +319,9 @@ namespace LiveChartsCore.SkiaSharpView.WPF
             set => SetValueOrCurrentValue(DrawMarginProperty, value);
         }
 
-        SizeF IChartView.ControlSize => canvas is null
-                    ? throw new Exception("Canvas not found")
-                    : (new() { Width = (float)canvas.ActualWidth, Height = (float)canvas.ActualHeight });
+        LvcSize IChartView.ControlSize => canvas is null
+            ? throw new Exception("Canvas not found")
+            : (new() { Width = (float)canvas.ActualWidth, Height = (float)canvas.ActualHeight });
 
         /// <inheritdoc cref="IChartView{TDrawingContext}.CoreCanvas" />
         public MotionCanvas<SkiaSharpDrawingContext> CoreCanvas => canvas is null ? throw new Exception("Canvas not found") : canvas.CanvasCore;
@@ -658,11 +654,11 @@ namespace LiveChartsCore.SkiaSharpView.WPF
             tooltip.Hide();
         }
 
-        /// <inheritdoc cref="IChartView.SetTooltipStyle(System.Drawing.Color, System.Drawing.Color)"/>
-        public void SetTooltipStyle(System.Drawing.Color background, System.Drawing.Color textColor)
+        /// <inheritdoc cref="IChartView.SetTooltipStyle(LvcColor, LvcColor)"/>
+        public void SetTooltipStyle(LvcColor background, LvcColor textColor)
         {
-            TooltipBackground = new SolidColorBrush(System.Windows.Media.Color.FromArgb(background.A, background.R, background.G, background.B));
-            TooltipTextBrush = new SolidColorBrush(System.Windows.Media.Color.FromArgb(textColor.A, textColor.R, textColor.G, textColor.B));
+            TooltipBackground = new SolidColorBrush(Color.FromArgb(background.A, background.R, background.G, background.B));
+            TooltipTextBrush = new SolidColorBrush(Color.FromArgb(textColor.A, textColor.R, textColor.G, textColor.B));
         }
 
         void IChartView.InvokeOnUIThread(Action action)
@@ -707,7 +703,7 @@ namespace LiveChartsCore.SkiaSharpView.WPF
         private void OnMouseMove(object sender, System.Windows.Input.MouseEventArgs e)
         {
             var p = e.GetPosition(this);
-            core?.InvokePointerMove(new PointF((float)p.X, (float)p.Y));
+            core?.InvokePointerMove(new LvcPoint((float)p.X, (float)p.Y));
         }
 
         private void OnCoreUpdateFinished(IChartView<SkiaSharpDrawingContext> chart)

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/DefaultTooltip.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/DefaultTooltip.xaml.cs
@@ -20,6 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using LiveChartsCore.Drawing;
 using LiveChartsCore.Kernel;
 using LiveChartsCore.Kernel.Sketches;
 using LiveChartsCore.SkiaSharpView.Drawing;
@@ -263,17 +264,17 @@ namespace LiveChartsCore.SkiaSharpView.WPF
                 return;
             }
 
-            System.Drawing.PointF? location = null;
+            LvcPoint? location = null;
 
             if (chart is CartesianChart<SkiaSharpDrawingContext> or PolarChart<SkiaSharpDrawingContext>)
             {
                 location = tooltipPoints.GetCartesianTooltipLocation(
-                    chart.TooltipPosition, new System.Drawing.SizeF((float)border.ActualWidth, (float)border.ActualHeight), chart.ControlSize);
+                    chart.TooltipPosition, new LvcSize((float)border.ActualWidth, (float)border.ActualHeight), chart.ControlSize);
             }
             if (chart is PieChart<SkiaSharpDrawingContext>)
             {
                 location = tooltipPoints.GetPieTooltipLocation(
-                    chart.TooltipPosition, new System.Drawing.SizeF((float)border.ActualWidth, (float)border.ActualHeight));
+                    chart.TooltipPosition, new LvcSize((float)border.ActualWidth, (float)border.ActualHeight));
             }
 
             if (location is null) throw new Exception("location not supported");

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/GeoMap.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/GeoMap.cs
@@ -41,7 +41,7 @@ namespace LiveChartsCore.SkiaSharpView.WPF
     {
         private static GeoJsonFile? s_map = null;
         private int _heatKnownLength = 0;
-        private List<Tuple<double, System.Drawing.Color>> _heatStops = new();
+        private List<Tuple<double, LvcColor>> _heatStops = new();
 
         static GeoMap()
         {
@@ -93,7 +93,8 @@ namespace LiveChartsCore.SkiaSharpView.WPF
         /// </summary>
         public static readonly DependencyProperty StrokeColorProperty =
             DependencyProperty.Register(
-                nameof(StrokeColor), typeof(System.Windows.Media.Color), typeof(GeoMap), new PropertyMetadata(System.Windows.Media.Color.FromRgb(224, 224, 224)));
+                nameof(StrokeColor), typeof(System.Windows.Media.Color), typeof(GeoMap),
+                new PropertyMetadata(System.Windows.Media.Color.FromRgb(224, 224, 224)));
 
         /// <summary>
         /// The stroke thickness property
@@ -106,7 +107,8 @@ namespace LiveChartsCore.SkiaSharpView.WPF
         /// </summary>
         public static readonly DependencyProperty FillColorProperty =
             DependencyProperty.Register(
-                nameof(FillColor), typeof(System.Windows.Media.Color), typeof(GeoMap), new PropertyMetadata(System.Windows.Media.Color.FromRgb(250, 250, 250)));
+                nameof(FillColor), typeof(System.Windows.Media.Color), typeof(GeoMap),
+                new PropertyMetadata(System.Windows.Media.Color.FromRgb(250, 250, 250)));
 
         /// <summary>
         /// Gets or sets the projection.
@@ -126,9 +128,9 @@ namespace LiveChartsCore.SkiaSharpView.WPF
             set => SetValue(HeatMapProperty, value);
         }
 
-        System.Drawing.Color[] IGeoMap.HeatMap
+        LvcColor[] IGeoMap.HeatMap
         {
-            get => HeatMap.Select(x => System.Drawing.Color.FromArgb(x.A, x.R, x.G, x.B)).ToArray();
+            get => HeatMap.Select(x => LvcColor.FromArgb(x.A, x.R, x.G, x.B)).ToArray();
             set => HeatMap = value.Select(x => System.Windows.Media.Color.FromArgb(x.A, x.R, x.G, x.B)).ToArray();
         }
 
@@ -150,9 +152,9 @@ namespace LiveChartsCore.SkiaSharpView.WPF
             set => SetValue(StrokeColorProperty, value);
         }
 
-        System.Drawing.Color IGeoMap.StrokeColor
+        LvcColor IGeoMap.StrokeColor
         {
-            get => System.Drawing.Color.FromArgb(StrokeColor.A, StrokeColor.R, StrokeColor.G, StrokeColor.B);
+            get => LvcColor.FromArgb(StrokeColor.A, StrokeColor.R, StrokeColor.G, StrokeColor.B);
             set => StrokeColor = System.Windows.Media.Color.FromArgb(value.A, value.R, value.G, value.B);
         }
 
@@ -174,9 +176,9 @@ namespace LiveChartsCore.SkiaSharpView.WPF
             set => SetValue(FillColorProperty, value);
         }
 
-        System.Drawing.Color IGeoMap.FillColor
+        LvcColor IGeoMap.FillColor
         {
-            get => System.Drawing.Color.FromArgb(FillColor.A, FillColor.R, FillColor.G, FillColor.B);
+            get => LvcColor.FromArgb(FillColor.A, FillColor.R, FillColor.G, FillColor.B);
             set => FillColor = System.Windows.Media.Color.FromArgb(value.A, value.R, value.G, value.B);
         }
 
@@ -199,10 +201,10 @@ namespace LiveChartsCore.SkiaSharpView.WPF
             var paint = new SolidColorPaint();
 
             var thickness = (float)StrokeThickness;
-            var stroke = System.Drawing.Color.FromArgb(255, StrokeColor.R, StrokeColor.G, StrokeColor.B);
-            var fill = System.Drawing.Color.FromArgb(255, FillColor.R, FillColor.G, FillColor.B);
+            var stroke = LvcColor.FromArgb(255, StrokeColor.R, StrokeColor.G, StrokeColor.B);
+            var fill = LvcColor.FromArgb(255, FillColor.R, FillColor.G, FillColor.B);
 
-            var hm = HeatMap.Select(x => System.Drawing.Color.FromArgb(x.A, x.R, x.G, x.B)).ToArray();
+            var hm = HeatMap.Select(x => LvcColor.FromArgb(x.A, x.R, x.G, x.B)).ToArray();
 
             if (_heatKnownLength != HeatMap.Length)
             {

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/PolarChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/PolarChart.cs
@@ -20,6 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using LiveChartsCore.Drawing;
 using LiveChartsCore.Kernel;
 using LiveChartsCore.Kernel.Sketches;
 using LiveChartsCore.SkiaSharpView.Drawing;
@@ -28,7 +29,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
-using System.Drawing;
 using System.Windows;
 
 namespace LiveChartsCore.SkiaSharpView.WPF
@@ -162,8 +162,8 @@ namespace LiveChartsCore.SkiaSharpView.WPF
 
         #endregion
 
-        /// <inheritdoc cref="IPolarChartView{TDrawingContext}.ScaleUIPoint(PointF, int, int)" />
-        public double[] ScaleUIPoint(PointF point, int xAxisIndex = 0, int yAxisIndex = 0)
+        /// <inheritdoc cref="IPolarChartView{TDrawingContext}.ScaleUIPoint(LvcPoint, int, int)" />
+        public double[] ScaleUIPoint(LvcPoint point, int xAxisIndex = 0, int yAxisIndex = 0)
         {
             return new double[0];
 
@@ -210,13 +210,13 @@ namespace LiveChartsCore.SkiaSharpView.WPF
         {
             _ = CaptureMouse();
             var p = e.GetPosition(this);
-            core?.InvokePointerDown(new PointF((float)p.X, (float)p.Y));
+            core?.InvokePointerDown(new LvcPoint((float)p.X, (float)p.Y));
         }
 
         private void OnMouseUp(object sender, System.Windows.Input.MouseButtonEventArgs e)
         {
             var p = e.GetPosition(this);
-            core?.InvokePointerUp(new PointF((float)p.X, (float)p.Y));
+            core?.InvokePointerUp(new LvcPoint((float)p.X, (float)p.Y));
             ReleaseMouseCapture();
         }
     }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WinForms/CartesianChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WinForms/CartesianChart.cs
@@ -20,6 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using LiveChartsCore.Drawing;
 using LiveChartsCore.Kernel;
 using LiveChartsCore.Kernel.Sketches;
 using LiveChartsCore.Measure;
@@ -29,7 +30,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
-using System.Drawing;
 using System.Windows.Forms;
 
 namespace LiveChartsCore.SkiaSharpView.WinForms
@@ -172,8 +172,8 @@ namespace LiveChartsCore.SkiaSharpView.WinForms
             core.Update();
         }
 
-        /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.ScaleUIPoint(PointF, int, int)" />
-        public double[] ScaleUIPoint(PointF point, int xAxisIndex = 0, int yAxisIndex = 0)
+        /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.ScaleUIPoint(LvcPoint, int, int)" />
+        public double[] ScaleUIPoint(LvcPoint point, int xAxisIndex = 0, int yAxisIndex = 0)
         {
             if (core is null) throw new Exception("core not found");
             var cartesianCore = (CartesianChart<SkiaSharpDrawingContext>)core;
@@ -195,18 +195,18 @@ namespace LiveChartsCore.SkiaSharpView.WinForms
             if (core is null) throw new Exception("core not found");
             var c = (CartesianChart<SkiaSharpDrawingContext>)core;
             var p = e.Location;
-            c.Zoom(new PointF(p.X, p.Y), e.Delta > 0 ? ZoomDirection.ZoomIn : ZoomDirection.ZoomOut);
+            c.Zoom(new LvcPoint(p.X, p.Y), e.Delta > 0 ? ZoomDirection.ZoomIn : ZoomDirection.ZoomOut);
             Capture = true;
         }
 
         private void OnMouseDown(object? sender, MouseEventArgs e)
         {
-            core?.InvokePointerDown(new PointF(e.Location.X, e.Location.Y));
+            core?.InvokePointerDown(new LvcPoint(e.Location.X, e.Location.Y));
         }
 
         private void OnMouseUp(object? sender, MouseEventArgs e)
         {
-            core?.InvokePointerUp(new PointF(e.Location.X, e.Location.Y));
+            core?.InvokePointerUp(new LvcPoint(e.Location.X, e.Location.Y));
         }
     }
 }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WinForms/Chart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WinForms/Chart.cs
@@ -142,19 +142,19 @@ namespace LiveChartsCore.SkiaSharpView.WinForms
         public IChart CoreChart => core ?? throw new Exception("Core not set yet.");
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        Color IChartView.BackColor
+        LvcColor IChartView.BackColor
         {
-            get => BackColor;
-            set => BackColor = value;
+            get => new(BackColor.R, BackColor.G, BackColor.B, BackColor.A);
+            set => BackColor = Color.FromArgb(value.A, value.R, value.G, value.B);
         }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        SizeF IChartView.ControlSize =>
-                // return the full control size as a workaround when the legend is not set.
-                // for some reason WinForms has not loaded the correct size at this point when the control loads.
-                LegendPosition == LegendPosition.Hidden
-                    ? new SizeF() { Width = ClientSize.Width, Height = ClientSize.Height }
-                    : new SizeF() { Width = motionCanvas.Width, Height = motionCanvas.Height };
+        LvcSize IChartView.ControlSize =>
+            // return the full control size as a workaround when the legend is not set.
+            // for some reason WinForms has not loaded the correct size at this point when the control loads.
+            LegendPosition == LegendPosition.Hidden
+                ? new LvcSize() { Width = ClientSize.Width, Height = ClientSize.Height }
+                : new LvcSize() { Width = motionCanvas.Width, Height = motionCanvas.Height };
 
         /// <inheritdoc cref="IChartView{TDrawingContext}.CoreCanvas" />
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
@@ -295,11 +295,11 @@ namespace LiveChartsCore.SkiaSharpView.WinForms
             tooltip.Hide();
         }
 
-        /// <inheritdoc cref="IChartView.SetTooltipStyle(Color, Color)"/>
-        public void SetTooltipStyle(Color background, Color textColor)
+        /// <inheritdoc cref="IChartView.SetTooltipStyle(LvcColor, LvcColor)"/>
+        public void SetTooltipStyle(LvcColor background, LvcColor textColor)
         {
-            TooltipBackColor = background;
-            TooltipTextColor = textColor;
+            TooltipBackColor = Color.FromArgb(background.A, background.R, background.G, background.B);
+            TooltipTextColor = Color.FromArgb(textColor.A, textColor.R, textColor.G, textColor.B);
         }
 
         void IChartView.InvokeOnUIThread(Action action)
@@ -351,7 +351,7 @@ namespace LiveChartsCore.SkiaSharpView.WinForms
 
         private void OnMouseMove(object? sender, MouseEventArgs e)
         {
-            core?.InvokePointerMove(new PointF(e.Location.X, e.Location.Y));
+            core?.InvokePointerMove(new LvcPoint(e.Location.X, e.Location.Y));
         }
 
         private void OnCoreUpdateFinished(IChartView<SkiaSharpDrawingContext> chart)

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WinForms/DefaultTooltip.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WinForms/DefaultTooltip.cs
@@ -20,6 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using LiveChartsCore.Drawing;
 using LiveChartsCore.Kernel;
 using LiveChartsCore.Kernel.Sketches;
 using LiveChartsCore.SkiaSharpView.Drawing;
@@ -64,17 +65,17 @@ namespace LiveChartsCore.SkiaSharpView.WinForms
             if (_activePoints.Count > 0 && tooltipPoints.All(x => _activePoints.ContainsKey(x.Point))) return;
 
             var size = DrawAndMesure(tooltipPoints, wfChart);
-            PointF? location = null;
+            LvcPoint? location = null;
 
             if (chart is CartesianChart<SkiaSharpDrawingContext> or PolarChart<SkiaSharpDrawingContext>)
             {
                 location = tooltipPoints.GetCartesianTooltipLocation(
-                    chart.TooltipPosition, new SizeF((float)size.Width, (float)size.Height), chart.ControlSize);
+                    chart.TooltipPosition, new LvcSize((float)size.Width, (float)size.Height), chart.ControlSize);
             }
             if (chart is PieChart<SkiaSharpDrawingContext>)
             {
                 location = tooltipPoints.GetPieTooltipLocation(
-                    chart.TooltipPosition, new SizeF((float)size.Width, (float)size.Height));
+                    chart.TooltipPosition, new LvcSize((float)size.Width, (float)size.Height));
             }
             if (location is null) throw new Exception("location not supported");
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WinForms/PolarChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WinForms/PolarChart.cs
@@ -20,6 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using LiveChartsCore.Drawing;
 using LiveChartsCore.Kernel;
 using LiveChartsCore.Kernel.Sketches;
 using LiveChartsCore.SkiaSharpView.Drawing;
@@ -28,7 +29,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
-using System.Drawing;
 using System.Windows.Forms;
 
 namespace LiveChartsCore.SkiaSharpView.WinForms
@@ -126,8 +126,8 @@ namespace LiveChartsCore.SkiaSharpView.WinForms
             core.Update();
         }
 
-        /// <inheritdoc cref="IPolarChartView{TDrawingContext}.ScaleUIPoint(PointF, int, int)" />
-        public double[] ScaleUIPoint(PointF point, int xAxisIndex = 0, int yAxisIndex = 0)
+        /// <inheritdoc cref="IPolarChartView{TDrawingContext}.ScaleUIPoint(LvcPoint, int, int)" />
+        public double[] ScaleUIPoint(LvcPoint point, int xAxisIndex = 0, int yAxisIndex = 0)
         {
             return new double[0];
             //if (core is null) throw new Exception("core not found");
@@ -156,12 +156,12 @@ namespace LiveChartsCore.SkiaSharpView.WinForms
 
         private void OnMouseDown(object? sender, MouseEventArgs e)
         {
-            core?.InvokePointerDown(new PointF(e.Location.X, e.Location.Y));
+            core?.InvokePointerDown(new LvcPoint(e.Location.X, e.Location.Y));
         }
 
         private void OnMouseUp(object? sender, MouseEventArgs e)
         {
-            core?.InvokePointerUp(new PointF(e.Location.X, e.Location.Y));
+            core?.InvokePointerUp(new LvcPoint(e.Location.X, e.Location.Y));
         }
     }
 }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/CartesianChart.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/CartesianChart.xaml.cs
@@ -29,7 +29,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
-using System.Drawing;
 using Xamarin.Essentials;
 using Xamarin.Forms.Xaml;
 using Xamarin.Forms;
@@ -113,7 +112,7 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
                 });
 
         /// <summary>
-        /// The series property
+        /// The series property.
         /// </summary>
         public static readonly BindableProperty SeriesProperty =
             BindableProperty.Create(
@@ -145,7 +144,7 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
                 });
 
         /// <summary>
-        /// The y axes property
+        /// The y axes property.
         /// </summary>
         public static readonly BindableProperty YAxesProperty =
             BindableProperty.Create(
@@ -160,6 +159,9 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
                     chart.core.Update();
                 });
 
+        /// <summary>
+        /// The sections property.
+        /// </summary>
         public static readonly BindableProperty SectionsProperty =
             BindableProperty.Create(
                 nameof(Sections), typeof(IEnumerable<Section<SkiaSharpDrawingContext>>), typeof(CartesianChart), new List<Section<SkiaSharpDrawingContext>>(),
@@ -174,7 +176,7 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
                 });
 
         /// <summary>
-        /// The draw margin frame property
+        /// The draw margin frame property.
         /// </summary>
         public static readonly BindableProperty DrawMarginFrameProperty =
             BindableProperty.Create(
@@ -182,14 +184,14 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
                 BindingMode.Default, null, OnBindablePropertyChanged);
 
         /// <summary>
-        /// The draw margin property
+        /// The draw margin property.
         /// </summary>
         public static readonly BindableProperty DrawMarginProperty =
             BindableProperty.Create(
                 nameof(DrawMargin), typeof(Margin), typeof(CartesianChart), null, BindingMode.Default, null, OnBindablePropertyChanged);
 
         /// <summary>
-        /// The zoom mode property
+        /// The zoom mode property.
         /// </summary>
         public static readonly BindableProperty ZoomModeProperty =
             BindableProperty.Create(
@@ -197,7 +199,7 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
                 LiveCharts.CurrentSettings.DefaultZoomMode, BindingMode.Default, null);
 
         /// <summary>
-        /// The zooming speed property
+        /// The zooming speed property.
         /// </summary>
         public static readonly BindableProperty ZoomingSpeedProperty =
             BindableProperty.Create(
@@ -205,14 +207,14 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
                 LiveCharts.CurrentSettings.DefaultZoomSpeed, BindingMode.Default, null);
 
         /// <summary>
-        /// The animations speed property
+        /// The animations speed property.
         /// </summary>
         public static readonly BindableProperty AnimationsSpeedProperty =
            BindableProperty.Create(
                nameof(AnimationsSpeed), typeof(TimeSpan), typeof(CartesianChart), LiveCharts.CurrentSettings.DefaultAnimationsSpeed);
 
         /// <summary>
-        /// The easing function property
+        /// The easing function property.
         /// </summary>
         public static readonly BindableProperty EasingFunctionProperty =
             BindableProperty.Create(
@@ -220,7 +222,7 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
                 LiveCharts.CurrentSettings.DefaultEasingFunction);
 
         /// <summary>
-        /// The legend position property
+        /// The legend position property.
         /// </summary>
         public static readonly BindableProperty LegendPositionProperty =
             BindableProperty.Create(
@@ -228,7 +230,7 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
                 LiveCharts.CurrentSettings.DefaultLegendPosition, propertyChanged: OnBindablePropertyChanged);
 
         /// <summary>
-        /// The legend orientation property
+        /// The legend orientation property.
         /// </summary>
         public static readonly BindableProperty LegendOrientationProperty =
             BindableProperty.Create(
@@ -236,28 +238,28 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
                 LiveCharts.CurrentSettings.DefaultLegendOrientation, propertyChanged: OnBindablePropertyChanged);
 
         /// <summary>
-        /// The legend template property
+        /// The legend template property.
         /// </summary>
         public static readonly BindableProperty LegendTemplateProperty =
             BindableProperty.Create(
                 nameof(LegendTemplate), typeof(DataTemplate), typeof(CartesianChart), null, propertyChanged: OnBindablePropertyChanged);
 
         /// <summary>
-        /// The legend font family property
+        /// The legend font family property.
         /// </summary>
         public static readonly BindableProperty LegendFontFamilyProperty =
             BindableProperty.Create(
                 nameof(LegendFontFamily), typeof(string), typeof(CartesianChart), null, propertyChanged: OnBindablePropertyChanged);
 
         /// <summary>
-        /// The legend font size property
+        /// The legend font size property.
         /// </summary>
         public static readonly BindableProperty LegendFontSizeProperty =
             BindableProperty.Create(
                 nameof(LegendFontSize), typeof(double), typeof(CartesianChart), 13d, propertyChanged: OnBindablePropertyChanged);
 
         /// <summary>
-        /// The legend text color property
+        /// The legend text color property.
         /// </summary>
         public static readonly BindableProperty LegendTextBrushProperty =
             BindableProperty.Create(
@@ -265,7 +267,7 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
                 new c(35 / 255d, 35 / 255d, 35 / 255d), propertyChanged: OnBindablePropertyChanged);
 
         /// <summary>
-        /// The legend background property
+        /// The legend background property.
         /// </summary>
         public static readonly BindableProperty LegendBackgroundProperty =
             BindableProperty.Create(
@@ -273,7 +275,7 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
                 new c(255 / 255d, 255 / 255d, 255 / 255d), propertyChanged: OnBindablePropertyChanged);
 
         /// <summary>
-        /// The legend font attributes property
+        /// The legend font attributes property.
         /// </summary>
         public static readonly BindableProperty LegendFontAttributesProperty =
             BindableProperty.Create(
@@ -281,7 +283,7 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
                 FontAttributes.None, propertyChanged: OnBindablePropertyChanged);
 
         /// <summary>
-        /// The tool tip position property
+        /// The tool tip position property.
         /// </summary>
         public static readonly BindableProperty TooltipPositionProperty =
            BindableProperty.Create(
@@ -289,7 +291,7 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
                LiveCharts.CurrentSettings.DefaultTooltipPosition, propertyChanged: OnBindablePropertyChanged);
 
         /// <summary>
-        /// The too ltip finding strategy property
+        /// The tool tip finding strategy property.
         /// </summary>
         public static readonly BindableProperty TooltipFindingStrategyProperty =
             BindableProperty.Create(
@@ -297,28 +299,28 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
                 LiveCharts.CurrentSettings.DefaultTooltipFindingStrategy);
 
         /// <summary>
-        /// The tool tip template property
+        /// The tool tip template property.
         /// </summary>
         public static readonly BindableProperty TooltipTemplateProperty =
             BindableProperty.Create(
                 nameof(TooltipTemplate), typeof(DataTemplate), typeof(CartesianChart), null, propertyChanged: OnBindablePropertyChanged);
 
         /// <summary>
-        /// The tool tip font family property
+        /// The tool tip font family property.
         /// </summary>
         public static readonly BindableProperty TooltipFontFamilyProperty =
             BindableProperty.Create(
                 nameof(TooltipFontFamily), typeof(string), typeof(CartesianChart), null, propertyChanged: OnBindablePropertyChanged);
 
         /// <summary>
-        /// The tool tip font size property
+        /// The tool tip font size property.
         /// </summary>
         public static readonly BindableProperty TooltipFontSizeProperty =
             BindableProperty.Create(
                 nameof(TooltipFontSize), typeof(double), typeof(CartesianChart), 13d, propertyChanged: OnBindablePropertyChanged);
 
         /// <summary>
-        /// The tool tip text color property
+        /// The tool tip text color property.
         /// </summary>
         public static readonly BindableProperty TooltipTextBrushProperty =
             BindableProperty.Create(
@@ -326,7 +328,7 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
                 new c(35 / 255d, 35 / 255d, 35 / 255d), propertyChanged: OnBindablePropertyChanged);
 
         /// <summary>
-        /// The tool tip background property
+        /// The tool tip background property.
         /// </summary>
         public static readonly BindableProperty TooltipBackgroundProperty =
             BindableProperty.Create(
@@ -364,18 +366,18 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
         /// <inheritdoc cref="IChartView.CoreChart" />
         public IChart CoreChart => core ?? throw new Exception("Core not set yet.");
 
-        System.Drawing.Color IChartView.BackColor
+        LvcColor IChartView.BackColor
         {
             get => Background is not SolidColorBrush b
-                    ? new System.Drawing.Color()
-                    : System.Drawing.Color.FromArgb(
-                        (int)(b.Color.R * 255), (int)(b.Color.G * 255), (int)(b.Color.B * 255), (int)(b.Color.A * 255));
+                ? new LvcColor()
+                : LvcColor.FromArgb(
+                    (byte)(b.Color.R * 255), (byte)(b.Color.G * 255), (byte)(b.Color.B * 255), (byte)(b.Color.A * 255));
             set => Background = new SolidColorBrush(new c(value.R / 255, value.G / 255, value.B / 255, value.A / 255));
         }
 
         CartesianChart<SkiaSharpDrawingContext> ICartesianChartView<SkiaSharpDrawingContext>.Core => core is null ? throw new Exception("core not found") : (CartesianChart<SkiaSharpDrawingContext>)core;
 
-        SizeF IChartView.ControlSize => new()
+        LvcSize IChartView.ControlSize => new()
         {
             Width = (float)(canvas.Width * DeviceDisplay.MainDisplayInfo.Density),
             Height = (float)(canvas.Height * DeviceDisplay.MainDisplayInfo.Density)
@@ -664,8 +666,8 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
 
         #endregion
 
-        /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.ScaleUIPoint(PointF, int, int)" />
-        public double[] ScaleUIPoint(PointF point, int xAxisIndex = 0, int yAxisIndex = 0)
+        /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.ScaleUIPoint(LvcPoint, int, int)" />
+        public double[] ScaleUIPoint(LvcPoint point, int xAxisIndex = 0, int yAxisIndex = 0)
         {
             if (core is null) throw new Exception("core not found");
             var cartesianCore = (CartesianChart<SkiaSharpDrawingContext>)core;
@@ -688,11 +690,11 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
             ((IChartTooltip<SkiaSharpDrawingContext>)tooltip).Hide();
         }
 
-        /// <inheritdoc cref="IChartView.SetTooltipStyle(System.Drawing.Color, System.Drawing.Color)"/>
-        public void SetTooltipStyle(System.Drawing.Color background, System.Drawing.Color textColor)
+        /// <inheritdoc cref="IChartView.SetTooltipStyle(LvcColor, LvcColor)"/>
+        public void SetTooltipStyle(LvcColor background, LvcColor textColor)
         {
-            TooltipBackground = background;
-            TooltipTextBrush = textColor;
+            TooltipBackground = new c(background.R, background.G, background.B, background.A);
+            TooltipTextBrush = new c(textColor.R, textColor.G, textColor.B, textColor.A);
         }
 
         void IChartView.InvokeOnUIThread(Action action)
@@ -757,7 +759,7 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
             if (e.StatusType != GestureStatus.Running) return;
 
             var c = (CartesianChart<SkiaSharpDrawingContext>)core;
-            var delta = new PointF((float)e.TotalX, (float)e.TotalY);
+            var delta = new LvcPoint((float)e.TotalX, (float)e.TotalY);
             var args = new PanGestureEventArgs(delta);
             c.InvokePanGestrue(args);
             if (!args.Handled) c.Pan(delta);
@@ -772,7 +774,7 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
             var s = c.ControlSize;
 
             c.Zoom(
-                new PointF((float)(p.X * s.Width), (float)(p.Y * s.Height)),
+                new LvcPoint((float)(p.X * s.Width), (float)(p.Y * s.Height)),
                 e.Scale > 1 ? ZoomDirection.ZoomIn : ZoomDirection.ZoomOut);
         }
 
@@ -780,7 +782,7 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
         {
             if (core is null) return;
             if (TooltipPosition == TooltipPosition.Hidden) return;
-            var location = new PointF(e.Location.X, e.Location.Y);
+            var location = new LvcPoint(e.Location.X, e.Location.Y);
             core.InvokePointerDown(location);
             ((IChartTooltip<SkiaSharpDrawingContext>)tooltip).Show(core.FindPointsNearTo(location), core);
         }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/DefaultTooltip.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/DefaultTooltip.xaml.cs
@@ -20,6 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using LiveChartsCore.Drawing;
 using LiveChartsCore.Kernel;
 using LiveChartsCore.Kernel.Sketches;
 using LiveChartsCore.SkiaSharpView.Drawing;
@@ -125,7 +126,7 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
 
             Points = tooltipPoints;
 
-            System.Drawing.PointF? location = null;
+            LvcPoint? location = null;
             var size = new Size
             {
                 Width = Width * DeviceDisplay.MainDisplayInfo.Density,
@@ -135,12 +136,12 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
             if (chart is CartesianChart<SkiaSharpDrawingContext> or PolarChart<SkiaSharpDrawingContext>)
             {
                 location = tooltipPoints.GetCartesianTooltipLocation(
-                    chart.TooltipPosition, new System.Drawing.SizeF((float)size.Width, (float)size.Height), chart.ControlSize);
+                    chart.TooltipPosition, new LvcSize((float)size.Width, (float)size.Height), chart.ControlSize);
             }
             if (chart is PieChart<SkiaSharpDrawingContext>)
             {
                 location = tooltipPoints.GetPieTooltipLocation(
-                    chart.TooltipPosition, new System.Drawing.SizeF((float)size.Width, (float)size.Height));
+                    chart.TooltipPosition, new LvcSize((float)size.Width, (float)size.Height));
             }
             if (location is null) throw new Exception("location not supported");
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/GeoMap.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/GeoMap.xaml.cs
@@ -42,7 +42,7 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
     {
         private static GeoJsonFile? s_map = null;
         private int _heatKnownLength = 0;
-        private List<Tuple<double, System.Drawing.Color>> _heatStops = new();
+        private List<Tuple<double, LvcColor>> _heatStops = new();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="GeoMap"/> class.
@@ -125,9 +125,9 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
             set => SetValue(HeatMapProperty, value);
         }
 
-        System.Drawing.Color[] IGeoMap.HeatMap
+        LvcColor[] IGeoMap.HeatMap
         {
-            get => HeatMap.Select(x => System.Drawing.Color.FromArgb((int)(x.A * 255), (int)(x.R * 255), (int)(x.G * 255), (int)(x.B * 255))).ToArray();
+            get => HeatMap.Select(x => LvcColor.FromArgb((byte)(x.A * 255), (byte)(x.R * 255), (byte)(x.G * 255), (byte)(x.B * 255))).ToArray();
             set => HeatMap = value.Select(x => new Color(x.R / 255d, x.G / 255d, x.B / 255d, x.A / 255d)).ToArray();
         }
 
@@ -149,9 +149,9 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
             set => SetValue(StrokeColorProperty, value);
         }
 
-        System.Drawing.Color IGeoMap.StrokeColor
+        LvcColor IGeoMap.StrokeColor
         {
-            get => System.Drawing.Color.FromArgb((int)(StrokeColor.A * 255), (int)(StrokeColor.R * 255), (int)(StrokeColor.G * 255), (int)(StrokeColor.B * 255));
+            get => LvcColor.FromArgb((byte)(StrokeColor.A * 255), (byte)(StrokeColor.R * 255), (byte)(StrokeColor.G * 255), (byte)(StrokeColor.B * 255));
             set => StrokeColor = new Color(value.R / 255d, value.G / 255d, value.B / 255d, value.A / 255d);
         }
 
@@ -173,9 +173,9 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
             set => SetValue(FillColorProperty, value);
         }
 
-        System.Drawing.Color IGeoMap.FillColor
+        LvcColor IGeoMap.FillColor
         {
-            get => System.Drawing.Color.FromArgb((int)(FillColor.A * 255), (int)(FillColor.R * 255), (int)(FillColor.G * 255), (int)(FillColor.B * 255));
+            get => LvcColor.FromArgb((byte)(FillColor.A * 255), (byte)(FillColor.R * 255), (byte)(FillColor.G * 255), (byte)(FillColor.B * 255));
             set => FillColor = new Color(value.R / 255d, value.G / 255d, value.B / 255d, value.A / 255d);
         }
 
@@ -198,10 +198,10 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
             var paint = new SolidColorPaintTask();
 
             var thickness = (float)StrokeThickness;
-            var stroke = System.Drawing.Color.FromArgb(255, (byte)(StrokeColor.R * 255), (byte)(StrokeColor.G * 255), (byte)(StrokeColor.B * 255));
-            var fill = System.Drawing.Color.FromArgb(255, (byte)(FillColor.R * 255), (byte)(FillColor.G * 255), (byte)(FillColor.B * 255));
+            var stroke = LvcColor.FromArgb(255, (byte)(StrokeColor.R * 255), (byte)(StrokeColor.G * 255), (byte)(StrokeColor.B * 255));
+            var fill = LvcColor.FromArgb(255, (byte)(FillColor.R * 255), (byte)(FillColor.G * 255), (byte)(FillColor.B * 255));
 
-            var hm = HeatMap.Select(x => System.Drawing.Color.FromArgb((byte)(255 * x.A), (byte)(255 * x.R), (byte)(255 * x.G), (byte)(255 * x.B))).ToArray();
+            var hm = HeatMap.Select(x => LvcColor.FromArgb((byte)(255 * x.A), (byte)(255 * x.R), (byte)(255 * x.G), (byte)(255 * x.B))).ToArray();
 
             if (_heatKnownLength != HeatMap.Length)
             {

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/PieChart.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/PieChart.xaml.cs
@@ -31,7 +31,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
-using System.Drawing;
 using Xamarin.Essentials;
 using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
@@ -308,12 +307,12 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
         /// <inheritdoc cref="IChartView.CoreChart" />
         public IChart CoreChart => core ?? throw new Exception("Core not set yet.");
 
-        System.Drawing.Color IChartView.BackColor
+        LvcColor IChartView.BackColor
         {
             get => Background is not SolidColorBrush b
-                    ? new System.Drawing.Color()
-                    : System.Drawing.Color.FromArgb(
-                        (int)(b.Color.A * 255), (int)(b.Color.R * 255), (int)(b.Color.G * 255), (int)(b.Color.B * 255));
+                ? new LvcColor()
+                : LvcColor.FromArgb(
+                    (byte)(b.Color.A * 255), (byte)(b.Color.R * 255), (byte)(b.Color.G * 255), (byte)(b.Color.B * 255));
             set => Background = new SolidColorBrush(new c(value.R / 255, value.G / 255, value.B / 255, value.A / 255));
         }
 
@@ -327,7 +326,7 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
             set => SetValue(SyncContextProperty, value);
         }
 
-        SizeF IChartView.ControlSize => new()
+        LvcSize IChartView.ControlSize => new()
         {
             Width = (float)(canvas.Width * DeviceDisplay.MainDisplayInfo.Density),
             Height = (float)(canvas.Height * DeviceDisplay.MainDisplayInfo.Density)
@@ -597,11 +596,11 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
             ((IChartTooltip<SkiaSharpDrawingContext>)tooltip).Hide();
         }
 
-        /// <inheritdoc cref="IChartView.SetTooltipStyle(System.Drawing.Color, System.Drawing.Color)"/>
-        public void SetTooltipStyle(System.Drawing.Color background, System.Drawing.Color textColor)
+        /// <inheritdoc cref="IChartView.SetTooltipStyle(LvcColor, LvcColor)"/>
+        public void SetTooltipStyle(LvcColor background, LvcColor textColor)
         {
-            TooltipBackground = background;
-            TooltipTextBrush = textColor;
+            TooltipBackground = new c(background.R, background.G, background.B, background.A);
+            TooltipTextBrush = new c(textColor.R, textColor.G, textColor.B, textColor.A);
         }
 
         void IChartView.InvokeOnUIThread(Action action)
@@ -652,7 +651,7 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
         {
             if (core is null) return;
             if (TooltipPosition == TooltipPosition.Hidden) return;
-            var location = new PointF(e.Location.X, e.Location.Y);
+            var location = new LvcPoint(e.Location.X, e.Location.Y);
             core.InvokePointerDown(location);
             ((IChartTooltip<SkiaSharpDrawingContext>)tooltip).Show(core.FindPointsNearTo(location), core);
         }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/PolarChart.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/PolarChart.xaml.cs
@@ -29,7 +29,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
-using System.Drawing;
 using Xamarin.Essentials;
 using Xamarin.Forms.Xaml;
 using Xamarin.Forms;
@@ -317,19 +316,19 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
         /// <inheritdoc cref="IChartView.CoreChart" />
         public IChart CoreChart => core ?? throw new Exception("Core not set yet.");
 
-        System.Drawing.Color IChartView.BackColor
+        LvcColor IChartView.BackColor
         {
             get => Background is not SolidColorBrush b
-                    ? new System.Drawing.Color()
-                    : System.Drawing.Color.FromArgb(
-                        (int)(b.Color.R * 255), (int)(b.Color.G * 255), (int)(b.Color.B * 255), (int)(b.Color.A * 255));
+                ? new LvcColor()
+                : LvcColor.FromArgb(
+                    (byte)(b.Color.R * 255), (byte)(b.Color.G * 255), (byte)(b.Color.B * 255), (byte)(b.Color.A * 255));
             set => Background = new SolidColorBrush(new c(value.R / 255, value.G / 255, value.B / 255, value.A / 255));
         }
 
         PolarChart<SkiaSharpDrawingContext> IPolarChartView<SkiaSharpDrawingContext>.Core
             => core is null ? throw new Exception("core not found") : (PolarChart<SkiaSharpDrawingContext>)core;
 
-        SizeF IChartView.ControlSize => new()
+        LvcSize IChartView.ControlSize => new()
         {
             Width = (float)(canvas.Width * DeviceDisplay.MainDisplayInfo.Density),
             Height = (float)(canvas.Height * DeviceDisplay.MainDisplayInfo.Density)
@@ -583,8 +582,8 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
 
         #endregion
 
-        /// <inheritdoc cref="IPolarChartView{TDrawingContext}.ScaleUIPoint(PointF, int, int)" />
-        public double[] ScaleUIPoint(PointF point, int xAxisIndex = 0, int yAxisIndex = 0)
+        /// <inheritdoc cref="IPolarChartView{TDrawingContext}.ScaleUIPoint(LvcPoint, int, int)" />
+        public double[] ScaleUIPoint(LvcPoint point, int xAxisIndex = 0, int yAxisIndex = 0)
         {
             return new double[0];
             //if (core is null) throw new Exception("core not found");
@@ -608,11 +607,11 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
             ((IChartTooltip<SkiaSharpDrawingContext>)tooltip).Hide();
         }
 
-        /// <inheritdoc cref="IChartView.SetTooltipStyle(System.Drawing.Color, System.Drawing.Color)"/>
-        public void SetTooltipStyle(System.Drawing.Color background, System.Drawing.Color textColor)
+        /// <inheritdoc cref="IChartView.SetTooltipStyle(LvcColor, LvcColor)"/>
+        public void SetTooltipStyle(LvcColor background, LvcColor textColor)
         {
-            TooltipBackground = background;
-            TooltipTextBrush = textColor;
+            TooltipBackground = new c(background.R, background.G, background.B, background.A);
+            TooltipTextBrush = new c(textColor.R, textColor.G, textColor.B, textColor.A);
         }
 
         void IChartView.InvokeOnUIThread(Action action)
@@ -700,7 +699,7 @@ namespace LiveChartsCore.SkiaSharpView.Xamarin.Forms
         {
             if (core is null) return;
             if (TooltipPosition == TooltipPosition.Hidden) return;
-            var location = new PointF(e.Location.X, e.Location.Y);
+            var location = new LvcPoint(e.Location.X, e.Location.Y);
             core.InvokePointerDown(location);
             ((IChartTooltip<SkiaSharpDrawingContext>)tooltip).Show(core.FindPointsNearTo(location), core);
         }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/Geometries/CandlestickGeometry.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/Geometries/CandlestickGeometry.cs
@@ -21,7 +21,6 @@
 // SOFTWARE.
 
 using System;
-using System.Drawing;
 using LiveChartsCore.Drawing;
 using LiveChartsCore.Motion;
 using LiveChartsCore.SkiaSharpView.Painting;
@@ -91,7 +90,7 @@ namespace LiveChartsCore.SkiaSharpView.Drawing.Geometries
         }
 
         /// <inheritdoc cref="Geometry.OnMeasure(Paint)" />
-        protected override SizeF OnMeasure(Paint paintTaks)
+        protected override LvcSize OnMeasure(Paint paintTaks)
         {
             return new(Width, Math.Abs(Low - Y));
         }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/Geometries/ColoredRectangleGeometry.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/Geometries/ColoredRectangleGeometry.cs
@@ -20,7 +20,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Drawing;
 using LiveChartsCore.Drawing;
 using LiveChartsCore.Motion;
 using SkiaSharp;
@@ -44,7 +43,7 @@ namespace LiveChartsCore.SkiaSharpView.Drawing.Geometries
         }
 
         /// <inheritdoc cref="ISolidColorGeometry{TDrawingContext}.Color" />
-        public Color Color
+        public LvcColor Color
         {
             get => _colorProperty.GetMovement(this);
             set => _colorProperty.SetMovement(value, this);

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/Geometries/DoughnutGeometry.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/Geometries/DoughnutGeometry.cs
@@ -25,7 +25,6 @@ using LiveChartsCore.Motion;
 using LiveChartsCore.SkiaSharpView.Painting;
 using SkiaSharp;
 using System;
-using System.Drawing;
 
 namespace LiveChartsCore.SkiaSharpView.Drawing.Geometries
 {
@@ -96,9 +95,9 @@ namespace LiveChartsCore.SkiaSharpView.Drawing.Geometries
         internal static Action<DoughnutGeometry, SkiaSharpDrawingContext, SKPaint>? AlternativeDraw { get; set; }
 
         /// <inheritdoc cref="Geometry.OnMeasure(Paint)" />
-        protected override SizeF OnMeasure(Paint paint)
+        protected override LvcSize OnMeasure(Paint paint)
         {
-            return new SizeF(Width, Height);
+            return new LvcSize(Width, Height);
         }
 
         /// <inheritdoc cref="Geometry.OnDraw(SkiaSharpDrawingContext, SKPaint)" />

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/Geometries/Geometry.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/Geometries/Geometry.cs
@@ -26,7 +26,6 @@ using LiveChartsCore.SkiaSharpView.Motion;
 using LiveChartsCore.SkiaSharpView.Painting;
 using SkiaSharp;
 using System;
-using System.Drawing;
 
 namespace LiveChartsCore.SkiaSharpView.Drawing.Geometries
 {
@@ -38,10 +37,10 @@ namespace LiveChartsCore.SkiaSharpView.Drawing.Geometries
         private readonly FloatMotionProperty _xProperty;
         private readonly FloatMotionProperty _yProperty;
         private readonly FloatMotionProperty _rotationProperty;
-        private readonly PointFMotionProperty _transformOriginProperty;
-        private readonly PointFMotionProperty _scaleProperty;
-        private readonly PointFMotionProperty _skewProperty;
-        private readonly PointFMotionProperty _translateProperty;
+        private readonly PointMotionProperty _transformOriginProperty;
+        private readonly PointMotionProperty _scaleProperty;
+        private readonly PointMotionProperty _skewProperty;
+        private readonly PointMotionProperty _translateProperty;
         private readonly SKMatrixMotionProperty _transformProperty;
         private bool _hasTransform = false;
         private bool _hasRotation = false;
@@ -59,15 +58,15 @@ namespace LiveChartsCore.SkiaSharpView.Drawing.Geometries
             _yProperty = RegisterMotionProperty(new FloatMotionProperty(nameof(Y), 0));
             _opacityProperty = RegisterMotionProperty(new FloatMotionProperty(nameof(Opacity), 1));
             _transformOriginProperty = RegisterMotionProperty(
-                new PointFMotionProperty(nameof(TransformOrigin), new PointF(0.5f, 0.5f)));
+                new PointMotionProperty(nameof(TransformOrigin), new LvcPoint(0.5f, 0.5f)));
             _translateProperty = RegisterMotionProperty(
-                new PointFMotionProperty(nameof(TranslateTransform), new PointF(0, 0)));
+                new PointMotionProperty(nameof(TranslateTransform), new LvcPoint(0, 0)));
             _rotationProperty = RegisterMotionProperty(
                 new FloatMotionProperty(nameof(RotateTransform), 0));
             _scaleProperty = RegisterMotionProperty(
-                new PointFMotionProperty(nameof(ScaleTransform), new PointF(1, 1)));
+                new PointMotionProperty(nameof(ScaleTransform), new LvcPoint(1, 1)));
             _skewProperty = RegisterMotionProperty(
-                new PointFMotionProperty(nameof(SkewTransform), new PointF(1, 1)));
+                new PointMotionProperty(nameof(SkewTransform), new LvcPoint(1, 1)));
             _transformProperty = RegisterMotionProperty(
                 new SKMatrixMotionProperty(nameof(Transform), SKMatrix.Identity));
         }
@@ -83,14 +82,14 @@ namespace LiveChartsCore.SkiaSharpView.Drawing.Geometries
         /// <summary>
         /// Gets or sets the transform origin.
         /// </summary>
-        public PointF TransformOrigin
+        public LvcPoint TransformOrigin
         {
             get => _transformOriginProperty.GetMovement(this);
             set => _transformOriginProperty.SetMovement(value, this);
         }
 
         /// <inheritdoc cref="IGeometry{TDrawingContext}.TranslateTransform" />
-        public PointF TranslateTransform
+        public LvcPoint TranslateTransform
         {
             get => _translateProperty.GetMovement(this);
             set
@@ -112,7 +111,7 @@ namespace LiveChartsCore.SkiaSharpView.Drawing.Geometries
         }
 
         /// <inheritdoc cref="IGeometry{TDrawingContext}.ScaleTransform" />
-        public PointF ScaleTransform
+        public LvcPoint ScaleTransform
         {
             get => _scaleProperty.GetMovement(this);
             set
@@ -123,7 +122,7 @@ namespace LiveChartsCore.SkiaSharpView.Drawing.Geometries
         }
 
         /// <inheritdoc cref="IGeometry{TDrawingContext}.SkewTransform" />
-        public PointF SkewTransform
+        public LvcPoint SkewTransform
         {
             get => _skewProperty.GetMovement(this);
             set
@@ -264,7 +263,7 @@ namespace LiveChartsCore.SkiaSharpView.Drawing.Geometries
         /// </summary>
         /// <param name="drawableTask">The drawable task.</param>
         /// <returns>the size of the geometry.</returns>
-        public SizeF Measure(IPaint<SkiaSharpDrawingContext> drawableTask)
+        public LvcSize Measure(IPaint<SkiaSharpDrawingContext> drawableTask)
         {
             var measure = OnMeasure((Paint)drawableTask);
 
@@ -284,7 +283,7 @@ namespace LiveChartsCore.SkiaSharpView.Drawing.Geometries
                 var w = (float)(Math.Cos(rRadians) * measure.Width + Math.Sin(rRadians) * measure.Height);
                 var h = (float)(Math.Sin(rRadians) * measure.Width + Math.Cos(rRadians) * measure.Height);
 
-                measure = new SizeF(w, h);
+                measure = new LvcSize(w, h);
             }
 
             return measure;
@@ -295,7 +294,7 @@ namespace LiveChartsCore.SkiaSharpView.Drawing.Geometries
         /// </summary>
         /// <param name="paintTaks">The paint task.</param>
         /// <returns>the size of the geometry</returns>
-        protected abstract SizeF OnMeasure(Paint paintTaks);
+        protected abstract LvcSize OnMeasure(Paint paintTaks);
 
         /// <summary>
         /// Gets the highlitable geometry.

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/Geometries/LabelGeometry.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/Geometries/LabelGeometry.cs
@@ -26,7 +26,6 @@ using LiveChartsCore.Motion;
 using LiveChartsCore.SkiaSharpView.Painting;
 using SkiaSharp;
 using System;
-using System.Drawing;
 
 namespace LiveChartsCore.SkiaSharpView.Drawing.Geometries
 {
@@ -42,7 +41,7 @@ namespace LiveChartsCore.SkiaSharpView.Drawing.Geometries
             : base(true)
         {
             _textSizeProperty = RegisterMotionProperty(new FloatMotionProperty(nameof(TextSize), 11));
-            TransformOrigin = new PointF(0f, 0f);
+            TransformOrigin = new LvcPoint(0f, 0f);
         }
 
         /// <summary>
@@ -78,7 +77,7 @@ namespace LiveChartsCore.SkiaSharpView.Drawing.Geometries
         }
 
         /// <inheritdoc cref="Geometry.OnMeasure(Paint)" />
-        protected override SizeF OnMeasure(Paint drawable)
+        protected override LvcSize OnMeasure(Paint drawable)
         {
             var p = new SKPaint
             {
@@ -92,7 +91,7 @@ namespace LiveChartsCore.SkiaSharpView.Drawing.Geometries
             var bounds = new SKRect();
 
             _ = p.MeasureText(Text, ref bounds);
-            return new SizeF(bounds.Size.Width + Padding.Left + Padding.Right, bounds.Size.Height + Padding.Top + Padding.Bottom);
+            return new LvcSize(bounds.Size.Width + Padding.Left + Padding.Right, bounds.Size.Height + Padding.Top + Padding.Bottom);
         }
 
         /// <inheritdoc cref="Geometry.ApplyCustomGeometryTransform(SkiaSharpDrawingContext)" />

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/Geometries/LineGeometry.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/Geometries/LineGeometry.cs
@@ -25,7 +25,6 @@ using LiveChartsCore.Motion;
 using LiveChartsCore.SkiaSharpView.Painting;
 using SkiaSharp;
 using System;
-using System.Drawing;
 
 namespace LiveChartsCore.SkiaSharpView.Drawing.Geometries
 {
@@ -57,9 +56,9 @@ namespace LiveChartsCore.SkiaSharpView.Drawing.Geometries
         }
 
         /// <inheritdoc cref="Geometry.OnMeasure(Paint)" />
-        protected override SizeF OnMeasure(Paint drawable)
+        protected override LvcSize OnMeasure(Paint drawable)
         {
-            return new SizeF(Math.Abs(X1 - X), Math.Abs(Y1 - Y));
+            return new LvcSize(Math.Abs(X1 - X), Math.Abs(Y1 - Y));
         }
     }
 }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/Geometries/PathShape.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/Geometries/PathShape.cs
@@ -24,7 +24,6 @@ using LiveChartsCore.Drawing;
 using LiveChartsCore.Motion;
 using SkiaSharp;
 using System.Collections.Generic;
-using System.Drawing;
 
 namespace LiveChartsCore.SkiaSharpView.Drawing.Geometries
 {
@@ -43,9 +42,9 @@ namespace LiveChartsCore.SkiaSharpView.Drawing.Geometries
         /// </summary>
         public PathShape() : base()
         {
-            _strokeProperty = RegisterMotionProperty(new ColorMotionProperty(nameof(StrokeColor), Color.FromArgb(0, 255, 255, 255)));
+            _strokeProperty = RegisterMotionProperty(new ColorMotionProperty(nameof(StrokeColor), LvcColor.FromArgb(0, 255, 255, 255)));
             _stProperty = RegisterMotionProperty(new FloatMotionProperty(nameof(StrokeThickness)));
-            _fillProperty = RegisterMotionProperty(new ColorMotionProperty(nameof(StrokeColor), Color.FromArgb(0, 255, 255, 255)));
+            _fillProperty = RegisterMotionProperty(new ColorMotionProperty(nameof(StrokeColor), LvcColor.FromArgb(0, 255, 255, 255)));
         }
 
         /// <summary>
@@ -54,7 +53,7 @@ namespace LiveChartsCore.SkiaSharpView.Drawing.Geometries
         /// <value>
         /// The color of the stroke.
         /// </value>
-        public Color StrokeColor
+        public LvcColor StrokeColor
         {
             get => _strokeProperty.GetMovement(this);
             set => _strokeProperty.SetMovement(value, this);
@@ -78,7 +77,7 @@ namespace LiveChartsCore.SkiaSharpView.Drawing.Geometries
         /// <value>
         /// The color of the fill.
         /// </value>
-        public Color FillColor
+        public LvcColor FillColor
         {
             get => _fillProperty.GetMovement(this);
             set => _fillProperty.SetMovement(value, this);

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/Geometries/SizedGeometry.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/Geometries/SizedGeometry.cs
@@ -23,7 +23,6 @@
 using LiveChartsCore.Drawing;
 using LiveChartsCore.Motion;
 using LiveChartsCore.SkiaSharpView.Painting;
-using System.Drawing;
 
 namespace LiveChartsCore.SkiaSharpView.Drawing.Geometries
 {
@@ -73,9 +72,9 @@ namespace LiveChartsCore.SkiaSharpView.Drawing.Geometries
         }
 
         /// <inheritdoc cref="Geometry.OnMeasure(Paint)" />
-        protected override SizeF OnMeasure(Paint paint)
+        protected override LvcSize OnMeasure(Paint paint)
         {
-            return new SizeF(Width, Height);
+            return new LvcSize(Width, Height);
         }
     }
 }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/HeatFunctions.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/HeatFunctions.cs
@@ -22,7 +22,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Drawing;
+using LiveChartsCore.Drawing;
 using LiveChartsCore.Geo;
 using LiveChartsCore.Measure;
 using LiveChartsCore.SkiaSharpView.Drawing.Geometries;
@@ -50,9 +50,9 @@ namespace LiveChartsCore.SkiaSharpView
         public static IEnumerable<PathShape> AsHeatMapShapes(
             this GeoJsonFile geoJson,
             Dictionary<string, double> values,
-            Color[] heatMap, List<Tuple<double, Color>> heatStops,
-            Color stroke,
-            Color fill,
+            LvcColor[] heatMap, List<Tuple<double, LvcColor>> heatStops,
+            LvcColor stroke,
+            LvcColor fill,
             float thickness,
             MapProjector projector)
         {
@@ -69,7 +69,7 @@ namespace LiveChartsCore.SkiaSharpView
             foreach (var feature in geoJson.Features ?? new GeoJsonFeature[0])
             {
                 var name = feature.Properties is not null ? feature.Properties["shortName"] : "";
-                Color? baseColor = values.TryGetValue(name, out var weight)
+                LvcColor? baseColor = values.TryGetValue(name, out var weight)
                     ? HeatFunctions.InterpolateColor((float)weight, weightBounds, heatMap, heatStops)
                     : null;
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/LiveChartsSkiaSharp.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/LiveChartsSkiaSharp.cs
@@ -20,6 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using LiveChartsCore.Drawing;
 using LiveChartsCore.Drawing.Common;
 using LiveChartsCore.Kernel;
 using LiveChartsCore.Kernel.Data;
@@ -31,7 +32,6 @@ using LiveChartsCore.SkiaSharpView.Painting;
 using LiveChartsCore.Themes;
 using SkiaSharp;
 using System;
-using System.Drawing;
 
 namespace LiveChartsCore.SkiaSharpView
 {
@@ -117,7 +117,7 @@ namespace LiveChartsCore.SkiaSharpView
                                    // over a point, for example, the first .WithState() defines that every time a point is marked
                                    // with the LiveCharts.BarSeriesHoverKey key, the library will draw a null stroke and
                                    // new SKColor(255, 255, 255, 180) as the fill (defaultHoverColor).
-                                   var defaultHoverColor = Color.FromArgb(180, 255, 255, 255).AsSKColor();
+                                   var defaultHoverColor = LvcColor.FromArgb(180, 255, 255, 255).AsSKColor();
                                    chart.PointStates = new PointStatesDictionary<SkiaSharpDrawingContext>()
                                         .WithState(LiveCharts.BarSeriesHoverKey, null, new SolidColorPaint(defaultHoverColor), true)
                                         .WithState(LiveCharts.LineSeriesHoverKey, null, new SolidColorPaint(defaultHoverColor), true)
@@ -147,7 +147,7 @@ namespace LiveChartsCore.SkiaSharpView
                                    // at this point ForAnySeries() was already called
                                    // we are configuring the missing properties
                                    lineSeries.GeometrySize = 18;
-                                   lineSeries.GeometryFill = new SolidColorPaint(Color.FromArgb(255, 250, 250, 250).AsSKColor());
+                                   lineSeries.GeometryFill = new SolidColorPaint(LvcColor.FromArgb(255, 250, 250, 250).AsSKColor());
                                    lineSeries.GeometryStroke = DefaultPaintTask;
                                })
                                .HasRuleForStepLineSeries(steplineSeries =>
@@ -155,7 +155,7 @@ namespace LiveChartsCore.SkiaSharpView
                                    // at this point ForAnySeries() was already called
                                    // we are configuring the missing properties
                                    steplineSeries.GeometrySize = 18;
-                                   steplineSeries.GeometryFill = new SolidColorPaint(Color.FromArgb(255, 250, 250, 250).AsSKColor());
+                                   steplineSeries.GeometryFill = new SolidColorPaint(LvcColor.FromArgb(255, 250, 250, 250).AsSKColor());
                                    steplineSeries.GeometryStroke = DefaultPaintTask;
                                })
                                .HasRuleForStackedLineSeries(stackedLine =>
@@ -243,7 +243,7 @@ namespace LiveChartsCore.SkiaSharpView
                                    // over a point, for example, the first .WithState() defines that every time a point is marked
                                    // with the LiveCharts.BarSeriesHoverKey key, the library will draw a null stroke and
                                    // new SKColor(255, 255, 255, 180) as the fill (defaultHoverColor).
-                                   var defaultHoverColor = Color.FromArgb(40, 255, 255, 255).AsSKColor();
+                                   var defaultHoverColor = LvcColor.FromArgb(40, 255, 255, 255).AsSKColor();
                                    chart.PointStates =
                                        new PointStatesDictionary<SkiaSharpDrawingContext>()
                                            .WithState(
@@ -279,7 +279,7 @@ namespace LiveChartsCore.SkiaSharpView
                                .HasRuleForLineSeries(lineSeries =>
                                {
                                    lineSeries.GeometrySize = 18;
-                                   lineSeries.GeometryFill = new SolidColorPaint(Color.FromArgb(255, 40, 40, 40).AsSKColor());
+                                   lineSeries.GeometryFill = new SolidColorPaint(LvcColor.FromArgb(255, 40, 40, 40).AsSKColor());
                                    lineSeries.GeometryStroke = DefaultPaintTask;
                                })
                                .HasRuleForStepLineSeries(steplineSeries =>
@@ -287,7 +287,7 @@ namespace LiveChartsCore.SkiaSharpView
                                    // at this point ForAnySeries() was already called
                                    // we are configuring the missing properties
                                    steplineSeries.GeometrySize = 18;
-                                   steplineSeries.GeometryFill = new SolidColorPaint(Color.FromArgb(255, 40, 40, 40).AsSKColor());
+                                   steplineSeries.GeometryFill = new SolidColorPaint(LvcColor.FromArgb(255, 40, 40, 40).AsSKColor());
                                    steplineSeries.GeometryStroke = DefaultPaintTask;
                                })
                                .HasRuleForStackedLineSeries(stackedLine =>
@@ -358,7 +358,7 @@ namespace LiveChartsCore.SkiaSharpView
         {
             return theme
                 .WithSeriesDefaultsResolver(
-                    (Color[] colors, IChartSeries<SkiaSharpDrawingContext> series, bool forceApply) =>
+                    (LvcColor[] colors, IChartSeries<SkiaSharpDrawingContext> series, bool forceApply) =>
                     {
                         if (forceApply)
                         {
@@ -494,7 +494,7 @@ namespace LiveChartsCore.SkiaSharpView
         {
             return theme
                 .WithSeriesDefaultsResolver(
-                    (Color[] colors, IChartSeries<SkiaSharpDrawingContext> series, bool forceApply) =>
+                    (LvcColor[] colors, IChartSeries<SkiaSharpDrawingContext> series, bool forceApply) =>
                     {
                         if (forceApply)
                         {
@@ -618,12 +618,12 @@ namespace LiveChartsCore.SkiaSharpView
         }
 
         /// <summary>
-        /// Converts a <see cref="Color"/> to a <see cref="SKColor"/> instance.
+        /// Converts a <see cref="LvcColor"/> to a <see cref="SKColor"/> instance.
         /// </summary>
         /// <param name="color">The color.</param>
         /// <param name="alphaOverrides">The alpha overrides.</param>
         /// <returns></returns>
-        public static SKColor AsSKColor(this Color color, byte? alphaOverrides = null)
+        public static SKColor AsSKColor(this LvcColor color, byte? alphaOverrides = null)
         {
             return new SKColor(color.R, color.G, color.B, alphaOverrides ?? color.A);
         }
@@ -634,9 +634,9 @@ namespace LiveChartsCore.SkiaSharpView
         /// <param name="color">The color.</param>
         /// <param name="opacity">The opacity from 0 to 255.</param>
         /// <returns></returns>
-        public static Color WithOpacity(this Color color, byte opacity)
+        public static LvcColor WithOpacity(this LvcColor color, byte opacity)
         {
-            return Color.FromArgb(opacity, color.R, color.G, color.B);
+            return LvcColor.FromArgb(opacity, color);
         }
     }
 }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/LiveChartsSkiaSharp.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/LiveChartsSkiaSharp.cs
@@ -638,5 +638,15 @@ namespace LiveChartsCore.SkiaSharpView
         {
             return LvcColor.FromArgb(opacity, color);
         }
+
+        /// <summary>
+        /// Converts a <see cref="SKColor"/> to a <see cref="LvcColor"/> intance.
+        /// </summary>
+        /// <param name="color">The color</param>
+        /// <returns></returns>
+        public static LvcColor AsLvcColor(this SKColor color)
+        {
+            return new LvcColor(color.Red, color.Green, color.Blue, color.Alpha);
+        }
     }
 }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/LinearGradientPaint.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/LinearGradientPaint.cs
@@ -188,7 +188,7 @@ namespace LiveChartsCore.SkiaSharpView.Painting
             }
 
             var clip = GetClipRectangle(drawingContext.MotionCanvas);
-            if (clip != RectangleF.Empty)
+            if (clip != LvcRectangle.Empty)
             {
                 _ = drawingContext.Canvas.Save();
                 drawingContext.Canvas.ClipRect(new SKRect(clip.X, clip.Y, clip.X + clip.Width, clip.Y + clip.Height));
@@ -208,7 +208,7 @@ namespace LiveChartsCore.SkiaSharpView.Painting
             if (PathEffect is not null) PathEffect.Dispose();
             if (ImageFilter is not null) ImageFilter.Dispose();
 
-            if (_drawingContext is not null && GetClipRectangle(_drawingContext.MotionCanvas) != RectangleF.Empty)
+            if (_drawingContext is not null && GetClipRectangle(_drawingContext.MotionCanvas) != LvcRectangle.Empty)
             {
                 _drawingContext.Canvas.Restore();
                 _drawingContext = null;
@@ -221,7 +221,7 @@ namespace LiveChartsCore.SkiaSharpView.Painting
         {
             var clip = GetClipRectangle(drawingContext.MotionCanvas);
 
-            return clip == RectangleF.Empty
+            return clip == LvcRectangle.Empty
                 ? new SKRect(0, 0, drawingContext.Info.Width, drawingContext.Info.Width)
                 : new SKRect(clip.X, clip.Y, clip.X + clip.Width, clip.Y + clip.Height);
         }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/LinearGradientPaint.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/LinearGradientPaint.cs
@@ -20,7 +20,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Drawing;
 using LiveChartsCore.Drawing;
 using LiveChartsCore.SkiaSharpView.Drawing;
 using SkiaSharp;

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/Paint.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/Paint.cs
@@ -29,7 +29,6 @@ using LiveChartsCore.SkiaSharpView.Painting.ImageFilters;
 using SkiaSharp;
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
 
 namespace LiveChartsCore.SkiaSharpView.Painting

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/Paint.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/Paint.cs
@@ -39,7 +39,7 @@ namespace LiveChartsCore.SkiaSharpView.Painting
     {
         private readonly FloatMotionProperty _strokeMiterTransition;
         private readonly Dictionary<object, HashSet<IDrawable<SkiaSharpDrawingContext>>> _geometriesByCanvas = new();
-        private readonly Dictionary<object, RectangleF> _clipRectangles = new();
+        private readonly Dictionary<object, LvcRectangle> _clipRectangles = new();
 
         /// <summary>
         /// The skia paint
@@ -209,13 +209,13 @@ namespace LiveChartsCore.SkiaSharpView.Painting
         }
 
         /// <inheritdoc cref="IPaint{TDrawingContext}.GetClipRectangle(MotionCanvas{TDrawingContext})" />
-        public RectangleF GetClipRectangle(MotionCanvas<SkiaSharpDrawingContext> canvas)
+        public LvcRectangle GetClipRectangle(MotionCanvas<SkiaSharpDrawingContext> canvas)
         {
-            return _clipRectangles.TryGetValue(canvas.Sync, out var clip) ? clip : RectangleF.Empty;
+            return _clipRectangles.TryGetValue(canvas.Sync, out var clip) ? clip : LvcRectangle.Empty;
         }
 
-        /// <inheritdoc cref="IPaint{TDrawingContext}.SetClipRectangle(MotionCanvas{TDrawingContext}, RectangleF)" />
-        public void SetClipRectangle(MotionCanvas<SkiaSharpDrawingContext> canvas, RectangleF value)
+        /// <inheritdoc cref="IPaint{TDrawingContext}.SetClipRectangle(MotionCanvas{TDrawingContext}, LvcRectangle)" />
+        public void SetClipRectangle(MotionCanvas<SkiaSharpDrawingContext> canvas, LvcRectangle value)
         {
             _clipRectangles[canvas.Sync] = value;
         }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/RadialGradientPaint.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/RadialGradientPaint.cs
@@ -142,7 +142,7 @@ namespace LiveChartsCore.SkiaSharpView.Painting
             }
 
             var clip = GetClipRectangle(drawingContext.MotionCanvas);
-            if (clip != RectangleF.Empty)
+            if (clip != LvcRectangle.Empty)
             {
                 _ = drawingContext.Canvas.Save();
                 drawingContext.Canvas.ClipRect(new SKRect(clip.X, clip.Y, clip.X + clip.Width, clip.Y + clip.Height));
@@ -174,7 +174,7 @@ namespace LiveChartsCore.SkiaSharpView.Painting
             if (PathEffect is not null) PathEffect.Dispose();
             if (ImageFilter is not null) ImageFilter.Dispose();
 
-            if (_drawingContext is not null && GetClipRectangle(_drawingContext.MotionCanvas) != RectangleF.Empty)
+            if (_drawingContext is not null && GetClipRectangle(_drawingContext.MotionCanvas) != LvcRectangle.Empty)
             {
                 _drawingContext.Canvas.Restore();
                 _drawingContext = null;
@@ -187,7 +187,7 @@ namespace LiveChartsCore.SkiaSharpView.Painting
         {
             var clip = GetClipRectangle(drawingContext.MotionCanvas);
 
-            return clip == RectangleF.Empty
+            return clip == LvcRectangle.Empty
                 ? new SKRect(0, 0, drawingContext.Info.Width, drawingContext.Info.Width)
                 : new SKRect(clip.X, clip.Y, clip.Width, clip.Height);
         }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/RadialGradientPaint.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/RadialGradientPaint.cs
@@ -20,7 +20,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Drawing;
 using LiveChartsCore.Drawing;
 using LiveChartsCore.SkiaSharpView.Drawing;
 using SkiaSharp;

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/SolidColorPaint.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/SolidColorPaint.cs
@@ -24,7 +24,6 @@ using LiveChartsCore.Drawing;
 using LiveChartsCore.Motion;
 using LiveChartsCore.SkiaSharpView.Drawing;
 using SkiaSharp;
-using System.Drawing;
 
 namespace LiveChartsCore.SkiaSharpView.Painting
 {

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/SolidColorPaint.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/SolidColorPaint.cs
@@ -115,7 +115,7 @@ namespace LiveChartsCore.SkiaSharpView.Painting
             }
 
             var clip = GetClipRectangle(drawingContext.MotionCanvas);
-            if (clip != RectangleF.Empty)
+            if (clip != LvcRectangle.Empty)
             {
                 _ = drawingContext.Canvas.Save();
                 drawingContext.Canvas.ClipRect(new SKRect(clip.X, clip.Y, clip.X + clip.Width, clip.Y + clip.Height));
@@ -154,7 +154,7 @@ namespace LiveChartsCore.SkiaSharpView.Painting
             if (PathEffect is not null) PathEffect.Dispose();
             if (ImageFilter is not null) ImageFilter.Dispose();
 
-            if (_drawingContext is not null && GetClipRectangle(_drawingContext.MotionCanvas) != RectangleF.Empty)
+            if (_drawingContext is not null && GetClipRectangle(_drawingContext.MotionCanvas) != LvcRectangle.Empty)
             {
                 _drawingContext.Canvas.Restore();
                 _drawingContext = null;

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/SKCharts/SKCartesianChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/SKCharts/SKCartesianChart.cs
@@ -22,7 +22,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.IO;
 using LiveChartsCore.Drawing;
 using LiveChartsCore.Kernel;
@@ -40,7 +39,7 @@ namespace LiveChartsCore.SkiaSharpView.SKCharts
     /// </summary>
     public class SKCartesianChart : ICartesianChartView<SkiaSharpDrawingContext>, ISkiaSharpChart
     {
-        private Color _backColor;
+        private LvcColor _backColor;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SKCartesianChart"/> class.
@@ -151,7 +150,7 @@ namespace LiveChartsCore.SkiaSharpView.SKCharts
         /// <inheritdoc cref="IChartView.CoreChart"/>
         public IChart CoreChart => Core;
 
-        Color IChartView.BackColor
+        LvcColor IChartView.BackColor
         {
             get => _backColor;
             set
@@ -161,7 +160,7 @@ namespace LiveChartsCore.SkiaSharpView.SKCharts
             }
         }
 
-        SizeF IChartView.ControlSize => new(Width, Height);
+        LvcSize IChartView.ControlSize => new(Width, Height);
 
         /// <inheritdoc cref="IChartView.DrawMargin"/>
         public Margin? DrawMargin { get; set; }
@@ -199,14 +198,14 @@ namespace LiveChartsCore.SkiaSharpView.SKCharts
             throw new NotImplementedException();
         }
 
-        /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.ScaleUIPoint(PointF, int, int)"/>
-        public double[] ScaleUIPoint(PointF point, int xAxisIndex = 0, int yAxisIndex = 0)
+        /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.ScaleUIPoint(LvcPoint, int, int)"/>
+        public double[] ScaleUIPoint(LvcPoint point, int xAxisIndex = 0, int yAxisIndex = 0)
         {
             throw new NotImplementedException();
         }
 
-        /// <inheritdoc cref="IChartView.SetTooltipStyle(Color, Color)"/>
-        public void SetTooltipStyle(Color background, Color textColor) { }
+        /// <inheritdoc cref="IChartView.SetTooltipStyle(LvcColor, LvcColor)"/>
+        public void SetTooltipStyle(LvcColor background, LvcColor textColor) { }
 
         /// <inheritdoc cref="IChartView{TDrawingContext}.ShowTooltip(IEnumerable{TooltipPoint})"/>
         public void ShowTooltip(IEnumerable<TooltipPoint> points)

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/SKCharts/SKGeoMap.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/SKCharts/SKGeoMap.cs
@@ -22,7 +22,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.IO;
 using System.Linq;
 using LiveChartsCore.Drawing;
@@ -39,7 +38,7 @@ namespace LiveChartsCore.SkiaSharpView.SKCharts
         private readonly MotionCanvas<SkiaSharpDrawingContext> _motionCanvas = new();
         private static GeoJsonFile? s_map = null;
         private int _heatKnownLength = 0;
-        private List<Tuple<double, Color>> _heatStops = new();
+        private List<Tuple<double, LvcColor>> _heatStops = new();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SKGeoMap"/> class.
@@ -92,23 +91,23 @@ namespace LiveChartsCore.SkiaSharpView.SKCharts
         public Projection Projection { get; set; }
 
         /// <inheritdoc cref="IGeoMap.HeatMap"/>
-        public Color[] HeatMap { get; set; } = new[]
+        public LvcColor[] HeatMap { get; set; } = new[]
         {
-            Color.FromArgb(255, 179, 229, 252), // cold (min value)
-            Color.FromArgb(255, 2, 136, 209) // hot (max value)
+            LvcColor.FromArgb(255, 179, 229, 252), // cold (min value)
+            LvcColor.FromArgb(255, 2, 136, 209) // hot (max value)
         };
 
         /// <inheritdoc cref="IGeoMap.ColorStops"/>
         public double[]? ColorStops { get; set; }
 
         /// <inheritdoc cref="IGeoMap.StrokeColor"/>
-        public Color StrokeColor { get; set; } = Color.FromArgb(255, 224, 224, 224);
+        public LvcColor StrokeColor { get; set; } = LvcColor.FromArgb(255, 224, 224, 224);
 
         /// <inheritdoc cref="IGeoMap.StrokeThickness"/>
         public double StrokeThickness { get; set; } = 1;
 
         /// <inheritdoc cref="IGeoMap.FillColor"/>
-        public Color FillColor { get; set; } = Color.FromArgb(255, 250, 250, 250);
+        public LvcColor FillColor { get; set; } = LvcColor.FromArgb(255, 250, 250, 250);
 
         /// <inheritdoc cref="IGeoMap.Values"/>
         public Dictionary<string, double> Values { get; set; } = new Dictionary<string, double>();
@@ -171,10 +170,10 @@ namespace LiveChartsCore.SkiaSharpView.SKCharts
             var paint = new SolidColorPaint();
 
             var thickness = (float)StrokeThickness;
-            var stroke = Color.FromArgb(255, StrokeColor.R, StrokeColor.G, StrokeColor.B);
-            var fill = Color.FromArgb(255, FillColor.R, FillColor.G, FillColor.B);
+            var stroke = LvcColor.FromArgb(255, StrokeColor.R, StrokeColor.G, StrokeColor.B);
+            var fill = LvcColor.FromArgb(255, FillColor.R, FillColor.G, FillColor.B);
 
-            var hm = HeatMap.Select(x => Color.FromArgb(x.A, x.R, x.G, x.B)).ToArray();
+            var hm = HeatMap.Select(x => LvcColor.FromArgb(x.A, x.R, x.G, x.B)).ToArray();
 
             if (_heatKnownLength != HeatMap.Length)
             {

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/SKCharts/SKPieChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/SKCharts/SKPieChart.cs
@@ -22,9 +22,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.IO;
-using System.Threading.Tasks;
 using LiveChartsCore.Drawing;
 using LiveChartsCore.Kernel;
 using LiveChartsCore.Kernel.Events;
@@ -40,7 +38,7 @@ namespace LiveChartsCore.SkiaSharpView.SKCharts
     /// </summary>
     public class SKPieChart : IPieChartView<SkiaSharpDrawingContext>, ISkiaSharpChart
     {
-        private Color _backColor;
+        private LvcColor _backColor;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SKPieChart"/> class.
@@ -137,7 +135,7 @@ namespace LiveChartsCore.SkiaSharpView.SKCharts
         /// <inheritdoc cref="IChartView.CoreChart"/>
         public IChart CoreChart => Core;
 
-        Color IChartView.BackColor
+        LvcColor IChartView.BackColor
         {
             get => _backColor;
             set
@@ -147,7 +145,7 @@ namespace LiveChartsCore.SkiaSharpView.SKCharts
             }
         }
 
-        SizeF IChartView.ControlSize => new(Width, Height);
+        LvcSize IChartView.ControlSize => new(Width, Height);
 
         /// <inheritdoc cref="IChartView.DrawMargin"/>
         public Margin? DrawMargin { get; set; }
@@ -185,8 +183,8 @@ namespace LiveChartsCore.SkiaSharpView.SKCharts
             throw new NotImplementedException();
         }
 
-        /// <inheritdoc cref="IChartView.SetTooltipStyle(Color, Color)"/>
-        public void SetTooltipStyle(Color background, Color textColor) { }
+        /// <inheritdoc cref="IChartView.SetTooltipStyle(LvcColor, LvcColor)"/>
+        public void SetTooltipStyle(LvcColor background, LvcColor textColor) { }
 
         /// <inheritdoc cref="IChartView{TDrawingContext}.ShowTooltip(IEnumerable{TooltipPoint})"/>
         public void ShowTooltip(IEnumerable<TooltipPoint> points)

--- a/src/skiasharp/LiveChartsCore.SkiaSharpVew.WinUI/CartesianChart.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpVew.WinUI/CartesianChart.xaml.cs
@@ -383,11 +383,11 @@ namespace LiveChartsCore.SkiaSharpView.WinUI
         /// <inheritdoc cref="IChartView.CoreChart" />
         public IChart CoreChart => _core ?? throw new Exception("Core not set yet.");
 
-        System.Drawing.Color IChartView.BackColor
+        LvcColor IChartView.BackColor
         {
             get => Background is not SolidColorBrush b
-                    ? new System.Drawing.Color()
-                    : System.Drawing.Color.FromArgb(b.Color.A, b.Color.R, b.Color.G, b.Color.B);
+                    ? new LvcColor()
+                    : LvcColor.FromArgb(b.Color.A, b.Color.R, b.Color.G, b.Color.B);
             set => SetValue(BackgroundProperty, new SolidColorBrush(Windows.UI.Color.FromArgb(value.A, value.R, value.G, value.B)));
         }
 
@@ -404,7 +404,7 @@ namespace LiveChartsCore.SkiaSharpView.WinUI
             set => SetValue(DrawMarginProperty, value);
         }
 
-        System.Drawing.SizeF IChartView.ControlSize => _canvas == null
+        LvcSize IChartView.ControlSize => _canvas == null
                     ? throw new Exception("Canvas not found")
                     : (new() { Width = (float)_canvas.ActualWidth, Height = (float)_canvas.ActualHeight });
 
@@ -772,8 +772,8 @@ namespace LiveChartsCore.SkiaSharpView.WinUI
 
         #endregion
 
-        /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.ScaleUIPoint(System.Drawing.PointF, int, int)" />
-        public double[] ScaleUIPoint(System.Drawing.PointF point, int xAxisIndex = 0, int yAxisIndex = 0)
+        /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.ScaleUIPoint(LvcPoint, int, int)" />
+        public double[] ScaleUIPoint(LvcPoint point, int xAxisIndex = 0, int yAxisIndex = 0)
         {
             if (_core == null) throw new Exception("core not found");
             var cartesianCore = (CartesianChart<SkiaSharpDrawingContext>)_core;
@@ -803,8 +803,8 @@ namespace LiveChartsCore.SkiaSharpView.WinUI
             ((IChartTooltip<SkiaSharpDrawingContext>)tooltip).Hide();
         }
 
-        /// <inheritdoc cref="IChartView.SetTooltipStyle(System.Drawing.Color, System.Drawing.Color)"/>
-        public void SetTooltipStyle(System.Drawing.Color background, System.Drawing.Color textColor)
+        /// <inheritdoc cref="IChartView.SetTooltipStyle(LvcColor, LvcColor)"/>
+        public void SetTooltipStyle(LvcColor background, LvcColor textColor)
         {
             TooltipBackground = new SolidColorBrush(Windows.UI.Color.FromArgb(background.A, background.R, background.G, background.B));
             TooltipTextBrush = new SolidColorBrush(Windows.UI.Color.FromArgb(textColor.A, textColor.R, textColor.G, textColor.B));
@@ -882,7 +882,7 @@ namespace LiveChartsCore.SkiaSharpView.WinUI
         private void OnPointerMoved(object sender, Microsoft.UI.Xaml.Input.PointerRoutedEventArgs e)
         {
             var p = e.GetCurrentPoint(this);
-            _core?.InvokePointerMove(new System.Drawing.PointF((float)p.Position.X, (float)p.Position.Y));
+            _core?.InvokePointerMove(new LvcPoint((float)p.Position.X, (float)p.Position.Y));
         }
 
         private void OnCoreUpdateFinished(IChartView<SkiaSharpDrawingContext> chart)
@@ -909,7 +909,7 @@ namespace LiveChartsCore.SkiaSharpView.WinUI
         private void OnPointerReleased(object sender, Microsoft.UI.Xaml.Input.PointerRoutedEventArgs e)
         {
             var p = e.GetCurrentPoint(this);
-            _core?.InvokePointerUp(new System.Drawing.PointF((float)p.Position.X, (float)p.Position.Y));
+            _core?.InvokePointerUp(new LvcPoint((float)p.Position.X, (float)p.Position.Y));
             ReleasePointerCapture(e.Pointer);
         }
 
@@ -917,7 +917,7 @@ namespace LiveChartsCore.SkiaSharpView.WinUI
         {
             _ = CapturePointer(e.Pointer);
             var p = e.GetCurrentPoint(this);
-            _core?.InvokePointerDown(new System.Drawing.PointF((float)p.Position.X, (float)p.Position.Y));
+            _core?.InvokePointerDown(new LvcPoint((float)p.Position.X, (float)p.Position.Y));
         }
 
         private void OnWheelChanged(object sender, Microsoft.UI.Xaml.Input.PointerRoutedEventArgs e)
@@ -927,7 +927,7 @@ namespace LiveChartsCore.SkiaSharpView.WinUI
             var p = e.GetCurrentPoint(this);
 
             c.Zoom(
-                new System.Drawing.PointF(
+                new LvcPoint(
                     (float)p.Position.X, (float)p.Position.Y),
                     p.Properties.MouseWheelDelta > 0 ? ZoomDirection.ZoomIn : ZoomDirection.ZoomOut);
         }

--- a/src/skiasharp/LiveChartsCore.SkiaSharpVew.WinUI/DefaultTooltip.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpVew.WinUI/DefaultTooltip.xaml.cs
@@ -24,6 +24,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices.WindowsRuntime;
+using LiveChartsCore.Drawing;
 using LiveChartsCore.Kernel;
 using LiveChartsCore.Kernel.Sketches;
 using LiveChartsCore.SkiaSharpView.Drawing;
@@ -85,7 +86,7 @@ namespace LiveChartsCore.SkiaSharpView.WinUI
 
             if (_activePoints.Count > 0 && tooltipPoints.All(x => _activePoints.ContainsKey(x.Point))) return;
 
-            System.Drawing.PointF? location = null;
+            LvcPoint? location = null;
 
             IsOpen = true;
             Points = tooltipPoints;
@@ -95,12 +96,12 @@ namespace LiveChartsCore.SkiaSharpView.WinUI
             if (chart is CartesianChart<SkiaSharpDrawingContext> or PolarChart<SkiaSharpDrawingContext>)
             {
                 location = tooltipPoints.GetCartesianTooltipLocation(
-                    chart.TooltipPosition, new System.Drawing.SizeF((float)DesiredSize.Width, (float)DesiredSize.Height), chart.ControlSize);
+                    chart.TooltipPosition, new LvcSize((float)DesiredSize.Width, (float)DesiredSize.Height), chart.ControlSize);
             }
             if (chart is PieChart<SkiaSharpDrawingContext>)
             {
                 location = tooltipPoints.GetPieTooltipLocation(
-                    chart.TooltipPosition, new System.Drawing.SizeF((float)DesiredSize.Width, (float)DesiredSize.Height));
+                    chart.TooltipPosition, new LvcSize((float)DesiredSize.Width, (float)DesiredSize.Height));
             }
 
             if (location is null) throw new Exception("location not supported");

--- a/src/skiasharp/LiveChartsCore.SkiaSharpVew.WinUI/PieChart.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpVew.WinUI/PieChart.xaml.cs
@@ -321,11 +321,11 @@ namespace LiveChartsCore.SkiaSharpView.WinUI
         PieChart<SkiaSharpDrawingContext> IPieChartView<SkiaSharpDrawingContext>.Core
             => _core == null ? throw new Exception("core not found") : (PieChart<SkiaSharpDrawingContext>)_core;
 
-        System.Drawing.Color IChartView.BackColor
+        LvcColor IChartView.BackColor
         {
             get => Background is not SolidColorBrush b
-                    ? new System.Drawing.Color()
-                    : System.Drawing.Color.FromArgb(b.Color.A, b.Color.R, b.Color.G, b.Color.B);
+                    ? new LvcColor()
+                    : LvcColor.FromArgb(b.Color.A, b.Color.R, b.Color.G, b.Color.B);
             set => SetValue(BackgroundProperty, new SolidColorBrush(Windows.UI.Color.FromArgb(value.A, value.R, value.G, value.B)));
         }
 
@@ -377,7 +377,7 @@ namespace LiveChartsCore.SkiaSharpView.WinUI
             set => SetValue(DrawMarginProperty, value);
         }
 
-        System.Drawing.SizeF IChartView.ControlSize => _canvas == null
+        LvcSize IChartView.ControlSize => _canvas == null
                     ? throw new Exception("Canvas not found")
                     : (new() { Width = (float)_canvas.ActualWidth, Height = (float)_canvas.ActualHeight });
 
@@ -689,8 +689,8 @@ namespace LiveChartsCore.SkiaSharpView.WinUI
             ((IChartTooltip<SkiaSharpDrawingContext>)tooltip).Hide();
         }
 
-        /// <inheritdoc cref="IChartView.SetTooltipStyle(System.Drawing.Color, System.Drawing.Color)"/>
-        public void SetTooltipStyle(System.Drawing.Color background, System.Drawing.Color textColor)
+        /// <inheritdoc cref="IChartView.SetTooltipStyle(LvcColor, LvcColor)"/>
+        public void SetTooltipStyle(LvcColor background, LvcColor textColor)
         {
             TooltipBackground = new SolidColorBrush(Windows.UI.Color.FromArgb(background.A, background.R, background.G, background.B));
             TooltipTextBrush = new SolidColorBrush(Windows.UI.Color.FromArgb(textColor.A, textColor.R, textColor.G, textColor.B));
@@ -755,7 +755,7 @@ namespace LiveChartsCore.SkiaSharpView.WinUI
         private void OnPointerMoved(object sender, Microsoft.UI.Xaml.Input.PointerRoutedEventArgs e)
         {
             var p = e.GetCurrentPoint(this);
-            _core?.InvokePointerMove(new System.Drawing.PointF((float)p.Position.X, (float)p.Position.Y));
+            _core?.InvokePointerMove(new LvcPoint((float)p.Position.X, (float)p.Position.Y));
         }
 
         private void OnCoreUpdateFinished(IChartView<SkiaSharpDrawingContext> chart)

--- a/src/skiasharp/LiveChartsCore.SkiaSharpVew.WinUI/PolarChart.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpVew.WinUI/PolarChart.xaml.cs
@@ -325,11 +325,11 @@ namespace LiveChartsCore.SkiaSharpView.WinUI
         /// <inheritdoc cref="IChartView.CoreChart" />
         public IChart CoreChart => _core ?? throw new Exception("Core not set yet.");
 
-        System.Drawing.Color IChartView.BackColor
+        LvcColor IChartView.BackColor
         {
             get => Background is not SolidColorBrush b
-                    ? new System.Drawing.Color()
-                    : System.Drawing.Color.FromArgb(b.Color.A, b.Color.R, b.Color.G, b.Color.B);
+                    ? new LvcColor()
+                    : LvcColor.FromArgb(b.Color.A, b.Color.R, b.Color.G, b.Color.B);
             set => SetValue(BackgroundProperty, new SolidColorBrush(Windows.UI.Color.FromArgb(value.A, value.R, value.G, value.B)));
         }
 
@@ -346,7 +346,7 @@ namespace LiveChartsCore.SkiaSharpView.WinUI
             set => throw new NotImplementedException();
         }
 
-        System.Drawing.SizeF IChartView.ControlSize => _canvas == null
+        LvcSize IChartView.ControlSize => _canvas == null
             ? throw new Exception("Canvas not found")
             : (new() { Width = (float)_canvas.ActualWidth, Height = (float)_canvas.ActualHeight });
 
@@ -666,8 +666,8 @@ namespace LiveChartsCore.SkiaSharpView.WinUI
 
         #endregion
 
-        /// <inheritdoc cref="IPolarChartView{TDrawingContext}.ScaleUIPoint(System.Drawing.PointF, int, int)" />
-        public double[] ScaleUIPoint(System.Drawing.PointF point, int xAxisIndex = 0, int yAxisIndex = 0)
+        /// <inheritdoc cref="IPolarChartView{TDrawingContext}.ScaleUIPoint(LvcPoint, int, int)" />
+        public double[] ScaleUIPoint(LvcPoint point, int xAxisIndex = 0, int yAxisIndex = 0)
         {
             return new double[0];
             //if (_core == null) throw new Exception("core not found");
@@ -698,8 +698,8 @@ namespace LiveChartsCore.SkiaSharpView.WinUI
             ((IChartTooltip<SkiaSharpDrawingContext>)tooltip).Hide();
         }
 
-        /// <inheritdoc cref="IChartView.SetTooltipStyle(System.Drawing.Color, System.Drawing.Color)"/>
-        public void SetTooltipStyle(System.Drawing.Color background, System.Drawing.Color textColor)
+        /// <inheritdoc cref="IChartView.SetTooltipStyle(LvcColor, LvcColor)"/>
+        public void SetTooltipStyle(LvcColor background, LvcColor textColor)
         {
             TooltipBackground = new SolidColorBrush(Windows.UI.Color.FromArgb(background.A, background.R, background.G, background.B));
             TooltipTextBrush = new SolidColorBrush(Windows.UI.Color.FromArgb(textColor.A, textColor.R, textColor.G, textColor.B));
@@ -777,7 +777,7 @@ namespace LiveChartsCore.SkiaSharpView.WinUI
         private void OnPointerMoved(object sender, Microsoft.UI.Xaml.Input.PointerRoutedEventArgs e)
         {
             var p = e.GetCurrentPoint(this);
-            _core?.InvokePointerMove(new System.Drawing.PointF((float)p.Position.X, (float)p.Position.Y));
+            _core?.InvokePointerMove(new LvcPoint((float)p.Position.X, (float)p.Position.Y));
         }
 
         private void OnCoreUpdateFinished(IChartView<SkiaSharpDrawingContext> chart)
@@ -804,7 +804,7 @@ namespace LiveChartsCore.SkiaSharpView.WinUI
         private void OnPointerReleased(object sender, Microsoft.UI.Xaml.Input.PointerRoutedEventArgs e)
         {
             var p = e.GetCurrentPoint(this);
-            _core?.InvokePointerUp(new System.Drawing.PointF((float)p.Position.X, (float)p.Position.Y));
+            _core?.InvokePointerUp(new LvcPoint((float)p.Position.X, (float)p.Position.Y));
             ReleasePointerCapture(e.Pointer);
         }
 
@@ -812,7 +812,7 @@ namespace LiveChartsCore.SkiaSharpView.WinUI
         {
             _ = CapturePointer(e.Pointer);
             var p = e.GetCurrentPoint(this);
-            _core?.InvokePointerDown(new System.Drawing.PointF((float)p.Position.X, (float)p.Position.Y));
+            _core?.InvokePointerDown(new LvcPoint((float)p.Position.X, (float)p.Position.Y));
         }
 
         private void OnWheelChanged(object sender, Microsoft.UI.Xaml.Input.PointerRoutedEventArgs e)
@@ -822,7 +822,7 @@ namespace LiveChartsCore.SkiaSharpView.WinUI
             //var p = e.GetCurrentPoint(this);
 
             //c.Zoom(
-            //    new System.Drawing.PointF(
+            //    new LvcPoint(
             //        (float)p.Position.X, (float)p.Position.Y),
             //        p.Properties.MouseWheelDelta > 0 ? ZoomDirection.ZoomIn : ZoomDirection.ZoomOut);
         }

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.UWP/CartesianChart.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.UWP/CartesianChart.xaml.cs
@@ -402,11 +402,11 @@ namespace LiveChartsCore.SkiaSharpView.UWP
             set => SetValue(SyncContextProperty, value);
         }
 
-        System.Drawing.Color IChartView.BackColor
+        LvcColor IChartView.BackColor
         {
             get => Background is not SolidColorBrush b
-                    ? new System.Drawing.Color()
-                    : System.Drawing.Color.FromArgb(b.Color.A, b.Color.R, b.Color.G, b.Color.B);
+                ? new LvcColor()
+                : LvcColor.FromArgb(b.Color.A, b.Color.R, b.Color.G, b.Color.B);
             set => SetValue(BackgroundProperty, new SolidColorBrush(Windows.UI.Color.FromArgb(value.A, value.R, value.G, value.B)));
         }
 
@@ -423,9 +423,9 @@ namespace LiveChartsCore.SkiaSharpView.UWP
             set => SetValue(DrawMarginProperty, value);
         }
 
-        System.Drawing.SizeF IChartView.ControlSize => _canvas == null
-                    ? throw new Exception("Canvas not found")
-                    : (new() { Width = (float)_canvas.ActualWidth, Height = (float)_canvas.ActualHeight });
+        LvcSize IChartView.ControlSize => _canvas == null
+            ? throw new Exception("Canvas not found")
+            : (new() { Width = (float)_canvas.ActualWidth, Height = (float)_canvas.ActualHeight });
 
         /// <inheritdoc cref="IChartView{TDrawingContext}.CoreCanvas" />
         public MotionCanvas<SkiaSharpDrawingContext> CoreCanvas => _canvas == null ? throw new Exception("Canvas not found") : _canvas.CanvasCore;
@@ -783,8 +783,8 @@ namespace LiveChartsCore.SkiaSharpView.UWP
 
         #endregion
 
-        /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.ScaleUIPoint(System.Drawing.PointF, int, int)" />
-        public double[] ScaleUIPoint(System.Drawing.PointF point, int xAxisIndex = 0, int yAxisIndex = 0)
+        /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.ScaleUIPoint(LvcPoint, int, int)" />
+        public double[] ScaleUIPoint(LvcPoint point, int xAxisIndex = 0, int yAxisIndex = 0)
         {
             if (_core == null) throw new Exception("core not found");
             var cartesianCore = (CartesianChart<SkiaSharpDrawingContext>)_core;
@@ -814,8 +814,8 @@ namespace LiveChartsCore.SkiaSharpView.UWP
             ((IChartTooltip<SkiaSharpDrawingContext>)tooltip).Hide();
         }
 
-        /// <inheritdoc cref="IChartView.SetTooltipStyle(System.Drawing.Color, System.Drawing.Color)"/>
-        public void SetTooltipStyle(System.Drawing.Color background, System.Drawing.Color textColor)
+        /// <inheritdoc cref="IChartView.SetTooltipStyle(LvcColor, LvcColor)"/>
+        public void SetTooltipStyle(LvcColor background, LvcColor textColor)
         {
             TooltipBackground = new SolidColorBrush(Windows.UI.Color.FromArgb(background.A, background.R, background.G, background.B));
             TooltipTextBrush = new SolidColorBrush(Windows.UI.Color.FromArgb(textColor.A, textColor.R, textColor.G, textColor.B));
@@ -885,7 +885,7 @@ namespace LiveChartsCore.SkiaSharpView.UWP
         private void OnPointerMoved(object sender, PointerRoutedEventArgs e)
         {
             var p = e.GetCurrentPoint(this);
-            _core?.InvokePointerMove(new System.Drawing.PointF((float)p.Position.X, (float)p.Position.Y));
+            _core?.InvokePointerMove(new LvcPoint((float)p.Position.X, (float)p.Position.Y));
         }
 
         private void OnCoreUpdateFinished(IChartView<SkiaSharpDrawingContext> chart)
@@ -912,7 +912,7 @@ namespace LiveChartsCore.SkiaSharpView.UWP
         private void OnPointerReleased(object sender, PointerRoutedEventArgs e)
         {
             var p = e.GetCurrentPoint(this);
-            _core?.InvokePointerUp(new System.Drawing.PointF((float)p.Position.X, (float)p.Position.Y));
+            _core?.InvokePointerUp(new LvcPoint((float)p.Position.X, (float)p.Position.Y));
             ReleasePointerCapture(e.Pointer);
         }
 
@@ -920,7 +920,7 @@ namespace LiveChartsCore.SkiaSharpView.UWP
         {
             _ = CapturePointer(e.Pointer);
             var p = e.GetCurrentPoint(this);
-            _core?.InvokePointerDown(new System.Drawing.PointF((float)p.Position.X, (float)p.Position.Y));
+            _core?.InvokePointerDown(new LvcPoint((float)p.Position.X, (float)p.Position.Y));
         }
 
         private void OnWheelChanged(object sender, PointerRoutedEventArgs e)
@@ -930,7 +930,7 @@ namespace LiveChartsCore.SkiaSharpView.UWP
             var p = e.GetCurrentPoint(this);
 
             c.Zoom(
-                new System.Drawing.PointF(
+                new LvcPoint(
                     (float)p.Position.X, (float)p.Position.Y),
                     p.Properties.MouseWheelDelta > 0 ? ZoomDirection.ZoomIn : ZoomDirection.ZoomOut);
         }

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.UWP/DefaultTooltip.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.UWP/DefaultTooltip.xaml.cs
@@ -24,6 +24,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices.WindowsRuntime;
+using LiveChartsCore.Drawing;
 using LiveChartsCore.Kernel;
 using LiveChartsCore.Kernel.Sketches;
 using LiveChartsCore.SkiaSharpView.Drawing;
@@ -84,7 +85,7 @@ namespace LiveChartsCore.SkiaSharpView.UWP
 
             if (_activePoints.Count > 0 && tooltipPoints.All(x => _activePoints.ContainsKey(x.Point))) return;
 
-            System.Drawing.PointF? location = null;
+            LvcPoint? location = null;
 
             IsOpen = true;
             Points = tooltipPoints;
@@ -94,12 +95,15 @@ namespace LiveChartsCore.SkiaSharpView.UWP
             if (chart is CartesianChart<SkiaSharpDrawingContext> or PolarChart<SkiaSharpDrawingContext>)
             {
                 location = tooltipPoints.GetCartesianTooltipLocation(
-                    chart.TooltipPosition, new System.Drawing.SizeF((float)DesiredSize.Width, (float)DesiredSize.Height), chart.ControlSize);
+                    chart.TooltipPosition,
+                    new LvcSize((float)DesiredSize.Width,
+                    (float)DesiredSize.Height),
+                    chart.ControlSize);
             }
             if (chart is PieChart<SkiaSharpDrawingContext>)
             {
                 location = tooltipPoints.GetPieTooltipLocation(
-                    chart.TooltipPosition, new System.Drawing.SizeF((float)DesiredSize.Width, (float)DesiredSize.Height));
+                    chart.TooltipPosition, new LvcSize((float)DesiredSize.Width, (float)DesiredSize.Height));
             }
 
             if (location is null) throw new Exception("location not supported");

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.UWP/PieChart.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.UWP/PieChart.xaml.cs
@@ -331,11 +331,11 @@ namespace LiveChartsCore.SkiaSharpView.UWP
         PieChart<SkiaSharpDrawingContext> IPieChartView<SkiaSharpDrawingContext>.Core
             => _core == null ? throw new Exception("core not found") : (PieChart<SkiaSharpDrawingContext>)_core;
 
-        System.Drawing.Color IChartView.BackColor
+        LvcColor IChartView.BackColor
         {
             get => Background is not SolidColorBrush b
-                    ? new System.Drawing.Color()
-                    : System.Drawing.Color.FromArgb(b.Color.A, b.Color.R, b.Color.G, b.Color.B);
+                    ? new LvcColor()
+                    : LvcColor.FromArgb(b.Color.A, b.Color.R, b.Color.G, b.Color.B);
             set => SetValue(BackgroundProperty, new SolidColorBrush(Windows.UI.Color.FromArgb(value.A, value.R, value.G, value.B)));
         }
 
@@ -388,9 +388,9 @@ namespace LiveChartsCore.SkiaSharpView.UWP
             set => SetValue(DrawMarginProperty, value);
         }
 
-        System.Drawing.SizeF IChartView.ControlSize => _canvas == null
-                    ? throw new Exception("Canvas not found")
-                    : (new() { Width = (float)_canvas.ActualWidth, Height = (float)_canvas.ActualHeight });
+        LvcSize IChartView.ControlSize => _canvas == null
+            ? throw new Exception("Canvas not found")
+            : (new() { Width = (float)_canvas.ActualWidth, Height = (float)_canvas.ActualHeight });
 
         /// <inheritdoc cref="IChartView{TDrawingContext}.CoreCanvas" />
         public MotionCanvas<SkiaSharpDrawingContext> CoreCanvas => _canvas == null ? throw new Exception("Canvas not found") : _canvas.CanvasCore;
@@ -700,8 +700,8 @@ namespace LiveChartsCore.SkiaSharpView.UWP
             ((IChartTooltip<SkiaSharpDrawingContext>)tooltip).Hide();
         }
 
-        /// <inheritdoc cref="IChartView.SetTooltipStyle(System.Drawing.Color, System.Drawing.Color)"/>
-        public void SetTooltipStyle(System.Drawing.Color background, System.Drawing.Color textColor)
+        /// <inheritdoc cref="IChartView.SetTooltipStyle(LvcColor, LvcColor)"/>
+        public void SetTooltipStyle(LvcColor background, LvcColor textColor)
         {
             TooltipBackground = new SolidColorBrush(Windows.UI.Color.FromArgb(background.A, background.R, background.G, background.B));
             TooltipTextBrush = new SolidColorBrush(Windows.UI.Color.FromArgb(textColor.A, textColor.R, textColor.G, textColor.B));
@@ -758,7 +758,7 @@ namespace LiveChartsCore.SkiaSharpView.UWP
         private void OnPointerMoved(object sender, PointerRoutedEventArgs e)
         {
             var p = e.GetCurrentPoint(this);
-            _core?.InvokePointerMove(new System.Drawing.PointF((float)p.Position.X, (float)p.Position.Y));
+            _core?.InvokePointerMove(new LvcPoint((float)p.Position.X, (float)p.Position.Y));
         }
 
         private void OnCoreUpdateFinished(IChartView<SkiaSharpDrawingContext> chart)

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.UWP/PolarChart.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.UWP/PolarChart.xaml.cs
@@ -355,11 +355,11 @@ namespace LiveChartsCore.SkiaSharpView.UWP
             set => SetValue(SyncContextProperty, value);
         }
 
-        System.Drawing.Color IChartView.BackColor
+        LvcColor IChartView.BackColor
         {
             get => Background is not SolidColorBrush b
-                    ? new System.Drawing.Color()
-                    : System.Drawing.Color.FromArgb(b.Color.A, b.Color.R, b.Color.G, b.Color.B);
+                ? new LvcColor()
+                : LvcColor.FromArgb(b.Color.A, b.Color.R, b.Color.G, b.Color.B);
             set => SetValue(BackgroundProperty, new SolidColorBrush(Windows.UI.Color.FromArgb(value.A, value.R, value.G, value.B)));
         }
 
@@ -376,7 +376,7 @@ namespace LiveChartsCore.SkiaSharpView.UWP
             set => throw new NotImplementedException();
         }
 
-        System.Drawing.SizeF IChartView.ControlSize => _canvas == null
+        LvcSize IChartView.ControlSize => _canvas == null
             ? throw new Exception("Canvas not found")
             : (new() { Width = (float)_canvas.ActualWidth, Height = (float)_canvas.ActualHeight });
 
@@ -689,8 +689,8 @@ namespace LiveChartsCore.SkiaSharpView.UWP
 
         #endregion
 
-        /// <inheritdoc cref="IPolarChartView{TDrawingContext}.ScaleUIPoint(System.Drawing.PointF, int, int)" />
-        public double[] ScaleUIPoint(System.Drawing.PointF point, int xAxisIndex = 0, int yAxisIndex = 0)
+        /// <inheritdoc cref="IPolarChartView{TDrawingContext}.ScaleUIPoint(LvcPoint, int, int)" />
+        public double[] ScaleUIPoint(LvcPoint point, int xAxisIndex = 0, int yAxisIndex = 0)
         {
             return new double[0];
             // if (_core == null) throw new Exception("core not found");
@@ -721,8 +721,8 @@ namespace LiveChartsCore.SkiaSharpView.UWP
             ((IChartTooltip<SkiaSharpDrawingContext>)tooltip).Hide();
         }
 
-        /// <inheritdoc cref="IChartView.SetTooltipStyle(System.Drawing.Color, System.Drawing.Color)"/>
-        public void SetTooltipStyle(System.Drawing.Color background, System.Drawing.Color textColor)
+        /// <inheritdoc cref="IChartView.SetTooltipStyle(LvcColor, LvcColor)"/>
+        public void SetTooltipStyle(LvcColor background, LvcColor textColor)
         {
             TooltipBackground = new SolidColorBrush(Windows.UI.Color.FromArgb(background.A, background.R, background.G, background.B));
             TooltipTextBrush = new SolidColorBrush(Windows.UI.Color.FromArgb(textColor.A, textColor.R, textColor.G, textColor.B));
@@ -792,7 +792,7 @@ namespace LiveChartsCore.SkiaSharpView.UWP
         private void OnPointerMoved(object sender, PointerRoutedEventArgs e)
         {
             var p = e.GetCurrentPoint(this);
-            _core?.InvokePointerMove(new System.Drawing.PointF((float)p.Position.X, (float)p.Position.Y));
+            _core?.InvokePointerMove(new LvcPoint((float)p.Position.X, (float)p.Position.Y));
         }
 
         private void OnCoreUpdateFinished(IChartView<SkiaSharpDrawingContext> chart)
@@ -819,7 +819,7 @@ namespace LiveChartsCore.SkiaSharpView.UWP
         private void OnPointerReleased(object sender, PointerRoutedEventArgs e)
         {
             var p = e.GetCurrentPoint(this);
-            _core?.InvokePointerUp(new System.Drawing.PointF((float)p.Position.X, (float)p.Position.Y));
+            _core?.InvokePointerUp(new LvcPoint((float)p.Position.X, (float)p.Position.Y));
             ReleasePointerCapture(e.Pointer);
         }
 
@@ -827,7 +827,7 @@ namespace LiveChartsCore.SkiaSharpView.UWP
         {
             _ = CapturePointer(e.Pointer);
             var p = e.GetCurrentPoint(this);
-            _core?.InvokePointerDown(new System.Drawing.PointF((float)p.Position.X, (float)p.Position.Y));
+            _core?.InvokePointerDown(new LvcPoint((float)p.Position.X, (float)p.Position.Y));
         }
 
         private void OnWheelChanged(object sender, PointerRoutedEventArgs e)


### PR DESCRIPTION
**Why?**

The future of `System.Drawing` namespace seems unclear, this PR removes the reference to any object in this namespace, the library was only using `Color`, `SizeF` and `PointF` structs in this namespace, with this PR the library defines is own objects and removes the need to reference this namespace in the core packages.

**Braking Changes**

Sadly this is the fist PR that has breaking changes, but the changes are minimal and might not apply for everyone using the library.

- Any property of type `System.Drawing.Color` now should use `LiveChartsCore.Drawing.LvcColor`.
- Any property of type `System.Drawing.SizeF` now should use `LiveChartsCore.Drawing.LvcSize`.
- Any property of type `System.Drawing.PointF` now should use `LiveChartsCore.Drawing.LvcPoint`.

