### PR TITLE
Improvements for zooming and panning

### DIFF
--- a/samples/ViewModelsSamples/Lines/Zoom/ViewModel.cs
+++ b/samples/ViewModelsSamples/Lines/Zoom/ViewModel.cs
@@ -19,7 +19,7 @@ public class ViewModel
             values[i] = t;
         }
 
-        SeriesCollection = new ISeries[] { new LineSeries<int> { Values = values } };
+        SeriesCollection = new ISeries[] { new LineSeries<int> { Values = values, GeometryFill = null, GeometryStroke = null } };
     }
 
     public IEnumerable<ISeries> SeriesCollection { get; set; }

--- a/src/LiveChartsCore/CartesianChart.cs
+++ b/src/LiveChartsCore/CartesianChart.cs
@@ -249,6 +249,8 @@ public class CartesianChart<TDrawingContext> : Chart<TDrawingContext>
         {
             for (var index = 0; index < XAxes.Length; index++)
             {
+                Trace.WriteLine($"=={delta.X:0.00}==");
+
                 var xi = XAxes[index];
                 var scale = new Scaler(DrawMarginLocation, DrawMarginSize, xi);
                 var dx = scale.ToChartValues(-delta.X) - scale.ToChartValues(0);

--- a/src/LiveChartsCore/CartesianChart.cs
+++ b/src/LiveChartsCore/CartesianChart.cs
@@ -195,8 +195,9 @@ public class CartesianChart<TDrawingContext> : Chart<TDrawingContext>
 
                 if (maxt - mint < xi.DataBounds.MinDelta * 5) return;
 
-                if (maxt > xi.DataBounds.Max) maxt = xi.DataBounds.Max;
-                if (mint < xi.DataBounds.Min) mint = xi.DataBounds.Min;
+                var xm = (max - min) * 0.05;
+                if (maxt > xi.DataBounds.Max && direction == ZoomDirection.ZoomOut) maxt = xi.DataBounds.Max + xm;
+                if (mint < xi.DataBounds.Min && direction == ZoomDirection.ZoomOut) mint = xi.DataBounds.Min - xm;
 
                 xi.MaxLimit = maxt;
                 xi.MinLimit = mint;
@@ -224,8 +225,9 @@ public class CartesianChart<TDrawingContext> : Chart<TDrawingContext>
 
                 if (maxt - mint < yi.DataBounds.MinDelta * 5) return;
 
-                if (maxt > yi.DataBounds.Max) maxt = yi.DataBounds.Max;
-                if (mint < yi.DataBounds.Min) mint = yi.DataBounds.Min;
+                var ym = (max - min) * 0.05;
+                if (maxt > yi.DataBounds.Max) maxt = yi.DataBounds.Max + ym;
+                if (mint < yi.DataBounds.Min) mint = yi.DataBounds.Min - ym;
 
                 yi.MaxLimit = maxt;
                 yi.MinLimit = mint;
@@ -239,8 +241,9 @@ public class CartesianChart<TDrawingContext> : Chart<TDrawingContext>
     /// Pans with the specified delta.
     /// </summary>
     /// <param name="delta">The delta.</param>
+    /// <param name="isPointerDown">Indicates whether the pointer is down.</param>
     /// <returns></returns>
-    public void Pan(LvcPoint delta)
+    public void Pan(LvcPoint delta, bool isPointerDown)
     {
         if ((_zoomMode & ZoomAndPanMode.X) == ZoomAndPanMode.X)
         {
@@ -253,17 +256,20 @@ public class CartesianChart<TDrawingContext> : Chart<TDrawingContext>
                 var max = xi.MaxLimit is null ? xi.DataBounds.Max : xi.MaxLimit.Value;
                 var min = xi.MinLimit is null ? xi.DataBounds.Min : xi.MinLimit.Value;
 
-                if (max + dx > xi.DataBounds.Max)
+                var xm = max - min;
+                xm = isPointerDown ? xm * 0.15 : xm * 0.05;
+
+                if (max + dx > xi.DataBounds.Max && delta.X < 0)
                 {
-                    xi.MaxLimit = xi.DataBounds.Max;
-                    xi.MinLimit = xi.DataBounds.Max - (max - min);
+                    xi.MaxLimit = xi.DataBounds.Max + xm;
+                    xi.MinLimit = xi.DataBounds.Max - (max - xm - min);
                     continue;
                 }
 
-                if (min + dx < xi.DataBounds.Min)
+                if (min + dx < xi.DataBounds.Min && delta.X > 0)
                 {
-                    xi.MinLimit = xi.DataBounds.Min;
-                    xi.MaxLimit = xi.DataBounds.Min + max - min;
+                    xi.MinLimit = xi.DataBounds.Min - xm;
+                    xi.MaxLimit = xi.DataBounds.Min + max - min - xm;
                     continue;
                 }
 
@@ -283,17 +289,20 @@ public class CartesianChart<TDrawingContext> : Chart<TDrawingContext>
                 var max = yi.MaxLimit is null ? yi.DataBounds.Max : yi.MaxLimit.Value;
                 var min = yi.MinLimit is null ? yi.DataBounds.Min : yi.MinLimit.Value;
 
+                var ym = max - min;
+                ym = isPointerDown ? ym * 0.15 : ym * 0.05;
+
                 if (max + dy > yi.DataBounds.Max)
                 {
-                    yi.MaxLimit = yi.DataBounds.Max;
-                    yi.MinLimit = yi.DataBounds.Max - (max - min);
+                    yi.MaxLimit = yi.DataBounds.Max + ym;
+                    yi.MinLimit = yi.DataBounds.Max - (max - ym - min);
                     continue;
                 }
 
                 if (min + dy < yi.DataBounds.Min)
                 {
-                    yi.MinLimit = yi.DataBounds.Min;
-                    yi.MaxLimit = yi.DataBounds.Min + max - min;
+                    yi.MinLimit = yi.DataBounds.Min - ym;
+                    yi.MaxLimit = yi.DataBounds.Min + max - min - ym;
                     continue;
                 }
 

--- a/src/LiveChartsCore/Chart.cs
+++ b/src/LiveChartsCore/Chart.cs
@@ -578,7 +578,8 @@ public abstract class Chart<TDrawingContext> : IChart
                     cartesianChart.Pan(
                         new LvcPoint(
                             (float)(_pointerPanningPosition.X - _pointerPreviousPanningPosition.X),
-                            (float)(_pointerPanningPosition.Y - _pointerPreviousPanningPosition.Y)));
+                            (float)(_pointerPanningPosition.Y - _pointerPreviousPanningPosition.Y)),
+                        _isPanning);
                     _pointerPreviousPanningPosition = new LvcPoint(
                         _pointerPanningPosition.X, _pointerPanningPosition.Y);
                 }
@@ -615,5 +616,6 @@ public abstract class Chart<TDrawingContext> : IChart
     {
         if (!_isPanning) return;
         _isPanning = false;
+        _panningThrottler.ForceCall();
     }
 }

--- a/src/LiveChartsCore/Chart.cs
+++ b/src/LiveChartsCore/Chart.cs
@@ -52,6 +52,7 @@ public abstract class Chart<TDrawingContext> : IChart
     private readonly ActionThrottler _tooltipThrottler;
     private readonly ActionThrottler _panningThrottler;
     private LvcPoint _pointerPosition = new(-10, -10);
+    private LvcPoint _pointerPanningStartPosition = new(-10, -10);
     private LvcPoint _pointerPanningPosition = new(-10, -10);
     private LvcPoint _pointerPreviousPanningPosition = new(-10, -10);
     private bool _isPanning = false;
@@ -575,13 +576,16 @@ public abstract class Chart<TDrawingContext> : IChart
 
                 lock (Canvas.Sync)
                 {
-                    cartesianChart.Pan(
-                        new LvcPoint(
-                            (float)(_pointerPanningPosition.X - _pointerPreviousPanningPosition.X),
-                            (float)(_pointerPanningPosition.Y - _pointerPreviousPanningPosition.Y)),
-                        _isPanning);
-                    _pointerPreviousPanningPosition = new LvcPoint(
-                        _pointerPanningPosition.X, _pointerPanningPosition.Y);
+                    var dx = _pointerPanningPosition.X - _pointerPreviousPanningPosition.X;
+                    var dy = _pointerPanningPosition.Y - _pointerPreviousPanningPosition.Y;
+
+                    // we need to send a dummy value indicating the direction (val > 0)
+                    // so the core is able to bounce the panning when the user reaches the limit.
+                    if (dx == 0) dx = _pointerPanningStartPosition.X - _pointerPanningPosition.X > 0 ? -0.01f : 0.01f;
+                    if (dy == 0) dy = _pointerPanningStartPosition.Y - _pointerPanningPosition.Y > 0 ? -0.01f : 0.01f;
+
+                    cartesianChart.Pan(new LvcPoint(dx, dy), _isPanning);
+                    _pointerPreviousPanningPosition = new LvcPoint(_pointerPanningPosition.X, _pointerPanningPosition.Y);
                 }
             }));
     }
@@ -595,6 +599,7 @@ public abstract class Chart<TDrawingContext> : IChart
     {
         _isPanning = true;
         _pointerPreviousPanningPosition = pointerPosition;
+        _pointerPanningStartPosition = pointerPosition;
     }
 
     private void Chart_PointerMove(LvcPoint pointerPosition)
@@ -616,6 +621,6 @@ public abstract class Chart<TDrawingContext> : IChart
     {
         if (!_isPanning) return;
         _isPanning = false;
-        _panningThrottler.ForceCall();
+        _panningThrottler.Call();
     }
 }

--- a/src/LiveChartsCore/Kernel/ActionThrottler.cs
+++ b/src/LiveChartsCore/Kernel/ActionThrottler.cs
@@ -98,6 +98,6 @@ public class ActionThrottler
     /// <returns></returns>
     public void ForceCall()
     {
-        _action().GetAwaiter().GetResult();
+        _ = _action();
     }
 }

--- a/src/LiveChartsCore/Motion/MotionCanvas.cs
+++ b/src/LiveChartsCore/Motion/MotionCanvas.cs
@@ -162,7 +162,8 @@ public class MotionCanvas<TDrawingContext> : IDisposable
             if (_fpsStack.Count > 15) _fpsStack.RemoveAt(0);
             if (frameTime - _previousLogTime > 500)
             {
-                Trace.WriteLine($"[LiveCharts] fps = {_fpsStack.DefaultIfEmpty(0).Average():0.00}");
+                if (LiveCharts.EnableLogging)
+                    Trace.WriteLine($"[LiveCharts] fps = {_fpsStack.DefaultIfEmpty(0).Average():0.00}");
                 _previousLogTime = frameTime;
             }
 #endif

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/CartesianChart.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/CartesianChart.xaml.cs
@@ -58,6 +58,8 @@ public partial class CartesianChart : ContentView, ICartesianChartView<SkiaSharp
     private CollectionDeepObserver<ICartesianAxis> _xObserver;
     private CollectionDeepObserver<ICartesianAxis> _yObserver;
     private CollectionDeepObserver<Section<SkiaSharpDrawingContext>> _sectionsObserver;
+    private double _lastPanX = 0;
+    private double _lastPanY = 0;
 
     #endregion
 
@@ -826,13 +828,36 @@ public partial class CartesianChart : ContentView, ICartesianChartView<SkiaSharp
     private void PanGestureRecognizer_PanUpdated(object? sender, PanUpdatedEventArgs e)
     {
         if (core is null) return;
-        if (e.StatusType != GestureStatus.Running) return;
+        if (e.StatusType is not GestureStatus.Running and not GestureStatus.Completed) return;
 
         var c = (CartesianChart<SkiaSharpDrawingContext>)core;
-        var delta = new LvcPoint((float)e.TotalX, (float)e.TotalY);
-        var args = new PanGestureEventArgs(delta);
-        c.InvokePanGestrue(args);
-        if (!args.Handled) c.Pan(delta);
+
+        if (e.StatusType == GestureStatus.Running)
+        {
+            var delta = new LvcPoint(
+                (float)((e.TotalX - _lastPanX) * DeviceDisplay.MainDisplayInfo.Density),
+                (float)((e.TotalY - _lastPanY) * DeviceDisplay.MainDisplayInfo.Density));
+
+            var args = new PanGestureEventArgs(delta);
+            c.InvokePanGestrue(args);
+
+            if (args.Handled) return;
+
+            c.Pan(delta, true);
+            _lastPanX = e.TotalX;
+            _lastPanY = e.TotalY;
+
+            return;
+        }
+
+        // lets just let the core know that the drag finished,
+        // so thwe core is able to bounce back the plot in case
+        // it exceeded the allowed limits
+        // this is a dummy request of += 0.01 pixels just in the corresponding direction
+        c.Pan(new LvcPoint(_lastPanX > 0 ? 0.01f : -0.01f, _lastPanY > 0 ? 0.01f : -0.01f), false);
+
+        _lastPanX = 0;
+        _lastPanY = 0;
     }
 
     private void PinchGestureRecognizer_PinchUpdated(object? sender, PinchGestureUpdatedEventArgs e)


### PR DESCRIPTION
Now zooming and panning feels more natural, fixed multiple bugs and improvements, now the Cartesian chart control bounces when a user reaches the edge, it should feel more intuitive from a user perspective.

**Desktop**:

![bounce on edge](https://user-images.githubusercontent.com/10853349/165182688-b816e6f8-4315-4d29-a2b7-cf610054f847.gif)

**Mobile** (Only Xamarin working correctly for now, Uno and Maui not ready yet)

https://user-images.githubusercontent.com/10853349/165182771-3a5cd49d-c6f3-4253-a9b4-19d106bc09a2.mp4


