### PR TITLE
Fixed memory leaks at least in WPF

### DIFF
--- a/docs/overview/1.2.install.md
+++ b/docs/overview/1.2.install.md
@@ -312,7 +312,7 @@ Name the project and the solution `UnoApp`. Uno has a `Shared` project, and mult
 ## Install from NuGet
 
 You can install LiveChart from NuGet, in the `Solution Explorer` right click on your solution, then `Manage Nuget Packages for Solution`,
-ensure the package source is `nuget.org` then in  the`Browse` tab search for `LiveChartsCore.SkiaSharpView.Uno` (check the include prerelease checkbox),
+ensure the package source is `nuget.org` then in  the `Browse` tab search for `LiveChartsCore.SkiaSharpView.Uno` (check the include prerelease checkbox),
 finally check all the projects to install LiveCharts on all the platforms in our project.
 
 <p align="center">

--- a/docs/overview/1.2.install.md
+++ b/docs/overview/1.2.install.md
@@ -312,7 +312,7 @@ Name the project and the solution `UnoApp`. Uno has a `Shared` project, and mult
 ## Install from NuGet
 
 You can install LiveChart from NuGet, in the `Solution Explorer` right click on your solution, then `Manage Nuget Packages for Solution`,
-ensure the package source is `nuget.org` then `Browse` tab search for `LiveChartsCore.SkiaSharpView.Uno` (check the include prerelease checkbox),
+ensure the package source is `nuget.org` then in `Browse` tab search for `LiveChartsCore.SkiaSharpView.Uno` (check the include prerelease checkbox),
 finally check all the projects to install LiveCharts on all the platforms in our project.
 
 <p align="center">

--- a/docs/overview/1.2.install.md
+++ b/docs/overview/1.2.install.md
@@ -311,7 +311,7 @@ Name the project and the solution `UnoApp`. Uno has a `Shared` project, and mult
 
 ## Install from NuGet
 
-You can install LiveChart from NuGet, in the `Solution Explorer` right click on `Manage Nuget Packages for Solution`,
+You can install LiveChart from NuGet, in the `Solution Explorer` right click on your solution, then `Manage Nuget Packages for Solution`,
 ensure the package source is `nuget.org` then `Browse` tab search for `LiveChartsCore.SkiaSharpView.Uno` (check the include prerelease checkbox),
 finally check all the projects to install LiveCharts on all the platforms in our project.
 
@@ -390,10 +390,14 @@ try re-starting visual studio, if this is your first time running an emulator, y
 And that's it, we have LiveCharts2 running on Android!.
 
 <p align="center">
-  <img src="{{ assets_url }}/docs/_assets/uno-android.png" />
+  <img src="https://lvcharts.com/images/uno-android.gif" alt="." />
 </p>
 
 Start the project for the rest of the platforms, the chart is ready to run everywhere!.
+
+<p align="center">
+  <img src="https://lvcharts.com/images/uno-windows.gif" alt="." />
+</p>
 
 {{~ end ~}}
 

--- a/docs/overview/1.2.install.md
+++ b/docs/overview/1.2.install.md
@@ -321,7 +321,7 @@ finally check all the projects to install LiveCharts on all the platforms in our
 
 ## Add a chart to the UI
 
-Let's start by defining a view model for your chart, in the `Solution Explorer` go to the `Shared` project and then open the
+Let's start by defining a view model for our chart, in the `Solution Explorer` go to the `Shared` project and then open the
 `MainPage.xaml.cs` file, and add the next view model class:
 
 <pre><code>using Windows.UI.Xaml.Controls;

--- a/docs/overview/1.2.install.md
+++ b/docs/overview/1.2.install.md
@@ -313,7 +313,7 @@ Name the project and the solution `UnoApp`. Uno has a `Shared` project, and mult
 
 You can install LiveChart from NuGet, in the `Solution Explorer` right click on `Manage Nuget Packages for Solution`,
 ensure the package source is `nuget.org` then `Browse` tab search for `LiveChartsCore.SkiaSharpView.Uno` (check the include prerelease checkbox),
-finally check all the projects to install LiveCharts in all the platforms in our project.
+finally check all the projects to install LiveCharts on all the platforms in our project.
 
 <p align="center">
   <img src="{{ assets_url }}/docs/_assets/uno-install.png" />
@@ -355,7 +355,7 @@ public class ViewModel // mark
 Now let's add the control to the UI, in the `Shared` project go to `MainPage.xaml` file, add the namespace for LiveCharts (lvc)
 and for the view model we just created (local).
 
-Set the `Page.DataSource` to our view model, and finally add the chart andd bind the `Series` property to our view model.
+Set the `Page.DataSource` to our view model, and finally add the chart and bind the `Series` property to our view model.
 
 <pre><code>&lt;!-- mark -skip 4 -take 2 --&gt;
 &lt;Page
@@ -366,7 +366,7 @@ Set the `Page.DataSource` to our view model, and finally add the chart andd bind
     xmlns:lvc="using:LiveChartsCore.SkiaSharpView.Uno"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d"    
+    mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
     &lt;Page.DataContext>
@@ -393,7 +393,7 @@ And that's it, we have LiveCharts2 running on Android!.
   <img src="{{ assets_url }}/docs/_assets/uno-android.png" />
 </p>
 
-Start the project in the rest of the platforms, the chart is ready to run everywhere!.
+Start the project for the rest of the platforms, the chart is ready to run everywhere!.
 
 {{~ end ~}}
 

--- a/docs/overview/1.2.install.md
+++ b/docs/overview/1.2.install.md
@@ -312,7 +312,7 @@ Name the project and the solution `UnoApp`. Uno has a `Shared` project, and mult
 ## Install from NuGet
 
 You can install LiveChart from NuGet, in the `Solution Explorer` right click on your solution, then `Manage Nuget Packages for Solution`,
-ensure the package source is `nuget.org` then in `Browse` tab search for `LiveChartsCore.SkiaSharpView.Uno` (check the include prerelease checkbox),
+ensure the package source is `nuget.org` then in  the`Browse` tab search for `LiveChartsCore.SkiaSharpView.Uno` (check the include prerelease checkbox),
 finally check all the projects to install LiveCharts on all the platforms in our project.
 
 <p align="center">

--- a/samples/ViewModelsSamples/Axes/ColorsAndPosition/ViewModel.cs
+++ b/samples/ViewModelsSamples/Axes/ColorsAndPosition/ViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Windows.Input;
 using LiveChartsCore;
 using LiveChartsCore.Drawing;
@@ -11,7 +12,7 @@ using SkiaSharp;
 
 namespace ViewModelsSamples.Axes.ColorsAndPosition;
 
-public class ViewModel
+public class ViewModel : INotifyPropertyChanged
 {
     private AxisPosition _selectedPosition;
     private int _selectedColor = 0;
@@ -67,6 +68,8 @@ public class ViewModel
     public List<Axis> XAxes { get; set; }
 
     public List<Axis> YAxes { get; set; }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
 
     public void SetNewColor()
     {

--- a/samples/ViewModelsSamples/Axes/Paging/ViewModel.cs
+++ b/samples/ViewModelsSamples/Axes/Paging/ViewModel.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Windows.Input;
 using LiveChartsCore;
 using LiveChartsCore.SkiaSharpView;
 
 namespace ViewModelsSamples.Axes.Paging;
 
-public class ViewModel
+public class ViewModel : INotifyPropertyChanged
 {
     private readonly Random _random = new();
 
@@ -35,6 +36,8 @@ public class ViewModel
     public ISeries[] Series { get; set; }
 
     public Axis[] XAxes { get; set; }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
 
     public ICommand GoToPage1Command => new Command(o => GoToPage1());
     public ICommand GoToPage2Command => new Command(o => GoToPage2());

--- a/samples/ViewModelsSamples/Bars/AutoUpdate/ViewModel.cs
+++ b/samples/ViewModelsSamples/Bars/AutoUpdate/ViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Windows.Input;
 using LiveChartsCore;
 using LiveChartsCore.Defaults;
@@ -8,17 +9,17 @@ using LiveChartsCore.SkiaSharpView;
 
 namespace ViewModelsSamples.Bars.AutoUpdate;
 
-public class ViewModel
+public class ViewModel : INotifyPropertyChanged
 {
-    private int index = 0;
-    private readonly Random random = new();
-    private readonly ObservableCollection<ObservablePoint> observableValues;
+    private int _index = 0;
+    private readonly Random _random = new();
+    private readonly ObservableCollection<ObservablePoint> _observableValues;
 
     public ViewModel()
     {
         // using an INotifyCollectionChanged as your values collection
         // will let the chart update every time a point is added, removed, replaced or the whole list was cleared
-        observableValues = new ObservableCollection<ObservablePoint>
+        _observableValues = new ObservableCollection<ObservablePoint>
             {
                 // using object that implements INotifyPropertyChanged
                 // will allow the chart to update everytime a property in a point changes.
@@ -28,19 +29,19 @@ public class ViewModel
                 // for more info please see:
                 // https://github.com/beto-rodriguez/LiveCharts2/blob/master/samples/ViewModelsSamples/General/UserDefinedTypes/ViewModel.cs#L22
 
-                new(index++, 2),
-                new(index++, 5),
-                new(index++, 4),
-                new(index++, 5),
-                new(index++, 2),
-                new(index++, 6),
-                new(index++, 6),
-                new(index++, 6),
-                new(index++, 4),
-                new(index++, 2),
-                new(index++, 3),
-                new(index++, 8),
-                new(index++, 3)
+                new(_index++, 2),
+                new(_index++, 5),
+                new(_index++, 4),
+                new(_index++, 5),
+                new(_index++, 2),
+                new(_index++, 6),
+                new(_index++, 6),
+                new(_index++, 6),
+                new(_index++, 4),
+                new(_index++, 2),
+                new(_index++, 3),
+                new(_index++, 8),
+                new(_index++, 3)
             };
 
         // using a collection that implements INotifyCollectionChanged as your series collection
@@ -48,7 +49,7 @@ public class ViewModel
         // .Net already provides the System.Collections.ObjectModel.ObservableCollection class
         Series = new ObservableCollection<ISeries>
             {
-                new ColumnSeries<ObservablePoint> { Values = observableValues }
+                new ColumnSeries<ObservablePoint> { Values = _observableValues }
             };
 
         // in the following series notice that the type int does not implement INotifyPropertyChanged
@@ -60,27 +61,29 @@ public class ViewModel
 
     public ObservableCollection<ISeries> Series { get; set; }
 
+    public event PropertyChangedEventHandler? PropertyChanged;
+
     public void AddRandomItem()
     {
         // for this sample only 50 items are supported.
-        if (observableValues.Count > 50) return;
+        if (_observableValues.Count > 50) return;
 
-        var randomValue = random.Next(1, 10);
-        observableValues.Add(new ObservablePoint(index++, randomValue));
+        var randomValue = _random.Next(1, 10);
+        _observableValues.Add(new ObservablePoint(_index++, randomValue));
     }
 
     public void RemoveFirstItem()
     {
-        if (observableValues.Count < 2) return;
+        if (_observableValues.Count < 2) return;
 
-        observableValues.RemoveAt(0);
+        _observableValues.RemoveAt(0);
     }
 
     public void ReplaceRandomItem()
     {
-        var randomValue = random.Next(1, 10);
-        var randomIndex = random.Next(0, observableValues.Count - 1);
-        observableValues[randomIndex] = new ObservablePoint(observableValues[randomIndex].X, randomValue);
+        var randomValue = _random.Next(1, 10);
+        var randomIndex = _random.Next(0, _observableValues.Count - 1);
+        _observableValues[randomIndex] = new ObservablePoint(_observableValues[randomIndex].X, randomValue);
     }
 
     public void AddSeries()
@@ -91,7 +94,7 @@ public class ViewModel
         Series.Add(
             new ColumnSeries<int>
             {
-                Values = new List<int> { random.Next(0, 10), random.Next(0, 10), random.Next(0, 10) }
+                Values = new List<int> { _random.Next(0, 10), _random.Next(0, 10), _random.Next(0, 10) }
             });
     }
 

--- a/samples/ViewModelsSamples/Command.cs
+++ b/samples/ViewModelsSamples/Command.cs
@@ -8,7 +8,7 @@ namespace ViewModelsSamples;
 public class Command : ICommand
 {
     private readonly Action<object?> _command;
-    public event EventHandler? CanExecuteChanged;
+    public event EventHandler? CanExecuteChanged { add { } remove { } }
 
     public Command(Action<object?> command)
     {

--- a/samples/ViewModelsSamples/Events/Cartesian/ViewModel.cs
+++ b/samples/ViewModelsSamples/Events/Cartesian/ViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Windows.Input;
 using LiveChartsCore;
@@ -10,7 +11,7 @@ using LiveChartsCore.SkiaSharpView.Drawing.Geometries;
 
 namespace ViewModelsSamples.Events.Cartesian;
 
-public class ViewModel
+public class ViewModel : INotifyPropertyChanged
 {
     public ViewModel()
     {
@@ -54,6 +55,8 @@ public class ViewModel
         Series = new ISeries[] { salesPerDaysSeries, stockSeries };
     }
 
+    public event PropertyChangedEventHandler? PropertyChanged;
+
     private void SalesPerDaysSeries_ChartPointPointerDown(
         IChartView chart,
         ChartPoint<Fruit, BezierPoint<CircleGeometry>, LabelGeometry> point)
@@ -61,7 +64,6 @@ public class ViewModel
         Trace.WriteLine(
             $"[salesPerDay ChartPointPointerDown] clicked on {point.Model?.Name}, {point.Model?.SalesPerDay} items sold per day");
     }
-
 
     private void StockSeries_ChartPointPointerDown(
         IChartView chart,

--- a/samples/ViewModelsSamples/Events/Pie/ViewModel.cs
+++ b/samples/ViewModelsSamples/Events/Pie/ViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Windows.Input;
 using LiveChartsCore;
@@ -9,7 +10,7 @@ using LiveChartsCore.SkiaSharpView.Drawing.Geometries;
 
 namespace ViewModelsSamples.Events.Pie;
 
-public class ViewModel
+public class ViewModel : INotifyPropertyChanged
 {
     public ViewModel()
     {
@@ -40,6 +41,8 @@ public class ViewModel
 
         Series = seriesCollection;
     }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
 
     private void Series_DataPointerDown(
         IChartView chart,

--- a/samples/ViewModelsSamples/Events/Polar/ViewModel.cs
+++ b/samples/ViewModelsSamples/Events/Polar/ViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Windows.Input;
 using LiveChartsCore;
@@ -10,7 +11,7 @@ using LiveChartsCore.SkiaSharpView.Drawing.Geometries;
 
 namespace ViewModelsSamples.Events.Polar;
 
-public class ViewModel
+public class ViewModel : INotifyPropertyChanged
 {
     public ViewModel()
     {
@@ -43,6 +44,8 @@ public class ViewModel
             new PolarLineSeries<int> { Values = new[] { 6, 7, 2, 9, 6, 2 } },
         };
     }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
 
     private void PolarLineSeries_DataPointerDown(IChartView chart, IEnumerable<ChartPoint<City, BezierPoint<CircleGeometry>, LabelGeometry>> points)
     {

--- a/samples/ViewModelsSamples/General/Sections/ViewModel.cs
+++ b/samples/ViewModelsSamples/General/Sections/ViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Windows.Input;
 using LiveChartsCore;
 using LiveChartsCore.Defaults;
@@ -8,7 +9,7 @@ using SkiaSharp;
 
 namespace ViewModelsSamples.General.Sections;
 
-public class ViewModel
+public class ViewModel : INotifyPropertyChanged
 {
     public ObservableCollection<RectangularSection> Sections { get; set; }
         = new()
@@ -74,4 +75,6 @@ public class ViewModel
         };
 
     public ICommand ToggleFirstCommand => new Command(o => Sections[0].IsVisible = !Sections[0].IsVisible);
+
+    public event PropertyChangedEventHandler? PropertyChanged;
 }

--- a/samples/ViewModelsSamples/General/Sections2/ViewModel.cs
+++ b/samples/ViewModelsSamples/General/Sections2/ViewModel.cs
@@ -1,4 +1,5 @@
-﻿using LiveChartsCore;
+﻿using System.ComponentModel;
+using LiveChartsCore;
 using LiveChartsCore.Defaults;
 using LiveChartsCore.SkiaSharpView;
 using LiveChartsCore.SkiaSharpView.Painting;
@@ -7,7 +8,7 @@ using SkiaSharp;
 
 namespace ViewModelsSamples.General.Sections2;
 
-public class ViewModel
+public class ViewModel : INotifyPropertyChanged
 {
     public RectangularSection[] Sections { get; set; }
         = new[]
@@ -51,4 +52,6 @@ public class ViewModel
                 }
             }
         };
+
+    public event PropertyChangedEventHandler? PropertyChanged;
 }

--- a/samples/ViewModelsSamples/Lines/AutoUpdate/ViewModel.cs
+++ b/samples/ViewModelsSamples/Lines/AutoUpdate/ViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Windows.Input;
 using LiveChartsCore;
 using LiveChartsCore.Defaults;
@@ -8,7 +9,7 @@ using LiveChartsCore.SkiaSharpView;
 
 namespace ViewModelsSamples.Lines.AutoUpdate;
 
-public class ViewModel
+public class ViewModel : INotifyPropertyChanged
 {
     private readonly Random _random = new();
     private readonly ObservableCollection<ObservableValue> _observableValues;
@@ -44,6 +45,8 @@ public class ViewModel
     }
 
     public ObservableCollection<ISeries> Series { get; set; }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
 
     public void AddItem()
     {

--- a/samples/ViewModelsSamples/Maps/World/ViewModel.cs
+++ b/samples/ViewModelsSamples/Maps/World/ViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Input;
@@ -8,12 +9,11 @@ using LiveChartsCore.SkiaSharpView.Drawing.Geometries;
 
 namespace ViewModelsSamples.Maps.World;
 
-public class ViewModel
+public class ViewModel : INotifyPropertyChanged
 {
     private bool _isBrazilInChart = true;
     private readonly IWeigthedMapLand _brazil;
     private readonly Random _r = new();
-
 
     public ViewModel()
     {
@@ -44,6 +44,8 @@ public class ViewModel
         _brazil = lands.First(x => x.Name == "bra");
         DoRandomChanges();
     }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
 
     public HeatLandSeries[] Series { get; set; }
 

--- a/samples/ViewModelsSamples/Pies/AutoUpdate/ViewModel.cs
+++ b/samples/ViewModelsSamples/Pies/AutoUpdate/ViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Windows.Input;
 using LiveChartsCore;
 using LiveChartsCore.Defaults;
@@ -7,7 +8,7 @@ using LiveChartsCore.SkiaSharpView;
 
 namespace ViewModelsSamples.Pies.AutoUpdate;
 
-public class ViewModel
+public class ViewModel : INotifyPropertyChanged
 {
     private readonly Random _random = new();
 
@@ -35,6 +36,8 @@ public class ViewModel
     }
 
     public ObservableCollection<ISeries> Series { get; set; }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
 
     public void AddSeries()
     {

--- a/samples/ViewModelsSamples/Pies/Gauges/ViewModel.cs
+++ b/samples/ViewModelsSamples/Pies/Gauges/ViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.ComponentModel;
 using LiveChartsCore;
 using LiveChartsCore.Defaults;
 using LiveChartsCore.Measure;
@@ -8,7 +9,7 @@ using SkiaSharp;
 
 namespace ViewModelsSamples.Pies.Gauges;
 
-public class ViewModel
+public class ViewModel : INotifyPropertyChanged
 {
     public ViewModel()
     {
@@ -248,4 +249,6 @@ public class ViewModel
     public double GaugeTotal14 { get; set; }
     public double InitialRotation14 { get; set; }
     public double MaxAngle14 { get; set; }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
 }

--- a/samples/ViewModelsSamples/Scatter/AutoUpdate/ViewModel.cs
+++ b/samples/ViewModelsSamples/Scatter/AutoUpdate/ViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Windows.Input;
 using LiveChartsCore;
 using LiveChartsCore.Defaults;
@@ -8,7 +9,7 @@ using LiveChartsCore.SkiaSharpView;
 
 namespace ViewModelsSamples.Scatter.AutoUpdate;
 
-public class ViewModel
+public class ViewModel : INotifyPropertyChanged
 {
     private int index = 0;
     private readonly Random random = new();
@@ -59,6 +60,8 @@ public class ViewModel
     }
 
     public ObservableCollection<ISeries> Series { get; set; }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
 
     public void AddRandomItem()
     {

--- a/samples/ViewModelsSamples/StepLines/AutoUpdate/ViewModel.cs
+++ b/samples/ViewModelsSamples/StepLines/AutoUpdate/ViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Windows.Input;
 using LiveChartsCore;
 using LiveChartsCore.Defaults;
@@ -8,7 +9,7 @@ using LiveChartsCore.SkiaSharpView;
 
 namespace ViewModelsSamples.StepLines.AutoUpdate;
 
-public class ViewModel
+public class ViewModel : INotifyPropertyChanged
 {
     private int _index = 0;
     private readonly Random _random = new();
@@ -63,6 +64,8 @@ public class ViewModel
     }
 
     public ObservableCollection<ISeries> Series { get; set; }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
 
     public void AddItem()
     {

--- a/samples/ViewModelsSamples/VisualTest/DataTemplate/ViewModel.cs
+++ b/samples/ViewModelsSamples/VisualTest/DataTemplate/ViewModel.cs
@@ -1,11 +1,12 @@
 ﻿using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using LiveChartsCore;
 using LiveChartsCore.SkiaSharpView;
 
 namespace ViewModelsSamples.VisualTest.DataTemplate;
 
-public class ViewModel
+public class ViewModel : INotifyPropertyChanged
 {
     public IEnumerable<IEnumerable<ISeries>> Models { get; set; }
         = new List<IEnumerable<ISeries>>
@@ -32,4 +33,6 @@ public class ViewModel
                     }
                 }
         };
+
+    public event PropertyChangedEventHandler? PropertyChanged;
 }

--- a/samples/WPFSample/VisualTest/Tabs/View.xaml
+++ b/samples/WPFSample/VisualTest/Tabs/View.xaml
@@ -2,7 +2,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" 
              xmlns:bars="clr-namespace:WPFSample.Bars.AutoUpdate"
-             xmlns:lines="clr-namespace:WPFSample.Lines.Basic">
+             xmlns:lines="clr-namespace:WPFSample.Lines.AutoUpdate">
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="*"/>

--- a/src/LiveChartsCore/Axis.cs
+++ b/src/LiveChartsCore/Axis.cs
@@ -590,6 +590,7 @@ public abstract class Axis<TDrawingContext, TTextGeometry, TLineGeometry>
         _orientation = orientation;
         _dataBounds = new Bounds();
         _visibleDataBounds = new Bounds();
+        if (_animatableBounds is null) _animatableBounds = new();
         Initialized?.Invoke(this);
     }
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/CartesianChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/CartesianChart.cs
@@ -312,6 +312,7 @@ public class CartesianChart : Chart, ICartesianChartView<SkiaSharpDrawingContext
         XAxes = Array.Empty<ICartesianAxis>();
         YAxes = Array.Empty<ICartesianAxis>();
         Sections = Array.Empty<RectangularSection>();
+
         _seriesObserver = null!;
         _xObserver = null!;
         _yObserver = null!;


### PR DESCRIPTION
Some of the view models did not implemented `INotifyPropertyChanged` this caused memory leaks when the view had bindings.