### PR TITLE
Fixed LegendBackground color issue and Binding exceptions for conversion to double (Xamarin Forms and Maui)

### DIFF
--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/CartesianChart.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/CartesianChart.xaml.cs
@@ -272,16 +272,16 @@ public partial class CartesianChart : ContentView, ICartesianChartView<SkiaSharp
     /// </summary>
     public static readonly BindableProperty LegendTextBrushProperty =
         BindableProperty.Create(
-            nameof(LegendTextBrush), typeof(c), typeof(CartesianChart),
-            new c(35 / 255d, 35 / 255d, 35 / 255d), propertyChanged: OnBindablePropertyChanged);
+            nameof(LegendTextBrush), typeof(Color), typeof(CartesianChart),
+            new Color(35 / 255d, 35 / 255d, 35 / 255d), propertyChanged: OnBindablePropertyChanged);
 
     /// <summary>
     /// The legend background property.
     /// </summary>
     public static readonly BindableProperty LegendBackgroundProperty =
         BindableProperty.Create(
-            nameof(LegendTextBrush), typeof(c), typeof(CartesianChart),
-            new c(255 / 255d, 255 / 255d, 255 / 255d), propertyChanged: OnBindablePropertyChanged);
+            nameof(LegendBackground), typeof(Color), typeof(CartesianChart),
+            new Color(255 / 255d, 255 / 255d, 255 / 255d), propertyChanged: OnBindablePropertyChanged);
 
     /// <summary>
     /// The legend font attributes property.
@@ -333,16 +333,16 @@ public partial class CartesianChart : ContentView, ICartesianChartView<SkiaSharp
     /// </summary>
     public static readonly BindableProperty TooltipTextBrushProperty =
         BindableProperty.Create(
-            nameof(TooltipTextBrush), typeof(c), typeof(CartesianChart),
-            new c(35 / 255d, 35 / 255d, 35 / 255d), propertyChanged: OnBindablePropertyChanged);
+            nameof(TooltipTextBrush), typeof(Color), typeof(CartesianChart),
+            new Color(35 / 255d, 35 / 255d, 35 / 255d), propertyChanged: OnBindablePropertyChanged);
 
     /// <summary>
     /// The tool tip background property.
     /// </summary>
     public static readonly BindableProperty TooltipBackgroundProperty =
         BindableProperty.Create(
-            nameof(TooltipBackground), typeof(c), typeof(CartesianChart),
-            new c(250 / 255d, 250 / 255d, 250 / 255d), propertyChanged: OnBindablePropertyChanged);
+            nameof(TooltipBackground), typeof(Color), typeof(CartesianChart),
+            new Color(250 / 255d, 250 / 255d, 250 / 255d), propertyChanged: OnBindablePropertyChanged);
 
     /// <summary>
     /// The tool tip font attributes property
@@ -561,9 +561,9 @@ public partial class CartesianChart : ContentView, ICartesianChartView<SkiaSharp
     /// <value>
     /// The color of the legend text.
     /// </value>
-    public c LegendTextBrush
+    public Color LegendTextBrush
     {
-        get => (c)GetValue(LegendTextBrushProperty);
+        get => (Color)GetValue(LegendTextBrushProperty);
         set => SetValue(LegendTextBrushProperty, value);
     }
 
@@ -573,9 +573,9 @@ public partial class CartesianChart : ContentView, ICartesianChartView<SkiaSharp
     /// <value>
     /// The color of the legend background.
     /// </value>
-    public c LegendBackground
+    public Color LegendBackground
     {
-        get => (c)GetValue(LegendBackgroundProperty);
+        get => (Color)GetValue(LegendBackgroundProperty);
         set => SetValue(LegendBackgroundProperty, value);
     }
 
@@ -650,9 +650,9 @@ public partial class CartesianChart : ContentView, ICartesianChartView<SkiaSharp
     /// <value>
     /// The color of the tool tip text.
     /// </value>
-    public c TooltipTextBrush
+    public Color TooltipTextBrush
     {
-        get => (c)GetValue(TooltipTextBrushProperty);
+        get => (Color)GetValue(TooltipTextBrushProperty);
         set => SetValue(TooltipTextBrushProperty, value);
     }
 
@@ -662,9 +662,9 @@ public partial class CartesianChart : ContentView, ICartesianChartView<SkiaSharp
     /// <value>
     /// The color of the tool tip background.
     /// </value>
-    public c TooltipBackground
+    public Color TooltipBackground
     {
-        get => (c)GetValue(TooltipBackgroundProperty);
+        get => (Color)GetValue(TooltipBackgroundProperty);
         set => SetValue(TooltipBackgroundProperty, value);
     }
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/DefaultLegend.xaml
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/DefaultLegend.xaml
@@ -7,7 +7,7 @@
 
     <ContentView.Resources>
         <DataTemplate x:Key="defaultTemplate">
-            <Frame>
+            <Frame BackgroundColor="{Binding BackgroundColor}">
                 <StackLayout 
                     BindableLayout.ItemsSource="{Binding Series, Source={RelativeSource AncestorType={x:Type local:LegendBindingContext}}}"
                     BackgroundColor="{Binding BackgroundColor, Source={RelativeSource AncestorType={x:Type local:LegendBindingContext}}}"

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/DefaultLegend.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/DefaultLegend.xaml.cs
@@ -112,10 +112,10 @@ public partial class DefaultLegend : ContentView, IChartLegend<SkiaSharpDrawingC
 
     void IChartLegend<SkiaSharpDrawingContext>.Draw(Chart<SkiaSharpDrawingContext> chart)
     {
-        var mobileChart = (IMobileChart)chart.View;
-        var series = chart.ChartSeries;
-        var legendOrientation = chart.LegendOrientation;
-        var legendPosition = chart.LegendPosition;
+        IMobileChart? mobileChart = (IMobileChart)chart.View;
+        IEnumerable<IChartSeries<SkiaSharpDrawingContext>>? series = chart.ChartSeries;
+        LegendOrientation legendOrientation = chart.LegendOrientation;
+        LegendPosition legendPosition = chart.LegendPosition;
         Series = series;
 
         switch (legendPosition)
@@ -201,7 +201,7 @@ public partial class DefaultLegend : ContentView, IChartLegend<SkiaSharpDrawingC
                 : StackOrientation.Vertical;
 
         LegendTemplate = mobileChart.LegendTemplate;
-        LegendBackgroundColor = mobileChart.TooltipBackground;
+        LegendBackgroundColor = mobileChart.LegendBackground;
         LegendFontFamily = mobileChart.LegendFontFamily;
         LegendFontSize = mobileChart.LegendFontSize;
         LegendTextColor = mobileChart.LegendTextBrush;
@@ -215,7 +215,7 @@ public partial class DefaultLegend : ContentView, IChartLegend<SkiaSharpDrawingC
     /// </summary>
     protected void BuildContent()
     {
-        var template = LegendTemplate ?? _defaultTemplate;
+        DataTemplate? template = LegendTemplate ?? _defaultTemplate;
         if (template.CreateContent() is not View view) return;
 
         view.BindingContext = new LegendBindingContext
@@ -226,7 +226,7 @@ public partial class DefaultLegend : ContentView, IChartLegend<SkiaSharpDrawingC
             TextColor = LegendTextColor,
             FontAttributes = LegendFontAttributes,
             Orientation = LegendOrientation,
-            BackgroundColor = LegendBackgroundColor
+            BackgroundColor = LegendBackgroundColor,
         };
 
         Content = view;

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/HeightConverter.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/HeightConverter.cs
@@ -50,8 +50,8 @@ public class HeightConverter : IValueConverter
     public object? Convert(object value, Type targetType, object parameter, CultureInfo culture)
     {
         return value is IChartSeries<SkiaSharpDrawingContext> v
-            ? v.CanvasSchedule.Height / DeviceDisplay.MainDisplayInfo.Density
-            : null;
+            ? (double)v.CanvasSchedule.Height / (double)DeviceDisplay.MainDisplayInfo.Density
+            : 0;
     }
 
     /// <summary>

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/PieChart.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/PieChart.xaml.cs
@@ -215,7 +215,7 @@ public partial class PieChart : ContentView, IPieChartView<SkiaSharpDrawingConte
     public static readonly BindableProperty LegendTextBrushProperty =
         BindableProperty.Create(
             nameof(LegendTextBrush), typeof(c), typeof(CartesianChart),
-            new c(35 / 255d, 35 / 255d, 35 / 255d), propertyChanged: OnBindablePropertyChanged);
+            new Color(35 / 255d, 35 / 255d, 35 / 255d), propertyChanged: OnBindablePropertyChanged);
 
     /// <summary>
     /// The legend background property
@@ -223,7 +223,7 @@ public partial class PieChart : ContentView, IPieChartView<SkiaSharpDrawingConte
     public static readonly BindableProperty LegendBackgroundProperty =
         BindableProperty.Create(
             nameof(LegendBackground), typeof(c), typeof(CartesianChart),
-            new c(250 / 255d, 250 / 255d, 250 / 255d), propertyChanged: OnBindablePropertyChanged);
+            new Color(250 / 255d, 250 / 255d, 250 / 255d), propertyChanged: OnBindablePropertyChanged);
 
     /// <summary>
     /// The legend font attributes property
@@ -267,16 +267,16 @@ public partial class PieChart : ContentView, IPieChartView<SkiaSharpDrawingConte
     /// </summary>
     public static readonly BindableProperty TooltipTextColorProperty =
         BindableProperty.Create(
-            nameof(TooltipTextBrush), typeof(c), typeof(CartesianChart),
-            new c(35 / 255d, 35 / 255d, 35 / 255d), propertyChanged: OnBindablePropertyChanged);
+            nameof(TooltipTextBrush), typeof(Color), typeof(CartesianChart),
+            new Color(35 / 255d, 35 / 255d, 35 / 255d), propertyChanged: OnBindablePropertyChanged);
 
     /// <summary>
     /// The tool tip background property
     /// </summary>
     public static readonly BindableProperty TooltipBackgroundProperty =
         BindableProperty.Create(
-            nameof(TooltipBackground), typeof(c), typeof(CartesianChart),
-            new c(250 / 255d, 250 / 255d, 250 / 255d), propertyChanged: OnBindablePropertyChanged);
+            nameof(TooltipBackground), typeof(Color), typeof(CartesianChart),
+            new Color(250 / 255d, 250 / 255d, 250 / 255d), propertyChanged: OnBindablePropertyChanged);
 
     /// <summary>
     /// The tool tip font attributes property
@@ -475,9 +475,9 @@ public partial class PieChart : ContentView, IPieChartView<SkiaSharpDrawingConte
     /// <value>
     /// The color of the legend text.
     /// </value>
-    public c LegendTextBrush
+    public Color LegendTextBrush
     {
-        get => (c)GetValue(LegendTextBrushProperty);
+        get => (Color)GetValue(LegendTextBrushProperty);
         set => SetValue(LegendTextBrushProperty, value);
     }
 
@@ -487,9 +487,9 @@ public partial class PieChart : ContentView, IPieChartView<SkiaSharpDrawingConte
     /// <value>
     /// The color of the legend background.
     /// </value>
-    public c LegendBackground
+    public Color LegendBackground
     {
-        get => (c)GetValue(LegendBackgroundProperty);
+        get => (Color)GetValue(LegendBackgroundProperty);
         set => SetValue(LegendBackgroundProperty, value);
     }
 
@@ -557,9 +557,9 @@ public partial class PieChart : ContentView, IPieChartView<SkiaSharpDrawingConte
     /// <value>
     /// The color of the tool tip text.
     /// </value>
-    public c TooltipTextBrush
+    public Color TooltipTextBrush
     {
-        get => (c)GetValue(TooltipTextColorProperty);
+        get => (Color)GetValue(TooltipTextColorProperty);
         set => SetValue(TooltipTextColorProperty, value);
     }
 
@@ -569,9 +569,9 @@ public partial class PieChart : ContentView, IPieChartView<SkiaSharpDrawingConte
     /// <value>
     /// The color of the tool tip background.
     /// </value>
-    public c TooltipBackground
+    public Color TooltipBackground
     {
-        get => (c)GetValue(TooltipBackgroundProperty);
+        get => (Color)GetValue(TooltipBackgroundProperty);
         set => SetValue(TooltipBackgroundProperty, value);
     }
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/PolarChart.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/PolarChart.xaml.cs
@@ -250,16 +250,16 @@ public partial class PolarChart : ContentView, IPolarChartView<SkiaSharpDrawingC
     /// </summary>
     public static readonly BindableProperty LegendTextBrushProperty =
         BindableProperty.Create(
-            nameof(LegendTextBrush), typeof(c), typeof(PolarChart),
-            new c(35 / 255d, 35 / 255d, 35 / 255d), propertyChanged: OnBindablePropertyChanged);
+            nameof(LegendTextBrush), typeof(Color), typeof(PolarChart),
+            new Color(35 / 255d, 35 / 255d, 35 / 255d), propertyChanged: OnBindablePropertyChanged);
 
     /// <summary>
     /// The legend background property.
     /// </summary>
     public static readonly BindableProperty LegendBackgroundProperty =
         BindableProperty.Create(
-            nameof(LegendTextBrush), typeof(c), typeof(PolarChart),
-            new c(255 / 255d, 255 / 255d, 255 / 255d), propertyChanged: OnBindablePropertyChanged);
+            nameof(LegendBackground), typeof(Color), typeof(PolarChart),
+            new Color(255 / 255d, 255 / 255d, 255 / 255d), propertyChanged: OnBindablePropertyChanged);
 
     /// <summary>
     /// The legend font attributes property.
@@ -311,16 +311,16 @@ public partial class PolarChart : ContentView, IPolarChartView<SkiaSharpDrawingC
     /// </summary>
     public static readonly BindableProperty TooltipTextBrushProperty =
         BindableProperty.Create(
-            nameof(TooltipTextBrush), typeof(c), typeof(PolarChart),
-            new c(35 / 255d, 35 / 255d, 35 / 255d), propertyChanged: OnBindablePropertyChanged);
+            nameof(TooltipTextBrush), typeof(Color), typeof(PolarChart),
+            new Color(35 / 255d, 35 / 255d, 35 / 255d), propertyChanged: OnBindablePropertyChanged);
 
     /// <summary>
     /// The tool tip background property.
     /// </summary>
     public static readonly BindableProperty TooltipBackgroundProperty =
         BindableProperty.Create(
-            nameof(TooltipBackground), typeof(c), typeof(PolarChart),
-            new c(250 / 255d, 250 / 255d, 250 / 255d), propertyChanged: OnBindablePropertyChanged);
+            nameof(TooltipBackground), typeof(Color), typeof(PolarChart),
+            new Color(250 / 255d, 250 / 255d, 250 / 255d), propertyChanged: OnBindablePropertyChanged);
 
     /// <summary>
     /// The tool tip font attributes property.
@@ -540,9 +540,9 @@ public partial class PolarChart : ContentView, IPolarChartView<SkiaSharpDrawingC
     /// <value>
     /// The color of the legend text.
     /// </value>
-    public c LegendTextBrush
+    public Color LegendTextBrush
     {
-        get => (c)GetValue(LegendTextBrushProperty);
+        get => (Color)GetValue(LegendTextBrushProperty);
         set => SetValue(LegendTextBrushProperty, value);
     }
 
@@ -552,9 +552,9 @@ public partial class PolarChart : ContentView, IPolarChartView<SkiaSharpDrawingC
     /// <value>
     /// The color of the legend background.
     /// </value>
-    public c LegendBackground
+    public Color LegendBackground
     {
-        get => (c)GetValue(LegendBackgroundProperty);
+        get => (Color)GetValue(LegendBackgroundProperty);
         set => SetValue(LegendBackgroundProperty, value);
     }
 
@@ -622,9 +622,9 @@ public partial class PolarChart : ContentView, IPolarChartView<SkiaSharpDrawingC
     /// <value>
     /// The color of the tool tip text.
     /// </value>
-    public c TooltipTextBrush
+    public Color TooltipTextBrush
     {
-        get => (c)GetValue(TooltipTextBrushProperty);
+        get => (Color)GetValue(TooltipTextBrushProperty);
         set => SetValue(TooltipTextBrushProperty, value);
     }
 
@@ -634,9 +634,9 @@ public partial class PolarChart : ContentView, IPolarChartView<SkiaSharpDrawingC
     /// <value>
     /// The color of the tool tip background.
     /// </value>
-    public c TooltipBackground
+    public Color TooltipBackground
     {
-        get => (c)GetValue(TooltipBackgroundProperty);
+        get => (Color)GetValue(TooltipBackgroundProperty);
         set => SetValue(TooltipBackgroundProperty, value);
     }
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/WidthConverter.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/WidthConverter.cs
@@ -51,7 +51,7 @@ public class WidthConverter : IValueConverter
     {
         return value is IChartSeries<SkiaSharpDrawingContext> v
             ? v.CanvasSchedule.Width / DeviceDisplay.MainDisplayInfo.Density
-            : null;
+            : 0;
     }
 
     /// <summary>

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Blazor/LiveChartsCore.SkiaSharpView.Blazor.csproj
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Blazor/LiveChartsCore.SkiaSharpView.Blazor.csproj
@@ -41,7 +41,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="6.0.1" />
-    <PackageReference Include="Microsoft.TypeScript.MSBuild" Version="4.5.3">
+    <PackageReference Include="Microsoft.TypeScript.MSBuild" Version="4.6.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/CartesianChart.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/CartesianChart.xaml.cs
@@ -280,7 +280,7 @@ public partial class CartesianChart : ContentView, ICartesianChartView<SkiaSharp
     /// </summary>
     public static readonly BindableProperty LegendBackgroundProperty =
         BindableProperty.Create(
-            nameof(LegendTextBrush), typeof(Color), typeof(CartesianChart),
+            nameof(LegendBackground), typeof(Color), typeof(CartesianChart),
             Color.FromRgb(255 / 255d, 255 / 255d, 255 / 255d), propertyChanged: OnBindablePropertyChanged);
 
     /// <summary>

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/DefaultLegend.xaml
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/DefaultLegend.xaml
@@ -6,7 +6,7 @@
              xmlns:local="clr-namespace:LiveChartsCore.SkiaSharpView.Maui">
     <ContentView.Resources>
         <DataTemplate x:Key="defaultTemplate">
-            <Frame>
+            <Frame BackgroundColor="{Binding BackgroundColor}">
                 <StackLayout 
                     BindableLayout.ItemsSource="{Binding Series, Source={RelativeSource AncestorType={x:Type local:LegendBindingContext}}}"
                     BackgroundColor="{Binding BackgroundColor, Source={RelativeSource AncestorType={x:Type local:LegendBindingContext}}}"

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/DefaultLegend.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/DefaultLegend.xaml.cs
@@ -203,7 +203,7 @@ public partial class DefaultLegend : ContentView, IChartLegend<SkiaSharpDrawingC
                 : StackOrientation.Vertical;
 
         LegendTemplate = mobileChart.LegendTemplate;
-        LegendBackgroundColor = mobileChart.TooltipBackground;
+        LegendBackgroundColor = mobileChart.LegendBackground;
         LegendFontFamily = mobileChart.LegendFontFamily;
         LegendFontSize = mobileChart.LegendFontSize;
         LegendTextColor = mobileChart.LegendTextBrush;
@@ -228,7 +228,7 @@ public partial class DefaultLegend : ContentView, IChartLegend<SkiaSharpDrawingC
             TextColor = LegendTextColor,
             FontAttributes = LegendFontAttributes,
             Orientation = LegendOrientation,
-            BackgroundColor = LegendBackgroundColor
+            BackgroundColor = LegendBackgroundColor,
         };
 
         Content = view;

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/HeightConverter.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/HeightConverter.cs
@@ -51,7 +51,7 @@ public class HeightConverter : IValueConverter
     {
         return value is IChartSeries<SkiaSharpDrawingContext> v
             ? v.CanvasSchedule.Height / DeviceDisplay.MainDisplayInfo.Density
-            : null;
+            : 0;
     }
 
     /// <summary>

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/PolarChart.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/PolarChart.xaml.cs
@@ -257,7 +257,7 @@ public partial class PolarChart : ContentView, IPolarChartView<SkiaSharpDrawingC
     /// </summary>
     public static readonly BindableProperty LegendBackgroundProperty =
         BindableProperty.Create(
-            nameof(LegendTextBrush), typeof(Color), typeof(PolarChart),
+            nameof(LegendBackground), typeof(Color), typeof(PolarChart),
             Color.FromRgb(255 / 255d, 255 / 255d, 255 / 255d), propertyChanged: OnBindablePropertyChanged);
 
     /// <summary>

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/WidthConverter.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/WidthConverter.cs
@@ -51,7 +51,7 @@ public class WidthConverter : IValueConverter
     {
         return value is IChartSeries<SkiaSharpDrawingContext> v
             ? v.CanvasSchedule.Width / DeviceDisplay.MainDisplayInfo.Density
-            : null;
+            : 0;
     }
 
     /// <summary>


### PR DESCRIPTION
Fixed LegendBackground color issue for Maui and Xamarin Forms (#439), fixed Binding exceptions for conversion to double (issue #429)