### PR TITLE
Fix some legend rendering issues.

### DIFF
--- a/src/LiveChartsCore/Chart.cs
+++ b/src/LiveChartsCore/Chart.cs
@@ -589,6 +589,9 @@ public abstract class Chart<TDrawingContext> : IChart
                 if (LegendPosition is LegendPosition.Top or LegendPosition.Bottom)
                     ControlSize = new(ControlSize.Width, ControlSize.Height - imageLegend.Size.Height);
 
+                // reset for cases when legend is hidden or changes postion
+                Canvas.StartPoint = new LvcPoint(0, 0);
+
                 Legend.Draw(this);
 
                 PreviousLegendPosition = LegendPosition;

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/SKCharts/SKDefaultLegend.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/SKCharts/SKDefaultLegend.cs
@@ -142,16 +142,19 @@ public class SKDefaultLegend : IChartLegend<SkiaSharpDrawingContext>, IImageCont
         _stackPanel ??= new StackPanel<RoundedRectangleGeometry, SkiaSharpDrawingContext>
         {
             Padding = new Padding(0),
-            Orientation = _orientation,
             HorizontalAlignment = Align.Start,
             VerticalAlignment = Align.Middle,
-            BackgroundPaint = BackgroundPaint
         };
+
+        _stackPanel.Orientation = _orientation;
+        _stackPanel.BackgroundPaint = BackgroundPaint;
 
         _toRemoveSeries = new List<VisualElement<SkiaSharpDrawingContext>>(_stackPanel.Children);
 
         foreach (var series in chart.ChartSeries)
         {
+            if (!series.IsVisibleAtLegend) continue;
+
             var seriesMiniatureVisual = GetSeriesVisual(series);
             _ = _toRemoveSeries.Remove(seriesMiniatureVisual);
         }


### PR DESCRIPTION
Issues fixed:
- When legend is shown(left) and hidden there was a big empty space. (`Canvas.StartPoint` was not reset)
- If legend was hidden initially, then left/right legends had horizontal layout (null-coalescing operator prevented changes to `StackPanel`)
- `Series.IsVisibleAtLegend` was completely ignored. Should probably fix #794.