### PR TITLE
Always add Crosshair Line and Label geo to PaintTask

### DIFF
--- a/src/LiveChartsCore/Axis.cs
+++ b/src/LiveChartsCore/Axis.cs
@@ -664,9 +664,9 @@ public abstract class Axis<TDrawingContext, TTextGeometry, TLineGeometry>
         if (_crosshairLine is null)
         {
             _crosshairLine = new TLineGeometry();
-            CrosshairPaint.AddGeometryToPaintTask(cartesianChart.Canvas, _crosshairLine);
             UpdateSeparator(_crosshairLine, x, y, lxi, lxj, lyi, lyj, UpdateMode.UpdateAndComplete);
         }
+        CrosshairPaint.AddGeometryToPaintTask(cartesianChart.Canvas, _crosshairLine);
 
         if (CrosshairLabelsPaint is not null)
         {
@@ -686,16 +686,8 @@ public abstract class Axis<TDrawingContext, TTextGeometry, TLineGeometry>
                     new LvcSize(controlSize.Width, drawMarginSize.Height)));
             }
             cartesianChart.Canvas.AddDrawableTask(CrosshairLabelsPaint);
-        }
 
-        if (_crosshairLabel is null && CrosshairLabelsPaint is not null)
-        {
-            _crosshairLabel = new TTextGeometry();
-            CrosshairLabelsPaint.AddGeometryToPaintTask(cartesianChart.Canvas, _crosshairLabel);
-        }
-
-        if (_crosshairLabel is not null)
-        {
+            _crosshairLabel ??= new TTextGeometry();
             var labeler = Labeler;
             if (Labels is not null)
             {
@@ -712,6 +704,7 @@ public abstract class Axis<TDrawingContext, TTextGeometry, TLineGeometry>
             var r = (float)_labelsRotation;
             var hasRotation = Math.Abs(r) > 0.01f;
             if (hasRotation) _crosshairLabel.RotateTransform = r;
+            CrosshairLabelsPaint.AddGeometryToPaintTask(cartesianChart.Canvas, _crosshairLabel);
         }
 
         UpdateSeparator(_crosshairLine, x, y, lxi, lxj, lyi, lyj, UpdateMode.Update);


### PR DESCRIPTION
Changing CrosshairPaint / Label to a different color made the Crosshair dissapear entirely. This was because _crosshairLine and _crosshairLabel were not added to the new PaintTasks. Fixed so they will always be added (the Add() is implemented using HashMap, so no duplicates) 