### PR TITLE
Fixes display scaling in UWP

### DIFF
--- a/src/skiasharp/LiveChartsCore.SkiaSharpVew.WinUI/MotionCanvas.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpVew.WinUI/MotionCanvas.xaml.cs
@@ -99,6 +99,8 @@ namespace LiveChartsCore.SkiaSharpView.WinUI
 
         private void OnPaintSurface(object? sender, SKPaintSurfaceEventArgs args)
         {
+            var scaleFactor = XamlRoot.RasterizationScale;
+            args.Surface.Canvas.Scale((float)scaleFactor, (float)scaleFactor);
             CanvasCore.DrawFrame(new SkiaSharpDrawingContext(CanvasCore, args.Info, args.Surface, args.Surface.Canvas));
         }
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.UWP/MotionCanvas.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.UWP/MotionCanvas.xaml.cs
@@ -27,6 +27,7 @@ using LiveChartsCore.Drawing;
 using LiveChartsCore.Kernel;
 using LiveChartsCore.SkiaSharpView.Drawing;
 using SkiaSharp.Views.UWP;
+using Windows.Graphics.Display;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 


### PR DESCRIPTION
When using HIDPI monitor with display scaling set to greater than 100%, chart canvas would not scale correctly. This PR corrects this issue, see before & after pics below:-

![image](https://user-images.githubusercontent.com/89976865/132248170-3c2254ad-b927-43f9-82c4-105b04ef8c21.png)
![image](https://user-images.githubusercontent.com/89976865/132248182-7583e34c-338a-4169-b102-c1bd58702e48.png)
