### PR TITLE
fixed polar bug

### DIFF
--- a/src/LiveChartsCore/Kernel/SeriesProperties.cs
+++ b/src/LiveChartsCore/Kernel/SeriesProperties.cs
@@ -119,6 +119,11 @@ namespace LiveChartsCore.Kernel
         /// <summary>
         /// The prefers xy tool tips
         /// </summary>
-        PrefersXYStrategyTooltips = 1 << 18
+        PrefersXYStrategyTooltips = 1 << 18,
+
+        /// <summary>
+        /// The polar series
+        /// </summary>
+        Polar = 1 << 19
     }
 }

--- a/src/LiveChartsCore/PolarChart.cs
+++ b/src/LiveChartsCore/PolarChart.cs
@@ -468,7 +468,6 @@ namespace LiveChartsCore
                 // apply padding
                 if (axis.MinLimit is null)
                 {
-                    var s = 0d;//new Scaler(DrawMarginLocation, DrawMarginSize, axis);
                     // correction by geometry size
                     var p = 0d;//Math.Abs(s.ToChartValues(axis.DataBounds.RequestedGeometrySize) - s.ToChartValues(0));
                     if (axis.DataBounds.PaddingMin > p) p = axis.DataBounds.PaddingMin;

--- a/src/LiveChartsCore/PolarLineSeries.cs
+++ b/src/LiveChartsCore/PolarLineSeries.cs
@@ -64,7 +64,7 @@ namespace LiveChartsCore
         /// <param name="isStacked">if set to <c>true</c> [is stacked].</param>
         public PolarLineSeries(bool isStacked = false)
             : base(
-                  SeriesProperties.Line | SeriesProperties.PrimaryAxisVerticalOrientation |
+                  SeriesProperties.Polar | SeriesProperties.PrimaryAxisVerticalOrientation |
                   (isStacked ? SeriesProperties.Stacked : 0) | SeriesProperties.Sketch | SeriesProperties.PrefersXStrategyTooltips)
         {
             DataPadding = new LvcPoint(1f, 1.5f);

--- a/src/LiveChartsCore/Themes/VisualsStyle.cs
+++ b/src/LiveChartsCore/Themes/VisualsStyle.cs
@@ -126,6 +126,22 @@ namespace LiveChartsCore.Themes
         /// Gets or sets the line series builder.
         /// </summary>
         /// <value>
+        /// The polar series builder.
+        /// </value>
+        public List<Action<IPolarSeries<TDrawingContext>>> PolarSeriesBuilder { get; set; } = new List<Action<IPolarSeries<TDrawingContext>>>();
+
+        /// <summary>
+        /// Gets or sets the line series builder.
+        /// </summary>
+        /// <value>
+        /// The polar series builder.
+        /// </value>
+        public List<Action<IPolarSeries<TDrawingContext>>> StackedPolarSeriesBuilder { get; set; } = new List<Action<IPolarSeries<TDrawingContext>>>();
+
+        /// <summary>
+        /// Gets or sets the line series builder.
+        /// </summary>
+        /// <value>
         /// The pie series builder.
         /// </value>
         public List<Action<IHeatSeries<TDrawingContext>>> HeatSeriesBuilder { get; set; } = new List<Action<IHeatSeries<TDrawingContext>>>();
@@ -310,6 +326,17 @@ namespace LiveChartsCore.Themes
                 if ((series.SeriesProperties & SeriesProperties.Stacked) == SeriesProperties.Stacked)
                 {
                     foreach (var rule in StackedLineSeriesBuilder) rule(lineSeries);
+                }
+            }
+
+            if ((series.SeriesProperties & SeriesProperties.Polar) == SeriesProperties.Polar)
+            {
+                var polarSeries = (IPolarSeries<TDrawingContext>)series;
+                foreach (var rule in PolarSeriesBuilder) rule(polarSeries);
+
+                if ((series.SeriesProperties & SeriesProperties.Stacked) == SeriesProperties.Stacked)
+                {
+                    foreach (var rule in StackedPolarSeriesBuilder) rule(polarSeries);
                 }
             }
 


### PR DESCRIPTION
This is a bug fix related to https://github.com/beto-rodriguez/LiveCharts2/issues/271.

The problem was actually with the implementation of PolarCharts. It seems that there was no definition of 'polar' in SeriesProperties.cs for the style object (VisualStyle.cs) to interpret _and_ that the seriesproperty in the PolarLineSeries constructor in core was being set to 'Line'. As far as I can tell, this patch corrects the issue. Polar/Basic is now working as well (same bug in effect there). 