### PR TITLE
Setting foreground and background for default legend in UWP

### DIFF
--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.UWP/DefaultLegend.xaml
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.UWP/DefaultLegend.xaml
@@ -13,7 +13,10 @@
     <ItemsControl ItemsSource="{Binding Series}">
         <ItemsControl.ItemsPanel>
             <ItemsPanelTemplate>
-                <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Orientation="Vertical" />
+                <StackPanel Background="{Binding Background}"
+                            HorizontalAlignment="Center"
+                            VerticalAlignment="Center"
+                            Orientation="Vertical" />
             </ItemsPanelTemplate>
         </ItemsControl.ItemsPanel>
         <ItemsControl.ItemTemplate>

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.UWP/DefaultLegend.xaml
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.UWP/DefaultLegend.xaml
@@ -20,13 +20,12 @@
             <DataTemplate x:DataType="core:ISeries">
                 <Border Padding="15 4">
                     <StackPanel Orientation="Horizontal">
-                        <local:MotionCanvas Margin="0 0 8 0" 
+                        <local:MotionCanvas Margin="0 0 8 0"
                                     PaintTasks="{Binding CanvasSchedule.PaintSchedules}"
                                     Width="{Binding CanvasSchedule.Width}"
                                     Height="{Binding CanvasSchedule.Height}"
                                     VerticalAlignment="Center"/>
                         <TextBlock Text="{x:Bind Name}"
-                                   Foreground="Black"
                                    VerticalAlignment="Center"/>
                     </StackPanel>
                 </Border>

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.UWP/DefaultLegend.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.UWP/DefaultLegend.xaml.cs
@@ -132,7 +132,7 @@ namespace LiveChartsCore.SkiaSharpView.UWP
                     : Orientation.Vertical;
 
             FontFamily = winuiChart.LegendFontFamily;
-            //TextColor = wpfChart.LegendTextBrush;
+            Foreground = winuiChart.LegendTextBrush;
             FontSize = winuiChart.LegendFontSize;
             FontWeight = winuiChart.LegendFontWeight;
             FontStyle = winuiChart.LegendFontStyle;

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.UWP/DefaultLegend.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.UWP/DefaultLegend.xaml.cs
@@ -137,7 +137,7 @@ namespace LiveChartsCore.SkiaSharpView.UWP
             FontWeight = winuiChart.LegendFontWeight;
             FontStyle = winuiChart.LegendFontStyle;
             FontStretch = winuiChart.LegendFontStretch;
-            //LegendBackground = wpfChart.LegendBackground;
+            Background = winuiChart.LegendBackground;
 
             UpdateLayout();
         }


### PR DESCRIPTION
Enabled setting text foreground color in legend by setting LegendTextBrush
Enabled setting legend background by LegendBackground

Fixes #264 