### PR TITLE
Bugfix WPF: Chart.cs and GeoMap.cs 

### DIFF
--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/Chart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/Chart.cs
@@ -668,7 +668,8 @@ namespace LiveChartsCore.SkiaSharpView.WPF
 
         void IChartView.InvokeOnUIThread(Action action)
         {
-            Application.Current.Dispatcher.Invoke(action);
+            Dispatcher.Invoke(action);
+            //Application.Current.Dispatcher.Invoke(action);
         }
 
         /// <inheritdoc cref="IChartView.SyncAction(Action)"/>

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/GeoMap.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/GeoMap.cs
@@ -267,7 +267,7 @@ namespace LiveChartsCore.SkiaSharpView.WPF
 
         void IGeoMapView<SkiaSharpDrawingContext>.InvokeOnUIThread(Action action)
         {
-            Application.Current.Dispatcher.Invoke(action);
+            Dispatcher.Invoke(action);
         }
 
         private void GeoMap_SizeChanged(object sender, SizeChangedEventArgs e)


### PR DESCRIPTION
Chart.cs and GeoMap.cs are now using "System.Windows.Threading.Dispatcher".Invoke instead of "Application.Current.Dispatcher" to execute code on the UI thread, as "Application.Current.Dispatcher" is not available, if the hosting UI framework is not WPF (e.g. a WinForms application shows a WPF view using a LiveCharts chart)

fixes #243 