### PR TITLE
Allow setting a Legend in SKCartesianChart

### DIFF
--- a/src/skiasharp/LiveChartsCore.SkiaSharp/SKCharts/SKCartesianChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/SKCharts/SKCartesianChart.cs
@@ -138,7 +138,7 @@ namespace LiveChartsCore.SkiaSharpView.SKCharts
         public MotionCanvas<SkiaSharpDrawingContext> CoreCanvas { get; } = new();
 
         /// <inheritdoc cref="IChartView{TDrawingContext}.Legend"/>
-        public IChartLegend<SkiaSharpDrawingContext>? Legend => null;
+        public IChartLegend<SkiaSharpDrawingContext>? Legend { get; set; }
 
         /// <inheritdoc cref="IChartView{TDrawingContext}.Tooltip"/>
         public IChartTooltip<SkiaSharpDrawingContext>? Tooltip => null;


### PR DESCRIPTION
Per #144, `Legend`s are not currently supported for `ISkiaSharpChart`s.

This PR takes a first step in adding legends to `SkiaSharp` charts, by allowing a custom `IChartLegend<SkiaSharpDrawingContext>` to be set on an `SKCartesianChart`.

My hope is to get all the details worked out in my own project and use what I learn to contribute a more generic default back upstream when it's ready.