### PR TITLE
Fixes reattach visual scaling in UWP & WinUI

### DIFF
--- a/src/skiasharp/LiveChartsCore.SkiaSharpVew.WinUI/MotionCanvas.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpVew.WinUI/MotionCanvas.xaml.cs
@@ -39,7 +39,7 @@ namespace LiveChartsCore.SkiaSharpView.WinUI
     /// <seealso cref="Microsoft.UI.Xaml.Markup.IComponentConnector" />
     public sealed partial class MotionCanvas : UserControl
     {
-        private SKXamlCanvas? _skiaElement;
+        private readonly SKXamlCanvas? _skiaElement;
         private bool _isDrawingLoopRunning;
 
         /// <summary>
@@ -50,7 +50,7 @@ namespace LiveChartsCore.SkiaSharpView.WinUI
             InitializeComponent();
             Loaded += OnLoaded;
             Unloaded += OnUnloaded;
-            
+
             var canvas = (SKXamlCanvas)FindName("canvas");
             _skiaElement = canvas;
             _skiaElement.PaintSurface += OnPaintSurface;

--- a/src/skiasharp/LiveChartsCore.SkiaSharpVew.WinUI/MotionCanvas.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpVew.WinUI/MotionCanvas.xaml.cs
@@ -50,6 +50,10 @@ namespace LiveChartsCore.SkiaSharpView.WinUI
             InitializeComponent();
             Loaded += OnLoaded;
             Unloaded += OnUnloaded;
+            
+            var canvas = (SKXamlCanvas)FindName("canvas");
+            _skiaElement = canvas;
+            _skiaElement.PaintSurface += OnPaintSurface;
         }
 
         /// <summary>
@@ -91,10 +95,6 @@ namespace LiveChartsCore.SkiaSharpView.WinUI
         private void OnLoaded(object sender, RoutedEventArgs e)
         {
             CanvasCore.Invalidated += OnCanvasCoreInvalidated;
-
-            var canvas = (SKXamlCanvas)FindName("canvas");
-            _skiaElement = canvas;
-            _skiaElement.PaintSurface += OnPaintSurface;
         }
 
         private void OnPaintSurface(object? sender, SKPaintSurfaceEventArgs args)

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.UWP/MotionCanvas.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.UWP/MotionCanvas.xaml.cs
@@ -35,7 +35,7 @@ namespace LiveChartsCore.SkiaSharpView.UWP
     /// <inheritdoc cref="MotionCanvas{TDrawingContext}"/>
     public sealed partial class MotionCanvas : UserControl
     {
-        private SKXamlCanvas? _skiaElement;
+        private readonly SKXamlCanvas _skiaElement;
         private bool _isDrawingLoopRunning;
 
         /// <summary>
@@ -46,7 +46,7 @@ namespace LiveChartsCore.SkiaSharpView.UWP
             InitializeComponent();
             Loaded += OnLoaded;
             Unloaded += OnUnloaded;
-            
+
             var canvas = (SKXamlCanvas)FindName("canvas");
             _skiaElement = canvas;
             _skiaElement.PaintSurface += OnPaintSurface;
@@ -93,7 +93,7 @@ namespace LiveChartsCore.SkiaSharpView.UWP
             CanvasCore.Invalidated += OnCanvasCoreInvalidated;
         }
 
-        private void OnPaintSurface(object? sender, SKPaintSurfaceEventArgs args)
+        private void OnPaintSurface(object sender, SKPaintSurfaceEventArgs args)
         {
             var scaleFactor = XamlRoot.RasterizationScale;
             args.Surface.Canvas.Scale((float)scaleFactor, (float)scaleFactor);

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.UWP/MotionCanvas.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.UWP/MotionCanvas.xaml.cs
@@ -27,7 +27,6 @@ using LiveChartsCore.Drawing;
 using LiveChartsCore.Kernel;
 using LiveChartsCore.SkiaSharpView.Drawing;
 using SkiaSharp.Views.UWP;
-using Windows.Graphics.Display;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
@@ -47,6 +46,10 @@ namespace LiveChartsCore.SkiaSharpView.UWP
             InitializeComponent();
             Loaded += OnLoaded;
             Unloaded += OnUnloaded;
+            
+            var canvas = (SKXamlCanvas)FindName("canvas");
+            _skiaElement = canvas;
+            _skiaElement.PaintSurface += OnPaintSurface;
         }
 
         /// <summary>
@@ -88,15 +91,11 @@ namespace LiveChartsCore.SkiaSharpView.UWP
         private void OnLoaded(object sender, RoutedEventArgs e)
         {
             CanvasCore.Invalidated += OnCanvasCoreInvalidated;
-
-            var canvas = (SKXamlCanvas)FindName("canvas");
-            _skiaElement = canvas;
-            _skiaElement.PaintSurface += OnPaintSurface;
         }
 
         private void OnPaintSurface(object? sender, SKPaintSurfaceEventArgs args)
         {
-            var scaleFactor = DisplayInformation.GetForCurrentView().RawPixelsPerViewPixel;
+            var scaleFactor = XamlRoot.RasterizationScale;
             args.Surface.Canvas.Scale((float)scaleFactor, (float)scaleFactor);
             CanvasCore.DrawFrame(new SkiaSharpDrawingContext(CanvasCore, args.Info, args.Surface, args.Surface.Canvas));
         }


### PR DESCRIPTION
Fixes issue where OnPaintSurface would be called each time we toggle attach visual. This caused behaviour on HIDPI display where canvas would be scaled each time. See before and after pics below:-

![image](https://user-images.githubusercontent.com/89976865/132342261-68a27cd9-2c82-4b79-a789-ec52fc9b1afe.png)
