### PR TITLE
Bugfix  InvalidOperationException on DataFactory.Fetch(..)

### DIFF
--- a/src/LiveChartsCore/Kernel/Providers/DataFactory.cs
+++ b/src/LiveChartsCore/Kernel/Providers/DataFactory.cs
@@ -22,6 +22,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using LiveChartsCore.Drawing;
 using LiveChartsCore.Kernel.Sketches;
@@ -102,16 +103,39 @@ public class DataFactory<TModel, TDrawingContext>
             }
             var byReferenceVisualMap = d;
 
-            foreach (var item in series.Values)
+            //Try to use list indexer instead of enumerator as the collection of the series is not synchronized
+            if (series.Values is IList<TModel> list)
             {
-                if (!byReferenceVisualMap.TryGetValue(item, out var cp))
-                    byReferenceVisualMap[item] = cp = new ChartPoint(chart.View, series);
+                for (var i = 0; i < list.Count; i++)
+                {
+                    var collectionItem = list[i];
+                    if (collectionItem == null)
+                        continue;
 
-                cp.Context.Index = index++;
-                cp.Context.DataSource = item;
-                mapper(item, cp);
+                    if (!byReferenceVisualMap.TryGetValue(collectionItem, out var cp))
+                        byReferenceVisualMap[collectionItem] = cp = new ChartPoint(chart.View, series);
 
-                yield return cp;
+                    cp.Context.Index = index++;
+                    cp.Context.DataSource = collectionItem;
+                    mapper(collectionItem, cp);
+
+                    yield return cp;
+                }
+            }
+            //Fallback: use enumerator
+            else
+            {
+                foreach (var item in series.Values)
+                {
+                    if (!byReferenceVisualMap.TryGetValue(item, out var cp))
+                        byReferenceVisualMap[item] = cp = new ChartPoint(chart.View, series);
+
+                    cp.Context.Index = index++;
+                    cp.Context.DataSource = item;
+                    mapper(item, cp);
+
+                    yield return cp;
+                }
             }
         }
     }


### PR DESCRIPTION
Fetch(..) does now try to use the IList indexer instead of the enumerator as other wise an InvalidOperationException could be thrown, if the data source changes faster than the chart could be updated

See #383 for a detailed error description