### PR TITLE
Fixes #355 (UWP compatibility issue with Win10 build 17763)

### DIFF
--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.UWP/MotionCanvas.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.UWP/MotionCanvas.xaml.cs
@@ -27,6 +27,7 @@ using LiveChartsCore.Drawing;
 using LiveChartsCore.Kernel;
 using LiveChartsCore.SkiaSharpView.Drawing;
 using SkiaSharp.Views.UWP;
+using Windows.Graphics.Display;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
@@ -95,7 +96,7 @@ namespace LiveChartsCore.SkiaSharpView.UWP
 
         private void OnPaintSurface(object sender, SKPaintSurfaceEventArgs args)
         {
-            var scaleFactor = XamlRoot.RasterizationScale;
+            var scaleFactor = DisplayInformation.GetForCurrentView().RawPixelsPerViewPixel;
             args.Surface.Canvas.Scale((float)scaleFactor, (float)scaleFactor);
             CanvasCore.DrawFrame(new SkiaSharpDrawingContext(CanvasCore, args.Info, args.Surface, args.Surface.Canvas));
         }


### PR DESCRIPTION
DisplayInformation.RawPixelsPerViewPixel property offers wider compatibility with early WinRT versions as shown below :-

![displayinformation](https://user-images.githubusercontent.com/89976865/148460351-a8f2c511-6730-4eaa-8c86-c0c9b2086114.png)

https://docs.microsoft.com/en-us/uwp/api/windows.graphics.display.displayinformation.rawpixelsperviewpixel
https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.xamlroot.rasterizationscale