### PR TITLE
Reduce gc allocations on render loop

### DIFF
--- a/src/LiveChartsCore/ColumnSeries.cs
+++ b/src/LiveChartsCore/ColumnSeries.cs
@@ -101,8 +101,7 @@ public abstract class ColumnSeries<TModel, TVisual, TLabel, TDrawingContext> : B
         }
 
         var dls = (float)DataLabelsSize;
-        var toDeletePointsCnt = everFetched.Count;
-        InvalidateAllPoints(everFetched);
+        var pointsCleanup = ChartPointCleanupContext.For(everFetched);
 
         var rx = (float)Rx;
         var ry = (float)Ry;
@@ -214,8 +213,7 @@ public abstract class ColumnSeries<TModel, TVisual, TLabel, TDrawingContext> : B
                 point.Context.HoverArea = ha = new RectangleHoverArea();
             _ = ha.SetDimensions(secondary - helper.actualUw * 0.5f, cy, helper.actualUw, b);
 
-            toDeletePointsCnt--;
-            point.RemoveOnCompleted = false;
+            pointsCleanup.RemovePoint(point);
 
             if (DataLabelsPaint is not null)
             {
@@ -255,8 +253,8 @@ public abstract class ColumnSeries<TModel, TVisual, TLabel, TDrawingContext> : B
             OnPointMeasured(point);
         }
 
-        if (toDeletePointsCnt != 0)
-            RemoveInvalidPoints(everFetched, cartesianChart.View, primaryScale, secondaryScale, SoftDeleteOrDisposePoint);
+        if (pointsCleanup.ToDeleteCnt != 0)
+            ChartPointCleanupContext.RemoveInvalidPoints(everFetched, cartesianChart.View, primaryScale, secondaryScale, SoftDeleteOrDisposePoint);
     }
 
     /// <inheritdoc cref="CartesianSeries{TModel, TVisual, TLabel, TDrawingContext}.GetRequestedSecondaryOffset"/>

--- a/src/LiveChartsCore/ColumnSeries.cs
+++ b/src/LiveChartsCore/ColumnSeries.cs
@@ -209,7 +209,9 @@ public abstract class ColumnSeries<TModel, TVisual, TLabel, TDrawingContext> : B
             }
             visual.RemoveOnCompleted = false;
 
-            point.Context.HoverArea = new RectangleHoverArea(secondary - helper.actualUw * 0.5f, cy, helper.actualUw, b);
+            if (point.Context.HoverArea is not RectangleHoverArea ha)
+                point.Context.HoverArea = ha = new RectangleHoverArea();
+            _ = ha.SetDimensions(secondary - helper.actualUw * 0.5f, cy, helper.actualUw, b);
 
             _ = toDeletePoints.Remove(point);
 

--- a/src/LiveChartsCore/ColumnSeries.cs
+++ b/src/LiveChartsCore/ColumnSeries.cs
@@ -21,7 +21,6 @@
 // SOFTWARE.
 
 using System;
-using System.Collections.Generic;
 using LiveChartsCore.Drawing;
 using LiveChartsCore.Kernel;
 using LiveChartsCore.Kernel.Drawing;
@@ -213,7 +212,7 @@ public abstract class ColumnSeries<TModel, TVisual, TLabel, TDrawingContext> : B
                 point.Context.HoverArea = ha = new RectangleHoverArea();
             _ = ha.SetDimensions(secondary - helper.actualUw * 0.5f, cy, helper.actualUw, b);
 
-            pointsCleanup.RemovePoint(point);
+            pointsCleanup.Clean(point);
 
             if (DataLabelsPaint is not null)
             {
@@ -253,8 +252,8 @@ public abstract class ColumnSeries<TModel, TVisual, TLabel, TDrawingContext> : B
             OnPointMeasured(point);
         }
 
-        if (pointsCleanup.ToDeleteCnt != 0)
-            ChartPointCleanupContext.RemoveInvalidPoints(everFetched, cartesianChart.View, primaryScale, secondaryScale, SoftDeleteOrDisposePoint);
+        pointsCleanup.CollectPoints(
+            everFetched, cartesianChart.View, primaryScale, secondaryScale, SoftDeleteOrDisposePoint);
     }
 
     /// <inheritdoc cref="CartesianSeries{TModel, TVisual, TLabel, TDrawingContext}.GetRequestedSecondaryOffset"/>

--- a/src/LiveChartsCore/ColumnSeries.cs
+++ b/src/LiveChartsCore/ColumnSeries.cs
@@ -101,7 +101,8 @@ public abstract class ColumnSeries<TModel, TVisual, TLabel, TDrawingContext> : B
         }
 
         var dls = (float)DataLabelsSize;
-        var toDeletePoints = new HashSet<ChartPoint>(everFetched);
+        var toDeletePointsCnt = everFetched.Count;
+        InvalidateAllPoints(everFetched);
 
         var rx = (float)Rx;
         var ry = (float)Ry;
@@ -213,7 +214,8 @@ public abstract class ColumnSeries<TModel, TVisual, TLabel, TDrawingContext> : B
                 point.Context.HoverArea = ha = new RectangleHoverArea();
             _ = ha.SetDimensions(secondary - helper.actualUw * 0.5f, cy, helper.actualUw, b);
 
-            _ = toDeletePoints.Remove(point);
+            toDeletePointsCnt--;
+            point.RemoveOnCompleted = false;
 
             if (DataLabelsPaint is not null)
             {
@@ -253,12 +255,8 @@ public abstract class ColumnSeries<TModel, TVisual, TLabel, TDrawingContext> : B
             OnPointMeasured(point);
         }
 
-        foreach (var point in toDeletePoints)
-        {
-            if (point.Context.Chart != cartesianChart.View) continue;
-            SoftDeleteOrDisposePoint(point, primaryScale, secondaryScale);
-            _ = everFetched.Remove(point);
-        }
+        if (toDeletePointsCnt != 0)
+            RemoveInvalidPoints(everFetched, cartesianChart.View, primaryScale, secondaryScale, SoftDeleteOrDisposePoint);
     }
 
     /// <inheritdoc cref="CartesianSeries{TModel, TVisual, TLabel, TDrawingContext}.GetRequestedSecondaryOffset"/>

--- a/src/LiveChartsCore/FinancialSeries.cs
+++ b/src/LiveChartsCore/FinancialSeries.cs
@@ -248,7 +248,7 @@ public abstract class FinancialSeries<TModel, TVisual, TLabel, TMiniatureGeometr
                 point.Context.HoverArea = ha = new RectangleHoverArea();
             _ = ha.SetDimensions(secondary - uwm, high, uw, Math.Abs(low - high));
 
-            pointsCleanup.RemovePoint(point);
+            pointsCleanup.Clean(point);
 
             if (DataLabelsPaint is not null)
             {
@@ -288,8 +288,8 @@ public abstract class FinancialSeries<TModel, TVisual, TLabel, TMiniatureGeometr
             OnPointMeasured(point);
         }
 
-        if (pointsCleanup.ToDeleteCnt != 0)
-            ChartPointCleanupContext.RemoveInvalidPoints(everFetched, cartesianChart.View, primaryScale, secondaryScale, SoftDeleteOrDisposePoint);
+        pointsCleanup.CollectPoints(
+            everFetched, cartesianChart.View, primaryScale, secondaryScale, SoftDeleteOrDisposePoint);
     }
 
     /// <inheritdoc cref="ICartesianSeries{TDrawingContext}.GetBounds(CartesianChart{TDrawingContext}, ICartesianAxis, ICartesianAxis)"/>

--- a/src/LiveChartsCore/FinancialSeries.cs
+++ b/src/LiveChartsCore/FinancialSeries.cs
@@ -244,8 +244,9 @@ public abstract class FinancialSeries<TModel, TVisual, TLabel, TMiniatureGeometr
             visual.Low = low;
             visual.RemoveOnCompleted = false;
 
-            var ha = new RectangleHoverArea().SetDimensions(secondary - uwm, high, uw, Math.Abs(low - high));
-            point.Context.HoverArea = ha;
+            if (point.Context.HoverArea is not RectangleHoverArea ha)
+                point.Context.HoverArea = ha = new RectangleHoverArea();
+            _ = ha.SetDimensions(secondary - uwm, high, uw, Math.Abs(low - high));
 
             _ = toDeletePoints.Remove(point);
 

--- a/src/LiveChartsCore/FinancialSeries.cs
+++ b/src/LiveChartsCore/FinancialSeries.cs
@@ -155,8 +155,7 @@ public abstract class FinancialSeries<TModel, TVisual, TLabel, TMiniatureGeometr
         }
 
         var dls = (float)DataLabelsSize;
-        var toDeletePointsCnt = everFetched.Count;
-        InvalidateAllPoints(everFetched);
+        var pointsCleanup = ChartPointCleanupContext.For(everFetched);
 
         foreach (var point in Fetch(cartesianChart))
         {
@@ -249,8 +248,7 @@ public abstract class FinancialSeries<TModel, TVisual, TLabel, TMiniatureGeometr
                 point.Context.HoverArea = ha = new RectangleHoverArea();
             _ = ha.SetDimensions(secondary - uwm, high, uw, Math.Abs(low - high));
 
-            toDeletePointsCnt--;
-            point.RemoveOnCompleted = false;
+            pointsCleanup.RemovePoint(point);
 
             if (DataLabelsPaint is not null)
             {
@@ -290,8 +288,8 @@ public abstract class FinancialSeries<TModel, TVisual, TLabel, TMiniatureGeometr
             OnPointMeasured(point);
         }
 
-        if (toDeletePointsCnt != 0)
-            RemoveInvalidPoints(everFetched, cartesianChart.View, primaryScale, secondaryScale, SoftDeleteOrDisposePoint);
+        if (pointsCleanup.ToDeleteCnt != 0)
+            ChartPointCleanupContext.RemoveInvalidPoints(everFetched, cartesianChart.View, primaryScale, secondaryScale, SoftDeleteOrDisposePoint);
     }
 
     /// <inheritdoc cref="ICartesianSeries{TDrawingContext}.GetBounds(CartesianChart{TDrawingContext}, ICartesianAxis, ICartesianAxis)"/>

--- a/src/LiveChartsCore/FinancialSeries.cs
+++ b/src/LiveChartsCore/FinancialSeries.cs
@@ -155,7 +155,8 @@ public abstract class FinancialSeries<TModel, TVisual, TLabel, TMiniatureGeometr
         }
 
         var dls = (float)DataLabelsSize;
-        var toDeletePoints = new HashSet<ChartPoint>(everFetched);
+        var toDeletePointsCnt = everFetched.Count;
+        InvalidateAllPoints(everFetched);
 
         foreach (var point in Fetch(cartesianChart))
         {
@@ -248,7 +249,8 @@ public abstract class FinancialSeries<TModel, TVisual, TLabel, TMiniatureGeometr
                 point.Context.HoverArea = ha = new RectangleHoverArea();
             _ = ha.SetDimensions(secondary - uwm, high, uw, Math.Abs(low - high));
 
-            _ = toDeletePoints.Remove(point);
+            toDeletePointsCnt--;
+            point.RemoveOnCompleted = false;
 
             if (DataLabelsPaint is not null)
             {
@@ -288,12 +290,8 @@ public abstract class FinancialSeries<TModel, TVisual, TLabel, TMiniatureGeometr
             OnPointMeasured(point);
         }
 
-        foreach (var point in toDeletePoints)
-        {
-            if (point.Context.Chart != cartesianChart.View) continue;
-            SoftDeleteOrDisposePoint(point, primaryScale, secondaryScale);
-            _ = everFetched.Remove(point);
-        }
+        if (toDeletePointsCnt != 0)
+            RemoveInvalidPoints(everFetched, cartesianChart.View, primaryScale, secondaryScale, SoftDeleteOrDisposePoint);
     }
 
     /// <inheritdoc cref="ICartesianSeries{TDrawingContext}.GetBounds(CartesianChart{TDrawingContext}, ICartesianAxis, ICartesianAxis)"/>

--- a/src/LiveChartsCore/HeatSeries.cs
+++ b/src/LiveChartsCore/HeatSeries.cs
@@ -109,8 +109,7 @@ public abstract class HeatSeries<TModel, TVisual, TLabel, TDrawingContext>
         }
 
         var dls = (float)DataLabelsSize;
-        var toDeletePointsCnt = everFetched.Count;
-        InvalidateAllPoints(everFetched);
+        var pointsCleanup = ChartPointCleanupContext.For(everFetched);
 
         var p = PointPadding;
 
@@ -189,8 +188,7 @@ public abstract class HeatSeries<TModel, TVisual, TLabel, TDrawingContext>
                 point.Context.HoverArea = ha = new RectangleHoverArea();
             _ = ha.SetDimensions(secondary - uws * 0.5f, primary - uwp * 0.5f, uws, uwp);
 
-            toDeletePointsCnt--;
-            point.RemoveOnCompleted = false;
+            pointsCleanup.RemovePoint(point);
 
             if (DataLabelsPaint is not null)
             {
@@ -226,8 +224,8 @@ public abstract class HeatSeries<TModel, TVisual, TLabel, TDrawingContext>
             OnPointMeasured(point);
         }
 
-        if (toDeletePointsCnt != 0)
-            RemoveInvalidPoints(everFetched, cartesianChart.View, primaryScale, secondaryScale, SoftDeleteOrDisposePoint);
+        if (pointsCleanup.ToDeleteCnt != 0)
+            ChartPointCleanupContext.RemoveInvalidPoints(everFetched, cartesianChart.View, primaryScale, secondaryScale, SoftDeleteOrDisposePoint);
     }
 
     /// <inheritdoc cref="ChartElement{TDrawingContext}.Invalidate(Chart{TDrawingContext})"/>

--- a/src/LiveChartsCore/HeatSeries.cs
+++ b/src/LiveChartsCore/HeatSeries.cs
@@ -184,8 +184,9 @@ public abstract class HeatSeries<TModel, TVisual, TLabel, TDrawingContext>
             visual.Color = LvcColor.FromArgb(baseColor.A, baseColor.R, baseColor.G, baseColor.B);
             visual.RemoveOnCompleted = false;
 
-            var ha = new RectangleHoverArea().SetDimensions(secondary - uws * 0.5f, primary - uwp * 0.5f, uws, uwp);
-            point.Context.HoverArea = ha;
+            if (point.Context.HoverArea is not RectangleHoverArea ha)
+                point.Context.HoverArea = ha = new RectangleHoverArea();
+            _ = ha.SetDimensions(secondary - uws * 0.5f, primary - uwp * 0.5f, uws, uwp);
 
             _ = toDeletePoints.Remove(point);
 

--- a/src/LiveChartsCore/HeatSeries.cs
+++ b/src/LiveChartsCore/HeatSeries.cs
@@ -188,7 +188,7 @@ public abstract class HeatSeries<TModel, TVisual, TLabel, TDrawingContext>
                 point.Context.HoverArea = ha = new RectangleHoverArea();
             _ = ha.SetDimensions(secondary - uws * 0.5f, primary - uwp * 0.5f, uws, uwp);
 
-            pointsCleanup.RemovePoint(point);
+            pointsCleanup.Clean(point);
 
             if (DataLabelsPaint is not null)
             {
@@ -224,8 +224,8 @@ public abstract class HeatSeries<TModel, TVisual, TLabel, TDrawingContext>
             OnPointMeasured(point);
         }
 
-        if (pointsCleanup.ToDeleteCnt != 0)
-            ChartPointCleanupContext.RemoveInvalidPoints(everFetched, cartesianChart.View, primaryScale, secondaryScale, SoftDeleteOrDisposePoint);
+        pointsCleanup.CollectPoints(
+            everFetched, cartesianChart.View, primaryScale, secondaryScale, SoftDeleteOrDisposePoint);
     }
 
     /// <inheritdoc cref="ChartElement{TDrawingContext}.Invalidate(Chart{TDrawingContext})"/>

--- a/src/LiveChartsCore/HeatSeries.cs
+++ b/src/LiveChartsCore/HeatSeries.cs
@@ -109,7 +109,8 @@ public abstract class HeatSeries<TModel, TVisual, TLabel, TDrawingContext>
         }
 
         var dls = (float)DataLabelsSize;
-        var toDeletePoints = new HashSet<ChartPoint>(everFetched);
+        var toDeletePointsCnt = everFetched.Count;
+        InvalidateAllPoints(everFetched);
 
         var p = PointPadding;
 
@@ -188,7 +189,8 @@ public abstract class HeatSeries<TModel, TVisual, TLabel, TDrawingContext>
                 point.Context.HoverArea = ha = new RectangleHoverArea();
             _ = ha.SetDimensions(secondary - uws * 0.5f, primary - uwp * 0.5f, uws, uwp);
 
-            _ = toDeletePoints.Remove(point);
+            toDeletePointsCnt--;
+            point.RemoveOnCompleted = false;
 
             if (DataLabelsPaint is not null)
             {
@@ -224,12 +226,8 @@ public abstract class HeatSeries<TModel, TVisual, TLabel, TDrawingContext>
             OnPointMeasured(point);
         }
 
-        foreach (var point in toDeletePoints)
-        {
-            if (point.Context.Chart != cartesianChart.View) continue;
-            SoftDeleteOrDisposePoint(point, primaryScale, secondaryScale);
-            _ = everFetched.Remove(point);
-        }
+        if (toDeletePointsCnt != 0)
+            RemoveInvalidPoints(everFetched, cartesianChart.View, primaryScale, secondaryScale, SoftDeleteOrDisposePoint);
     }
 
     /// <inheritdoc cref="ChartElement{TDrawingContext}.Invalidate(Chart{TDrawingContext})"/>

--- a/src/LiveChartsCore/Kernel/ChartPoint.cs
+++ b/src/LiveChartsCore/Kernel/ChartPoint.cs
@@ -184,6 +184,8 @@ public class ChartPoint
     /// </value>
     public ChartPointContext Context { get; }
 
+    internal bool RemoveOnCompleted { get; set; }
+
     /// <summary>
     /// Gets the distance to a given point.
     /// </summary>

--- a/src/LiveChartsCore/Kernel/ChartPointCleanupContext.cs
+++ b/src/LiveChartsCore/Kernel/ChartPointCleanupContext.cs
@@ -32,7 +32,6 @@ internal struct ChartPointCleanupContext
 {
     public int ToDeleteCnt { get; private set; }
 
-
     public void RemovePoint(ChartPoint point)
     {
         if (point.RemoveOnCompleted) // protect against deleting same point again
@@ -41,7 +40,6 @@ internal struct ChartPointCleanupContext
             point.RemoveOnCompleted = false;
         }
     }
-
 
     public static ChartPointCleanupContext For(HashSet<ChartPoint> points)
     {

--- a/src/LiveChartsCore/Kernel/ChartPointCleanupContext.cs
+++ b/src/LiveChartsCore/Kernel/ChartPointCleanupContext.cs
@@ -74,7 +74,6 @@ internal class ChartPointCleanupContext
         PolarScaler scale,
         Action<ChartPoint, PolarScaler> disposeAction)
     {
-
         if (_toDeleteCount == 0) return;
 
         // It would be nice to have System.Buffers installed to use rented buffer

--- a/src/LiveChartsCore/Kernel/ChartPointCleanupContext.cs
+++ b/src/LiveChartsCore/Kernel/ChartPointCleanupContext.cs
@@ -1,0 +1,87 @@
+﻿// The MIT License(MIT)
+//
+// Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using LiveChartsCore.Kernel.Sketches;
+using LiveChartsCore.Measure;
+using System.Collections.Generic;
+using System;
+using System.Linq;
+
+namespace LiveChartsCore.Kernel;
+
+internal struct ChartPointCleanupContext
+{
+    public int ToDeleteCnt { get; private set; }
+
+
+    public void RemovePoint(ChartPoint point)
+    {
+        if (point.RemoveOnCompleted) // protect against deleting same point again
+        {
+            ToDeleteCnt--;
+            point.RemoveOnCompleted = false;
+        }
+    }
+
+
+    public static ChartPointCleanupContext For(HashSet<ChartPoint> points)
+    {
+        InvalidateAllPoints(points);
+        return new ChartPointCleanupContext() { ToDeleteCnt = points.Count };
+    }
+
+    internal static void InvalidateAllPoints(HashSet<ChartPoint> points)
+    {
+        foreach (var point in points)
+            point.RemoveOnCompleted = true;
+    }
+
+    internal static void RemoveInvalidPoints(HashSet<ChartPoint> points, IChartView chartView, Scaler primaryScale, Scaler secondaryScale, Action<ChartPoint, Scaler, Scaler> disposeAction)
+    {
+        // It would be nice to have System.Buffers installed to use rented buffer
+        // Or we can probably use single cached buffer since all calculations are running on GUI thread
+        // At least we don't allocate when there is nothing to remove
+        // And allocate only as much as we need to remove
+        var toDeletePoints = points.Where(p => p.RemoveOnCompleted).ToArray();
+        foreach (var p in toDeletePoints)
+        {
+            if (p.Context.Chart != chartView) continue;
+            disposeAction(p, primaryScale, secondaryScale);
+            _ = points.Remove(p);
+        }
+    }
+
+    internal static void RemoveInvalidPoints(HashSet<ChartPoint> points, IChartView chartView, PolarScaler scale, Action<ChartPoint, PolarScaler> disposeAction)
+    {
+        // It would be nice to have System.Buffers installed to use rented buffer
+        // Or we can probably use single cached buffer since all calculations are running on GUI thread
+        // At least we don't allocate when there is nothing to remove
+        // And allocate only as much as we need to remove
+        var toDeletePoints = points.Where(p => p.RemoveOnCompleted).ToArray();
+        foreach (var p in toDeletePoints)
+        {
+            if (p.Context.Chart != chartView) continue;
+            disposeAction(p, scale);
+            _ = points.Remove(p);
+        }
+    }
+}

--- a/src/LiveChartsCore/Kernel/Drawing/BezierData.cs
+++ b/src/LiveChartsCore/Kernel/Drawing/BezierData.cs
@@ -25,7 +25,7 @@ namespace LiveChartsCore.Kernel.Drawing;
 /// <summary>
 /// Defines the bezier data class.
 /// </summary>
-public class BezierData
+public struct BezierData
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="BezierData"/> class.
@@ -34,6 +34,7 @@ public class BezierData
     public BezierData(ChartPoint chartPoint)
     {
         TargetPoint = chartPoint;
+        X0 = Y0 = X1 = Y1 = X2 = Y2 = 0;
     }
 
     /// <summary>

--- a/src/LiveChartsCore/Kernel/Extensions.cs
+++ b/src/LiveChartsCore/Kernel/Extensions.cs
@@ -23,6 +23,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using LiveChartsCore.Drawing;
 using LiveChartsCore.Kernel.Sketches;
 using LiveChartsCore.Measure;
@@ -36,6 +37,8 @@ namespace LiveChartsCore.Kernel;
 public static class Extensions
 {
     private const double Cf = 3d;
+
+    private static readonly Type s_nullableType = typeof(Nullable<>);
 
     /// <summary>
     /// Calculates the tooltip location.
@@ -487,6 +490,15 @@ public static class Extensions
 
         data.GoNext(data.Next);
         yield return data;
+    }
+
+    /// <summary>
+    /// Returns <see langword="true" /> when the given type is either a reference type or of type <see cref="Nullable{T}"/>.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static bool CanBeNull(Type type)
+    {
+        return !type.IsValueType || (type.IsGenericType && type.GetGenericTypeDefinition() == s_nullableType);
     }
 
     private static IEnumerable<ChartPoint> YieldReturnUntilNextNullChartPoint(

--- a/src/LiveChartsCore/LineSeries.cs
+++ b/src/LiveChartsCore/LineSeries.cs
@@ -307,7 +307,9 @@ public class LineSeries<TModel, TVisual, TLabel, TDrawingContext, TPathGeometry,
 
                 var hags = gs < 8 ? 8 : gs;
 
-                data.TargetPoint.Context.HoverArea = new RectangleHoverArea(x - uwx * 0.5f, y - hgs, uwx, gs);
+                if (data.TargetPoint.Context.HoverArea is not RectangleHoverArea ha)
+                    data.TargetPoint.Context.HoverArea = ha = new RectangleHoverArea();
+                _ = ha.SetDimensions(x - uwx * 0.5f, y - hgs, uwx, gs);
 
                 _ = toDeletePoints.Remove(data.TargetPoint);
 

--- a/src/LiveChartsCore/LineSeries.cs
+++ b/src/LiveChartsCore/LineSeries.cs
@@ -311,7 +311,7 @@ public class LineSeries<TModel, TVisual, TLabel, TDrawingContext, TPathGeometry,
                     data.TargetPoint.Context.HoverArea = ha = new RectangleHoverArea();
                 _ = ha.SetDimensions(x - uwx * 0.5f, y - hgs, uwx, gs);
 
-                pointsCleanup.RemovePoint(data.TargetPoint);
+                pointsCleanup.Clean(data.TargetPoint);
 
                 if (DataLabelsPaint is not null)
                 {
@@ -399,8 +399,8 @@ public class LineSeries<TModel, TVisual, TLabel, TDrawingContext, TPathGeometry,
             DataLabelsPaint.ZIndex = actualZIndex + 0.5;
         }
 
-        if (pointsCleanup.ToDeleteCnt != 0)
-            ChartPointCleanupContext.RemoveInvalidPoints(everFetched, cartesianChart.View, primaryScale, secondaryScale, SoftDeleteOrDisposePoint);
+        pointsCleanup.CollectPoints(
+            everFetched, cartesianChart.View, primaryScale, secondaryScale, SoftDeleteOrDisposePoint);
 
         IsFirstDraw = false;
     }

--- a/src/LiveChartsCore/LineSeries.cs
+++ b/src/LiveChartsCore/LineSeries.cs
@@ -150,7 +150,8 @@ public class LineSeries<TModel, TVisual, TLabel, TDrawingContext, TPathGeometry,
         }
 
         var dls = (float)DataLabelsSize;
-        var toDeletePoints = new HashSet<ChartPoint>(everFetched);
+        var toDeletePointsCnt = everFetched.Count;
+        InvalidateAllPoints(everFetched);
 
         if (!_strokePathHelperDictionary.TryGetValue(chart.Canvas.Sync, out var strokePathHelperContainer))
         {
@@ -311,7 +312,8 @@ public class LineSeries<TModel, TVisual, TLabel, TDrawingContext, TPathGeometry,
                     data.TargetPoint.Context.HoverArea = ha = new RectangleHoverArea();
                 _ = ha.SetDimensions(x - uwx * 0.5f, y - hgs, uwx, gs);
 
-                _ = toDeletePoints.Remove(data.TargetPoint);
+                toDeletePointsCnt--;
+                data.TargetPoint.RemoveOnCompleted = false;
 
                 if (DataLabelsPaint is not null)
                 {
@@ -399,12 +401,8 @@ public class LineSeries<TModel, TVisual, TLabel, TDrawingContext, TPathGeometry,
             DataLabelsPaint.ZIndex = actualZIndex + 0.5;
         }
 
-        foreach (var point in toDeletePoints)
-        {
-            if (point.Context.Chart != cartesianChart.View) continue;
-            SoftDeleteOrDisposePoint(point, primaryScale, secondaryScale);
-            _ = everFetched.Remove(point);
-        }
+        if (toDeletePointsCnt != 0)
+            RemoveInvalidPoints(everFetched, cartesianChart.View, primaryScale, secondaryScale, SoftDeleteOrDisposePoint);
 
         IsFirstDraw = false;
     }

--- a/src/LiveChartsCore/LineSeries.cs
+++ b/src/LiveChartsCore/LineSeries.cs
@@ -150,8 +150,7 @@ public class LineSeries<TModel, TVisual, TLabel, TDrawingContext, TPathGeometry,
         }
 
         var dls = (float)DataLabelsSize;
-        var toDeletePointsCnt = everFetched.Count;
-        InvalidateAllPoints(everFetched);
+        var pointsCleanup = ChartPointCleanupContext.For(everFetched);
 
         if (!_strokePathHelperDictionary.TryGetValue(chart.Canvas.Sync, out var strokePathHelperContainer))
         {
@@ -312,8 +311,7 @@ public class LineSeries<TModel, TVisual, TLabel, TDrawingContext, TPathGeometry,
                     data.TargetPoint.Context.HoverArea = ha = new RectangleHoverArea();
                 _ = ha.SetDimensions(x - uwx * 0.5f, y - hgs, uwx, gs);
 
-                toDeletePointsCnt--;
-                data.TargetPoint.RemoveOnCompleted = false;
+                pointsCleanup.RemovePoint(data.TargetPoint);
 
                 if (DataLabelsPaint is not null)
                 {
@@ -401,8 +399,8 @@ public class LineSeries<TModel, TVisual, TLabel, TDrawingContext, TPathGeometry,
             DataLabelsPaint.ZIndex = actualZIndex + 0.5;
         }
 
-        if (toDeletePointsCnt != 0)
-            RemoveInvalidPoints(everFetched, cartesianChart.View, primaryScale, secondaryScale, SoftDeleteOrDisposePoint);
+        if (pointsCleanup.ToDeleteCnt != 0)
+            ChartPointCleanupContext.RemoveInvalidPoints(everFetched, cartesianChart.View, primaryScale, secondaryScale, SoftDeleteOrDisposePoint);
 
         IsFirstDraw = false;
     }

--- a/src/LiveChartsCore/Motion/MotionProperty.cs
+++ b/src/LiveChartsCore/Motion/MotionProperty.cs
@@ -30,6 +30,9 @@ namespace LiveChartsCore.Motion;
 /// <typeparam name="T"></typeparam>
 public abstract class MotionProperty<T> : IMotionProperty
 {
+    private static readonly bool s_canBeNull = Kernel.Extensions.CanBeNull(typeof(T));
+
+
     /// <summary>
     /// From value
     /// </summary>
@@ -120,9 +123,10 @@ public abstract class MotionProperty<T> : IMotionProperty
     /// <returns></returns>
     public T GetMovement(Animatable animatable)
     {
-        // For some reason JITter can't remove value type boxing when this statement is used inside composite if statement
+        // For some reason JITter can't remove value type boxing when started under PerfView Run command
         // Emitted IL has boxing originally, but JITter should be able to optimize it to 'false' or 'Nullable<T>.HasValue'
-        var fromValueIsNull = fromValue is null;
+        // When s_canBeNull is false JITter should remove second check from generated code
+        var fromValueIsNull = s_canBeNull && fromValue is null;
         if (Animation is null || Animation.EasingFunction is null || fromValueIsNull || IsCompleted) return OnGetMovement(1);
 
         if (_requiresToInitialize || _startTime == long.MinValue)

--- a/src/LiveChartsCore/Motion/MotionProperty.cs
+++ b/src/LiveChartsCore/Motion/MotionProperty.cs
@@ -32,7 +32,6 @@ public abstract class MotionProperty<T> : IMotionProperty
 {
     private static readonly bool s_canBeNull = Kernel.Extensions.CanBeNull(typeof(T));
 
-
     /// <summary>
     /// From value
     /// </summary>

--- a/src/LiveChartsCore/Motion/MotionProperty.cs
+++ b/src/LiveChartsCore/Motion/MotionProperty.cs
@@ -120,7 +120,10 @@ public abstract class MotionProperty<T> : IMotionProperty
     /// <returns></returns>
     public T GetMovement(Animatable animatable)
     {
-        if (Animation is null || Animation.EasingFunction is null || fromValue is null || IsCompleted) return OnGetMovement(1);
+        // For some reason JITter can't remove value type boxing when this statement is used inside composite if statement
+        // Emitted IL has boxing originally, but JITter should be able to optimize it to 'false' or 'Nullable<T>.HasValue'
+        var fromValueIsNull = fromValue is null;
+        if (Animation is null || Animation.EasingFunction is null || fromValueIsNull || IsCompleted) return OnGetMovement(1);
 
         if (_requiresToInitialize || _startTime == long.MinValue)
         {

--- a/src/LiveChartsCore/PieSeries.cs
+++ b/src/LiveChartsCore/PieSeries.cs
@@ -343,7 +343,7 @@ public abstract class PieSeries<TModel, TVisual, TLabel, TMiniatureGeometry, TDr
                 point.Context.HoverArea = ha = new SemicircleHoverArea();
             _ = ha.SetDimensions(cx, cy, (float)(start + initialRotation), (float)(start + initialRotation + sweep), md * 0.5f);
 
-            pointsCleanup.RemovePoint(point);
+            pointsCleanup.Clean(point);
 
             if (DataLabelsPaint is not null && point.PrimaryValue >= 0)
             {
@@ -429,11 +429,8 @@ public abstract class PieSeries<TModel, TVisual, TLabel, TMiniatureGeometry, TDr
             i++;
         }
 
-        if (pointsCleanup.ToDeleteCnt != 0)
-        {
-            var u = new Scaler();
-            ChartPointCleanupContext.RemoveInvalidPoints(everFetched, pieChart.View, u, u, SoftDeleteOrDisposePoint);
-        }
+        var u = new Scaler(); // dummy scaler, this is not used in the SoftDeleteOrDisposePoint method.
+        pointsCleanup.CollectPoints(everFetched, pieChart.View, u, u, SoftDeleteOrDisposePoint);
     }
 
     /// <inheritdoc cref="IPieSeries{TDrawingContext}.GetBounds(PieChart{TDrawingContext})"/>

--- a/src/LiveChartsCore/PieSeries.cs
+++ b/src/LiveChartsCore/PieSeries.cs
@@ -339,8 +339,9 @@ public abstract class PieSeries<TModel, TVisual, TLabel, TMiniatureGeometry, TDr
             if (start + initialRotation == initialRotation && sweep == 360)
                 dougnutGeometry.SweepAngle = 359.99f;
 
-            point.Context.HoverArea = new SemicircleHoverArea()
-                .SetDimensions(cx, cy, (float)(start + initialRotation), (float)(start + initialRotation + sweep), md * 0.5f);
+            if (point.Context.HoverArea is not SemicircleHoverArea ha)
+                point.Context.HoverArea = ha = new SemicircleHoverArea();
+            _ = ha.SetDimensions(cx, cy, (float)(start + initialRotation), (float)(start + initialRotation + sweep), md * 0.5f);
 
             _ = toDeletePoints.Remove(point);
 

--- a/src/LiveChartsCore/PieSeries.cs
+++ b/src/LiveChartsCore/PieSeries.cs
@@ -177,8 +177,7 @@ public abstract class PieSeries<TModel, TVisual, TLabel, TMiniatureGeometry, TDr
         var stacker = pieChart.SeriesContext.GetStackPosition(this, GetStackGroup());
         if (stacker is null) throw new NullReferenceException("Unexpected null stacker");
 
-        var toDeletePointsCnt = everFetched.Count;
-        InvalidateAllPoints(everFetched);
+        var pointsCleanup = ChartPointCleanupContext.For(everFetched);
 
         var fetched = Fetch(pieChart).ToArray();
 
@@ -344,8 +343,7 @@ public abstract class PieSeries<TModel, TVisual, TLabel, TMiniatureGeometry, TDr
                 point.Context.HoverArea = ha = new SemicircleHoverArea();
             _ = ha.SetDimensions(cx, cy, (float)(start + initialRotation), (float)(start + initialRotation + sweep), md * 0.5f);
 
-            toDeletePointsCnt--;
-            point.RemoveOnCompleted = false;
+            pointsCleanup.RemovePoint(point);
 
             if (DataLabelsPaint is not null && point.PrimaryValue >= 0)
             {
@@ -431,10 +429,10 @@ public abstract class PieSeries<TModel, TVisual, TLabel, TMiniatureGeometry, TDr
             i++;
         }
 
-        if (toDeletePointsCnt != 0)
+        if (pointsCleanup.ToDeleteCnt != 0)
         {
             var u = new Scaler();
-            RemoveInvalidPoints(everFetched, pieChart.View, u, u, SoftDeleteOrDisposePoint);
+            ChartPointCleanupContext.RemoveInvalidPoints(everFetched, pieChart.View, u, u, SoftDeleteOrDisposePoint);
         }
     }
 

--- a/src/LiveChartsCore/PolarLineSeries.cs
+++ b/src/LiveChartsCore/PolarLineSeries.cs
@@ -324,7 +324,9 @@ public class PolarLineSeries<TModel, TVisual, TLabel, TDrawingContext, TPathGeom
                 visual.StrokePath = strokePath;
 
                 var hags = gs < 16 ? 16 : gs;
-                data.TargetPoint.Context.HoverArea = new RectangleHoverArea(x - hags * 0.5f, y - hags * 0.5f, hags, hags);
+                if (data.TargetPoint.Context.HoverArea is not RectangleHoverArea ha)
+                    data.TargetPoint.Context.HoverArea = ha = new RectangleHoverArea();
+                _ = ha.SetDimensions(x - hags * 0.5f, y - hags * 0.5f, hags, hags);
 
                 _ = toDeletePoints.Remove(data.TargetPoint);
 

--- a/src/LiveChartsCore/PolarLineSeries.cs
+++ b/src/LiveChartsCore/PolarLineSeries.cs
@@ -189,7 +189,8 @@ public class PolarLineSeries<TModel, TVisual, TLabel, TDrawingContext, TPathGeom
         var dls = unchecked((float)DataLabelsSize);
 
         var segmentI = 0;
-        var toDeletePoints = new HashSet<ChartPoint>(everFetched);
+        var toDeletePointsCnt = everFetched.Count;
+        InvalidateAllPoints(everFetched);
 
         if (!_strokePathHelperDictionary.TryGetValue(chart.Canvas.Sync, out var strokePathHelperContainer))
         {
@@ -328,7 +329,8 @@ public class PolarLineSeries<TModel, TVisual, TLabel, TDrawingContext, TPathGeom
                     data.TargetPoint.Context.HoverArea = ha = new RectangleHoverArea();
                 _ = ha.SetDimensions(x - hags * 0.5f, y - hags * 0.5f, hags, hags);
 
-                _ = toDeletePoints.Remove(data.TargetPoint);
+                toDeletePointsCnt--;
+                data.TargetPoint.RemoveOnCompleted = false;
 
                 if (DataLabelsPaint is not null)
                 {
@@ -410,12 +412,8 @@ public class PolarLineSeries<TModel, TVisual, TLabel, TDrawingContext, TPathGeom
             DataLabelsPaint.ZIndex = actualZIndex + 0.5;
         }
 
-        foreach (var point in toDeletePoints)
-        {
-            if (point.Context.Chart != polarChart.View) continue;
-            SoftDeleteOrDisposePoint(point, scaler);
-            _ = everFetched.Remove(point);
-        }
+        if (toDeletePointsCnt != 0)
+            RemoveInvalidPoints(everFetched, polarChart.View, scaler, SoftDeleteOrDisposePoint);
     }
 
     /// <inheritdoc cref="IPolarSeries{TDrawingContext}.GetBounds(PolarChart{TDrawingContext}, IPolarAxis, IPolarAxis)"/>

--- a/src/LiveChartsCore/PolarLineSeries.cs
+++ b/src/LiveChartsCore/PolarLineSeries.cs
@@ -189,8 +189,7 @@ public class PolarLineSeries<TModel, TVisual, TLabel, TDrawingContext, TPathGeom
         var dls = unchecked((float)DataLabelsSize);
 
         var segmentI = 0;
-        var toDeletePointsCnt = everFetched.Count;
-        InvalidateAllPoints(everFetched);
+        var pointsCleanup = ChartPointCleanupContext.For(everFetched);
 
         if (!_strokePathHelperDictionary.TryGetValue(chart.Canvas.Sync, out var strokePathHelperContainer))
         {
@@ -329,8 +328,7 @@ public class PolarLineSeries<TModel, TVisual, TLabel, TDrawingContext, TPathGeom
                     data.TargetPoint.Context.HoverArea = ha = new RectangleHoverArea();
                 _ = ha.SetDimensions(x - hags * 0.5f, y - hags * 0.5f, hags, hags);
 
-                toDeletePointsCnt--;
-                data.TargetPoint.RemoveOnCompleted = false;
+                pointsCleanup.RemovePoint(data.TargetPoint);
 
                 if (DataLabelsPaint is not null)
                 {
@@ -412,8 +410,8 @@ public class PolarLineSeries<TModel, TVisual, TLabel, TDrawingContext, TPathGeom
             DataLabelsPaint.ZIndex = actualZIndex + 0.5;
         }
 
-        if (toDeletePointsCnt != 0)
-            RemoveInvalidPoints(everFetched, polarChart.View, scaler, SoftDeleteOrDisposePoint);
+        if (pointsCleanup.ToDeleteCnt != 0)
+            ChartPointCleanupContext.RemoveInvalidPoints(everFetched, polarChart.View, scaler, SoftDeleteOrDisposePoint);
     }
 
     /// <inheritdoc cref="IPolarSeries{TDrawingContext}.GetBounds(PolarChart{TDrawingContext}, IPolarAxis, IPolarAxis)"/>

--- a/src/LiveChartsCore/PolarLineSeries.cs
+++ b/src/LiveChartsCore/PolarLineSeries.cs
@@ -328,7 +328,7 @@ public class PolarLineSeries<TModel, TVisual, TLabel, TDrawingContext, TPathGeom
                     data.TargetPoint.Context.HoverArea = ha = new RectangleHoverArea();
                 _ = ha.SetDimensions(x - hags * 0.5f, y - hags * 0.5f, hags, hags);
 
-                pointsCleanup.RemovePoint(data.TargetPoint);
+                pointsCleanup.Clean(data.TargetPoint);
 
                 if (DataLabelsPaint is not null)
                 {
@@ -410,8 +410,7 @@ public class PolarLineSeries<TModel, TVisual, TLabel, TDrawingContext, TPathGeom
             DataLabelsPaint.ZIndex = actualZIndex + 0.5;
         }
 
-        if (pointsCleanup.ToDeleteCnt != 0)
-            ChartPointCleanupContext.RemoveInvalidPoints(everFetched, polarChart.View, scaler, SoftDeleteOrDisposePoint);
+        pointsCleanup.CollectPoints(everFetched, polarChart.View, scaler, SoftDeleteOrDisposePoint);
     }
 
     /// <inheritdoc cref="IPolarSeries{TDrawingContext}.GetBounds(PolarChart{TDrawingContext}, IPolarAxis, IPolarAxis)"/>

--- a/src/LiveChartsCore/RowSeries.cs
+++ b/src/LiveChartsCore/RowSeries.cs
@@ -102,8 +102,7 @@ public class RowSeries<TModel, TVisual, TLabel, TDrawingContext> : BarSeries<TMo
         }
 
         var dls = (float)DataLabelsSize;
-        var toDeletePointsCnt = everFetched.Count;
-        InvalidateAllPoints(everFetched);
+        var pointsCleanup = ChartPointCleanupContext.For(everFetched);
 
         var rx = (float)Rx;
         var ry = (float)Ry;
@@ -215,8 +214,7 @@ public class RowSeries<TModel, TVisual, TLabel, TDrawingContext> : BarSeries<TMo
                 point.Context.HoverArea = ha = new RectangleHoverArea();
             _ = ha.SetDimensions(cx, secondary - helper.actualUw * 0.5f, b, helper.actualUw);
 
-            toDeletePointsCnt--;
-            point.RemoveOnCompleted = false;
+            pointsCleanup.RemovePoint(point);
 
             if (DataLabelsPaint is not null)
             {
@@ -256,8 +254,8 @@ public class RowSeries<TModel, TVisual, TLabel, TDrawingContext> : BarSeries<TMo
             OnPointMeasured(point);
         }
 
-        if (toDeletePointsCnt != 0)
-            RemoveInvalidPoints(everFetched, cartesianChart.View, primaryScale, secondaryScale, SoftDeleteOrDisposePoint);
+        if (pointsCleanup.ToDeleteCnt != 0)
+            ChartPointCleanupContext.RemoveInvalidPoints(everFetched, cartesianChart.View, primaryScale, secondaryScale, SoftDeleteOrDisposePoint);
     }
 
     /// <inheritdoc cref="CartesianSeries{TModel, TVisual, TLabel, TDrawingContext}.GetRequestedSecondaryOffset"/>

--- a/src/LiveChartsCore/RowSeries.cs
+++ b/src/LiveChartsCore/RowSeries.cs
@@ -210,7 +210,9 @@ public class RowSeries<TModel, TVisual, TLabel, TDrawingContext> : BarSeries<TMo
             }
             visual.RemoveOnCompleted = false;
 
-            point.Context.HoverArea = new RectangleHoverArea(cx, secondary - helper.actualUw * 0.5f, b, helper.actualUw);
+            if (point.Context.HoverArea is not RectangleHoverArea ha)
+                point.Context.HoverArea = ha = new RectangleHoverArea();
+            _ = ha.SetDimensions(cx, secondary - helper.actualUw * 0.5f, b, helper.actualUw);
 
             _ = toDeletePoints.Remove(point);
 

--- a/src/LiveChartsCore/RowSeries.cs
+++ b/src/LiveChartsCore/RowSeries.cs
@@ -102,7 +102,8 @@ public class RowSeries<TModel, TVisual, TLabel, TDrawingContext> : BarSeries<TMo
         }
 
         var dls = (float)DataLabelsSize;
-        var toDeletePoints = new HashSet<ChartPoint>(everFetched);
+        var toDeletePointsCnt = everFetched.Count;
+        InvalidateAllPoints(everFetched);
 
         var rx = (float)Rx;
         var ry = (float)Ry;
@@ -214,7 +215,8 @@ public class RowSeries<TModel, TVisual, TLabel, TDrawingContext> : BarSeries<TMo
                 point.Context.HoverArea = ha = new RectangleHoverArea();
             _ = ha.SetDimensions(cx, secondary - helper.actualUw * 0.5f, b, helper.actualUw);
 
-            _ = toDeletePoints.Remove(point);
+            toDeletePointsCnt--;
+            point.RemoveOnCompleted = false;
 
             if (DataLabelsPaint is not null)
             {
@@ -254,12 +256,8 @@ public class RowSeries<TModel, TVisual, TLabel, TDrawingContext> : BarSeries<TMo
             OnPointMeasured(point);
         }
 
-        foreach (var point in toDeletePoints)
-        {
-            if (point.Context.Chart != cartesianChart.View) continue;
-            SoftDeleteOrDisposePoint(point, primaryScale, secondaryScale);
-            _ = everFetched.Remove(point);
-        }
+        if (toDeletePointsCnt != 0)
+            RemoveInvalidPoints(everFetched, cartesianChart.View, primaryScale, secondaryScale, SoftDeleteOrDisposePoint);
     }
 
     /// <inheritdoc cref="CartesianSeries{TModel, TVisual, TLabel, TDrawingContext}.GetRequestedSecondaryOffset"/>

--- a/src/LiveChartsCore/RowSeries.cs
+++ b/src/LiveChartsCore/RowSeries.cs
@@ -214,7 +214,7 @@ public class RowSeries<TModel, TVisual, TLabel, TDrawingContext> : BarSeries<TMo
                 point.Context.HoverArea = ha = new RectangleHoverArea();
             _ = ha.SetDimensions(cx, secondary - helper.actualUw * 0.5f, b, helper.actualUw);
 
-            pointsCleanup.RemovePoint(point);
+            pointsCleanup.Clean(point);
 
             if (DataLabelsPaint is not null)
             {
@@ -254,8 +254,8 @@ public class RowSeries<TModel, TVisual, TLabel, TDrawingContext> : BarSeries<TMo
             OnPointMeasured(point);
         }
 
-        if (pointsCleanup.ToDeleteCnt != 0)
-            ChartPointCleanupContext.RemoveInvalidPoints(everFetched, cartesianChart.View, primaryScale, secondaryScale, SoftDeleteOrDisposePoint);
+        pointsCleanup.CollectPoints(
+            everFetched, cartesianChart.View, primaryScale, secondaryScale, SoftDeleteOrDisposePoint);
     }
 
     /// <inheritdoc cref="CartesianSeries{TModel, TVisual, TLabel, TDrawingContext}.GetRequestedSecondaryOffset"/>

--- a/src/LiveChartsCore/ScatterSeries.cs
+++ b/src/LiveChartsCore/ScatterSeries.cs
@@ -178,7 +178,9 @@ public class ScatterSeries<TModel, TVisual, TLabel, TDrawingContext>
 
             sizedGeometry.RemoveOnCompleted = false;
 
-            point.Context.HoverArea = new RectangleHoverArea(x - uwx * 0.5f, y - uwy * 0.5f, uwx, uwy);
+            if (point.Context.HoverArea is not RectangleHoverArea ha)
+                point.Context.HoverArea = ha = new RectangleHoverArea();
+            _ = ha.SetDimensions(x - uwx * 0.5f, y - uwy * 0.5f, uwx, uwy);
 
             _ = toDeletePoints.Remove(point);
 

--- a/src/LiveChartsCore/ScatterSeries.cs
+++ b/src/LiveChartsCore/ScatterSeries.cs
@@ -108,7 +108,8 @@ public class ScatterSeries<TModel, TVisual, TLabel, TDrawingContext>
         }
 
         var dls = (float)DataLabelsSize;
-        var toDeletePoints = new HashSet<ChartPoint>(everFetched);
+        var toDeletePointsCnt = everFetched.Count;
+        InvalidateAllPoints(everFetched);
 
         var gs = (float)GeometrySize;
         var hgs = gs / 2f;
@@ -182,7 +183,8 @@ public class ScatterSeries<TModel, TVisual, TLabel, TDrawingContext>
                 point.Context.HoverArea = ha = new RectangleHoverArea();
             _ = ha.SetDimensions(x - uwx * 0.5f, y - uwy * 0.5f, uwx, uwy);
 
-            _ = toDeletePoints.Remove(point);
+            toDeletePointsCnt--;
+            point.RemoveOnCompleted = false;
 
             if (DataLabelsPaint is not null)
             {
@@ -218,12 +220,8 @@ public class ScatterSeries<TModel, TVisual, TLabel, TDrawingContext>
             OnPointMeasured(point);
         }
 
-        foreach (var point in toDeletePoints)
-        {
-            if (point.Context.Chart != cartesianChart.View) continue;
-            SoftDeleteOrDisposePoint(point, yScale, xScale);
-            _ = everFetched.Remove(point);
-        }
+        if (toDeletePointsCnt != 0)
+            RemoveInvalidPoints(everFetched, cartesianChart.View, yScale, xScale, SoftDeleteOrDisposePoint);
     }
 
     /// <inheritdoc cref="ChartElement{TDrawingContext}.Invalidate(Chart{TDrawingContext})"/>

--- a/src/LiveChartsCore/ScatterSeries.cs
+++ b/src/LiveChartsCore/ScatterSeries.cs
@@ -108,8 +108,7 @@ public class ScatterSeries<TModel, TVisual, TLabel, TDrawingContext>
         }
 
         var dls = (float)DataLabelsSize;
-        var toDeletePointsCnt = everFetched.Count;
-        InvalidateAllPoints(everFetched);
+        var pointsCleanup = ChartPointCleanupContext.For(everFetched);
 
         var gs = (float)GeometrySize;
         var hgs = gs / 2f;
@@ -183,8 +182,7 @@ public class ScatterSeries<TModel, TVisual, TLabel, TDrawingContext>
                 point.Context.HoverArea = ha = new RectangleHoverArea();
             _ = ha.SetDimensions(x - uwx * 0.5f, y - uwy * 0.5f, uwx, uwy);
 
-            toDeletePointsCnt--;
-            point.RemoveOnCompleted = false;
+            pointsCleanup.RemovePoint(point);
 
             if (DataLabelsPaint is not null)
             {
@@ -220,8 +218,8 @@ public class ScatterSeries<TModel, TVisual, TLabel, TDrawingContext>
             OnPointMeasured(point);
         }
 
-        if (toDeletePointsCnt != 0)
-            RemoveInvalidPoints(everFetched, cartesianChart.View, yScale, xScale, SoftDeleteOrDisposePoint);
+        if (pointsCleanup.ToDeleteCnt != 0)
+            ChartPointCleanupContext.RemoveInvalidPoints(everFetched, cartesianChart.View, yScale, xScale, SoftDeleteOrDisposePoint);
     }
 
     /// <inheritdoc cref="ChartElement{TDrawingContext}.Invalidate(Chart{TDrawingContext})"/>

--- a/src/LiveChartsCore/ScatterSeries.cs
+++ b/src/LiveChartsCore/ScatterSeries.cs
@@ -182,7 +182,7 @@ public class ScatterSeries<TModel, TVisual, TLabel, TDrawingContext>
                 point.Context.HoverArea = ha = new RectangleHoverArea();
             _ = ha.SetDimensions(x - uwx * 0.5f, y - uwy * 0.5f, uwx, uwy);
 
-            pointsCleanup.RemovePoint(point);
+            pointsCleanup.Clean(point);
 
             if (DataLabelsPaint is not null)
             {
@@ -218,8 +218,7 @@ public class ScatterSeries<TModel, TVisual, TLabel, TDrawingContext>
             OnPointMeasured(point);
         }
 
-        if (pointsCleanup.ToDeleteCnt != 0)
-            ChartPointCleanupContext.RemoveInvalidPoints(everFetched, cartesianChart.View, yScale, xScale, SoftDeleteOrDisposePoint);
+        pointsCleanup.CollectPoints(everFetched, cartesianChart.View, yScale, xScale, SoftDeleteOrDisposePoint);
     }
 
     /// <inheritdoc cref="ChartElement{TDrawingContext}.Invalidate(Chart{TDrawingContext})"/>

--- a/src/LiveChartsCore/Series.cs
+++ b/src/LiveChartsCore/Series.cs
@@ -566,40 +566,4 @@ public abstract class Series<TModel, TVisual, TLabel, TDrawingContext>
     {
         foreach (var chart in subscribedTo) chart.Update();
     }
-
-    internal static void InvalidateAllPoints(HashSet<ChartPoint> points)
-    {
-        foreach (var point in points)
-            point.RemoveOnCompleted = true;
-    }
-
-    internal static void RemoveInvalidPoints(HashSet<ChartPoint> points, IChartView chartView, Scaler primaryScale, Scaler secondaryScale, Action<ChartPoint, Scaler, Scaler> disposeAction)
-    {
-        // It would be nice to have System.Buffers installed to use rented buffer
-        // Or we can probably use single cached buffer since all calculations are running on GUI thread
-        // At least we don't allocate when there is nothing to remove
-        // And allocate only as much as we need to remove
-        var toDeletePoints = points.Where(p => p.RemoveOnCompleted).ToArray();
-        foreach (var p in toDeletePoints)
-        {
-            if (p.Context.Chart != chartView) continue;
-            disposeAction(p, primaryScale, secondaryScale);
-            _ = points.Remove(p);
-        }
-    }
-
-    internal static void RemoveInvalidPoints(HashSet<ChartPoint> points, IChartView chartView, PolarScaler scale, Action<ChartPoint, PolarScaler> disposeAction)
-    {
-        // It would be nice to have System.Buffers installed to use rented buffer
-        // Or we can probably use single cached buffer since all calculations are running on GUI thread
-        // At least we don't allocate when there is nothing to remove
-        // And allocate only as much as we need to remove
-        var toDeletePoints = points.Where(p => p.RemoveOnCompleted).ToArray();
-        foreach (var p in toDeletePoints)
-        {
-            if (p.Context.Chart != chartView) continue;
-            disposeAction(p, scale);
-            _ = points.Remove(p);
-        }
-    }
 }

--- a/src/LiveChartsCore/Series.cs
+++ b/src/LiveChartsCore/Series.cs
@@ -566,4 +566,40 @@ public abstract class Series<TModel, TVisual, TLabel, TDrawingContext>
     {
         foreach (var chart in subscribedTo) chart.Update();
     }
+
+    internal static void InvalidateAllPoints(HashSet<ChartPoint> points)
+    {
+        foreach (var point in points)
+            point.RemoveOnCompleted = true;
+    }
+
+    internal static void RemoveInvalidPoints(HashSet<ChartPoint> points, IChartView chartView, Scaler primaryScale, Scaler secondaryScale, Action<ChartPoint, Scaler, Scaler> disposeAction)
+    {
+        // It would be nice to have System.Buffers installed to use rented buffer
+        // Or we can probably use single cached buffer since all calculations are running on GUI thread
+        // At least we don't allocate when there is nothing to remove
+        // And allocate only as much as we need to remove
+        var toDeletePoints = points.Where(p => p.RemoveOnCompleted).ToArray();
+        foreach (var p in toDeletePoints)
+        {
+            if (p.Context.Chart != chartView) continue;
+            disposeAction(p, primaryScale, secondaryScale);
+            _ = points.Remove(p);
+        }
+    }
+
+    internal static void RemoveInvalidPoints(HashSet<ChartPoint> points, IChartView chartView, PolarScaler scale, Action<ChartPoint, PolarScaler> disposeAction)
+    {
+        // It would be nice to have System.Buffers installed to use rented buffer
+        // Or we can probably use single cached buffer since all calculations are running on GUI thread
+        // At least we don't allocate when there is nothing to remove
+        // And allocate only as much as we need to remove
+        var toDeletePoints = points.Where(p => p.RemoveOnCompleted).ToArray();
+        foreach (var p in toDeletePoints)
+        {
+            if (p.Context.Chart != chartView) continue;
+            disposeAction(p, scale);
+            _ = points.Remove(p);
+        }
+    }
 }

--- a/src/LiveChartsCore/StepLineSeries.cs
+++ b/src/LiveChartsCore/StepLineSeries.cs
@@ -268,7 +268,9 @@ public class StepLineSeries<TModel, TVisual, TLabel, TDrawingContext, TPathGeome
 
                 var hags = gs < 8 ? 8 : gs;
 
-                point.Context.HoverArea = new RectangleHoverArea(x - uwx * 0.5f, y - hgs, uwx, gs);
+                if (point.Context.HoverArea is not RectangleHoverArea ha)
+                    point.Context.HoverArea = ha = new RectangleHoverArea();
+                _ = ha.SetDimensions(x - uwx * 0.5f, y - hgs, uwx, gs);
 
                 _ = toDeletePoints.Remove(point);
 

--- a/src/LiveChartsCore/StepLineSeries.cs
+++ b/src/LiveChartsCore/StepLineSeries.cs
@@ -129,8 +129,7 @@ public class StepLineSeries<TModel, TVisual, TLabel, TDrawingContext, TPathGeome
         var dls = (float)DataLabelsSize;
 
         var segmentI = 0;
-        var toDeletePointsCnt = everFetched.Count;
-        InvalidateAllPoints(everFetched);
+        var pointsCleanup = ChartPointCleanupContext.For(everFetched);
 
         if (!_strokePathHelperDictionary.TryGetValue(chart.Canvas.Sync, out var strokePathHelperContainer))
         {
@@ -273,8 +272,7 @@ public class StepLineSeries<TModel, TVisual, TLabel, TDrawingContext, TPathGeome
                     point.Context.HoverArea = ha = new RectangleHoverArea();
                 _ = ha.SetDimensions(x - uwx * 0.5f, y - hgs, uwx, gs);
 
-                toDeletePointsCnt--;
-                point.RemoveOnCompleted = false;
+                pointsCleanup.RemovePoint(point);
 
                 if (DataLabelsPaint is not null)
                 {
@@ -353,8 +351,8 @@ public class StepLineSeries<TModel, TVisual, TLabel, TDrawingContext, TPathGeome
             DataLabelsPaint.ZIndex = actualZIndex + 0.5;
         }
 
-        if (toDeletePointsCnt != 0)
-            RemoveInvalidPoints(everFetched, cartesianChart.View, primaryScale, secondaryScale, SoftDeleteOrDisposePoint);
+        if (pointsCleanup.ToDeleteCnt != 0)
+            ChartPointCleanupContext.RemoveInvalidPoints(everFetched, cartesianChart.View, primaryScale, secondaryScale, SoftDeleteOrDisposePoint);
 
         IsFirstDraw = false;
     }

--- a/src/LiveChartsCore/StepLineSeries.cs
+++ b/src/LiveChartsCore/StepLineSeries.cs
@@ -272,7 +272,7 @@ public class StepLineSeries<TModel, TVisual, TLabel, TDrawingContext, TPathGeome
                     point.Context.HoverArea = ha = new RectangleHoverArea();
                 _ = ha.SetDimensions(x - uwx * 0.5f, y - hgs, uwx, gs);
 
-                pointsCleanup.RemovePoint(point);
+                pointsCleanup.Clean(point);
 
                 if (DataLabelsPaint is not null)
                 {
@@ -351,8 +351,8 @@ public class StepLineSeries<TModel, TVisual, TLabel, TDrawingContext, TPathGeome
             DataLabelsPaint.ZIndex = actualZIndex + 0.5;
         }
 
-        if (pointsCleanup.ToDeleteCnt != 0)
-            ChartPointCleanupContext.RemoveInvalidPoints(everFetched, cartesianChart.View, primaryScale, secondaryScale, SoftDeleteOrDisposePoint);
+        pointsCleanup.CollectPoints(
+            everFetched, cartesianChart.View, primaryScale, secondaryScale, SoftDeleteOrDisposePoint);
 
         IsFirstDraw = false;
     }

--- a/src/LiveChartsCore/StepLineSeries.cs
+++ b/src/LiveChartsCore/StepLineSeries.cs
@@ -129,7 +129,8 @@ public class StepLineSeries<TModel, TVisual, TLabel, TDrawingContext, TPathGeome
         var dls = (float)DataLabelsSize;
 
         var segmentI = 0;
-        var toDeletePoints = new HashSet<ChartPoint>(everFetched);
+        var toDeletePointsCnt = everFetched.Count;
+        InvalidateAllPoints(everFetched);
 
         if (!_strokePathHelperDictionary.TryGetValue(chart.Canvas.Sync, out var strokePathHelperContainer))
         {
@@ -272,7 +273,8 @@ public class StepLineSeries<TModel, TVisual, TLabel, TDrawingContext, TPathGeome
                     point.Context.HoverArea = ha = new RectangleHoverArea();
                 _ = ha.SetDimensions(x - uwx * 0.5f, y - hgs, uwx, gs);
 
-                _ = toDeletePoints.Remove(point);
+                toDeletePointsCnt--;
+                point.RemoveOnCompleted = false;
 
                 if (DataLabelsPaint is not null)
                 {
@@ -351,12 +353,8 @@ public class StepLineSeries<TModel, TVisual, TLabel, TDrawingContext, TPathGeome
             DataLabelsPaint.ZIndex = actualZIndex + 0.5;
         }
 
-        foreach (var point in toDeletePoints)
-        {
-            if (point.Context.Chart != cartesianChart.View) continue;
-            SoftDeleteOrDisposePoint(point, primaryScale, secondaryScale);
-            _ = everFetched.Remove(point);
-        }
+        if (toDeletePointsCnt != 0)
+            RemoveInvalidPoints(everFetched, cartesianChart.View, primaryScale, secondaryScale, SoftDeleteOrDisposePoint);
 
         IsFirstDraw = false;
     }


### PR DESCRIPTION
I have been investigating performance and memory issues on my app recently and mentioned that LiveCharts allocate a lot of single use data on every update. This introduces GC pressure which can be avoided.

I created a test workload to highlight those issues. It has 14x4k LineSeries, 4k FinancialSeries, 150k FinancialSeries and 2 ScatterSeries of 8K points on both. Responsiveness in that setup is really bad. It moves, but has huge lags. Though this story is for another time.

This PR focuses on reducing GC allocation on render loop.

Let's take a look at allocations during render (GC Heap Alloc Ignore Free Stacks). I used PerfView Collect command here, app was already started and data loaded for 10-20 seconds. This highlights what types are being constantly allocated.

![gc-pressure1 0](https://user-images.githubusercontent.com/16784232/204797055-735b3a03-f402-40d2-9801-1f1732f29463.png)

![gc-pressure1 1](https://user-images.githubusercontent.com/16784232/204797056-f3344b57-8595-40c8-be2e-87549de31d61.PNG)

As we can see main allocation sources are:
 - `BezierData`
 - `RectangleHoverArea`
 - `HashSet<ChartPoint>` copy constructor


There is also a tricky case with `float is null`. For some reason JITter doesn't optimize boxing when using launching app using PerfView Run command. This doesn't reproduce on normal start (or at least I can't find evidence). However I need that fix in `MotionProperty<T>` keep recorded performance data clear. JITter should treat `static readonly bool` fields as constants at IL->Asm compilation and simplify comparison.

![gc-pressure1 2](https://user-images.githubusercontent.com/16784232/204797054-4f76721c-4ee0-4a14-8e11-2423f1b1d28b.PNG)
