### PR TITLE
Expose MiniatureShapeSize on ISeries interface

### DIFF
--- a/src/LiveChartsCore/ISeries.cs
+++ b/src/LiveChartsCore/ISeries.cs
@@ -99,6 +99,14 @@ public interface ISeries
     ///   <c>true</c> if this instance is visible at legends; otherwise, <c>false</c>.
     /// </value>
     bool IsVisibleAtLegend { get; set; }
+    
+    /// <summary>
+    /// Gets or sets the size of the legend shape.
+    /// </summary>
+    /// <value>
+    /// The size of the legend shape.
+    /// </value>
+    double MiniatureShapeSize { get; set; }
 
     /// <summary>
     /// Gets or sets the data padding, both coordinates (X and Y) from 0 to 1, where 0 is nothing and 1 is the axis tick


### PR DESCRIPTION
Exposing MiniatureShapeSize on ISeries interface (that's already implemented in the Series class) allows to customize the theme using `HasRuleForAnySeries` or specialized extensions like `HasRuleForLineSeries`,