### PR TITLE
Prevent setting MotionCanvas.Sync to null.

### DIFF
--- a/src/LiveChartsCore/Motion/MotionCanvas.cs
+++ b/src/LiveChartsCore/Motion/MotionCanvas.cs
@@ -40,6 +40,7 @@ public class MotionCanvas<TDrawingContext> : IDisposable
     private readonly List<double> _fpsStack = new();
     private long _previousFrameTime;
     private long _previousLogTime;
+    private object _sync = new();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="MotionCanvas{TDrawingContext}"/> class.
@@ -80,7 +81,7 @@ public class MotionCanvas<TDrawingContext> : IDisposable
     /// <value>
     /// The synchronize.
     /// </value>
-    public object Sync { get; internal set; } = new();
+    public object Sync { get => _sync; internal set => _sync = value ?? new object(); }
 
     /// <summary>
     /// Gets the animatables collection.


### PR DESCRIPTION
While checking #785 I mentioned that you can set `MotionCanvas.Sync` to null in a variety of ways. Originally app crashed because of unhandled exception on thread pool thread which was fixed by PR #776. However [in this comment](https://github.com/beto-rodriguez/LiveCharts2/issues/785#issuecomment-1340009778) I posted another way to crash the app. There is probably a way to achieve same result using all WPF guidelines, instead of setting `DataContext` to `null` explicitly.

Simple solution would be to prevent setting this to `null` since it used a lot internally. 

Stacktrace of crash:
```
Application: TestLvc785.exe
CoreCLR Version: 6.0.1122.52304
.NET Version: 6.0.11
Description: The process was terminated due to an unhandled exception.
Exception Info: System.ArgumentNullException: Value cannot be null.
   at System.Threading.Monitor.ReliableEnter(Object obj, Boolean& lockTaken)
   at LiveChartsCore.Motion.MotionCanvas`1.DrawFrame(TDrawingContext context) in D:\projects\LiveCharts2\src\LiveChartsCore\Motion\MotionCanvas.cs:line 122
   at LiveChartsCore.SkiaSharpView.WPF.MotionCanvas.OnPaintSurface(Object sender, SKPaintSurfaceEventArgs args) in D:\projects\LiveCharts2\src\skiasharp\LiveChartsCore.SkiaSharp.WPF\MotionCanvas.cs:line 120
   at SkiaSharp.Views.WPF.SKElement.OnPaintSurface(SKPaintSurfaceEventArgs e)
   at SkiaSharp.Views.WPF.SKElement.OnRender(DrawingContext drawingContext)
   at System.Windows.UIElement.Arrange(Rect finalRect)
   at System.Windows.ContextLayoutManager.UpdateLayout()
   at System.Windows.ContextLayoutManager.UpdateLayoutCallback(Object arg)
   at System.Windows.Media.MediaContext.FireInvokeOnRenderCallbacks()
   at System.Windows.Media.MediaContext.RenderMessageHandlerCore(Object resizedCompositionTarget)
   at System.Windows.Media.MediaContext.RenderMessageHandler(Object resizedCompositionTarget)
   at System.Windows.Threading.ExceptionWrapper.InternalRealCall(Delegate callback, Object args, Int32 numArgs)
   at System.Windows.Threading.ExceptionWrapper.TryCatchWhen(Object source, Delegate callback, Object args, Int32 numArgs, Delegate catchHandler)
   at System.Windows.Threading.DispatcherOperation.InvokeImpl()
   at System.Windows.Threading.DispatcherOperation.InvokeInSecurityContext(Object state)
   at MS.Internal.CulturePreservingExecutionContext.CallbackWrapper(Object obj)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location ---
   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state)
   at MS.Internal.CulturePreservingExecutionContext.Run(CulturePreservingExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Windows.Threading.DispatcherOperation.Invoke()
   at System.Windows.Threading.Dispatcher.ProcessQueue()
   at System.Windows.Threading.Dispatcher.WndProcHook(IntPtr hwnd, Int32 msg, IntPtr wParam, IntPtr lParam, Boolean& handled)
   at MS.Win32.HwndWrapper.WndProc(IntPtr hwnd, Int32 msg, IntPtr wParam, IntPtr lParam, Boolean& handled)
   at MS.Win32.HwndSubclass.DispatcherCallbackOperation(Object o)
   at System.Windows.Threading.ExceptionWrapper.InternalRealCall(Delegate callback, Object args, Int32 numArgs)
   at System.Windows.Threading.ExceptionWrapper.TryCatchWhen(Object source, Delegate callback, Object args, Int32 numArgs, Delegate catchHandler)
   at System.Windows.Threading.Dispatcher.LegacyInvokeImpl(DispatcherPriority priority, TimeSpan timeout, Delegate method, Object args, Int32 numArgs)
   at MS.Win32.HwndSubclass.SubclassWndProc(IntPtr hwnd, Int32 msg, IntPtr wParam, IntPtr lParam)
   at MS.Win32.UnsafeNativeMethods.DispatchMessage(MSG& msg)
   at System.Windows.Threading.Dispatcher.PushFrameImpl(DispatcherFrame frame)
   at System.Windows.Threading.Dispatcher.PushFrame(DispatcherFrame frame)
   at System.Windows.Threading.Dispatcher.Run()
   at System.Windows.Application.RunDispatcher(Object ignore)
   at System.Windows.Application.RunInternal(Window window)
   at System.Windows.Application.Run()
   at TestLvc785.App.Main()
```