### PR TITLE
#859 Do not override tooltip in InitializeCore method

### DIFF
--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/CartesianChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/CartesianChart.cs
@@ -85,6 +85,8 @@ public class CartesianChart : Chart, ICartesianChartView<SkiaSharpDrawingContext
         MouseUp += OnMouseUp;
         ManipulationDelta += OnManipulationDelta;
         ManipulationStarting += OnManipulationStarting;
+
+        tooltip = new SKDefaultTooltip();
     }
 
     #region dependency properties
@@ -359,7 +361,6 @@ public class CartesianChart : Chart, ICartesianChartView<SkiaSharpDrawingContext
         core = new CartesianChart<SkiaSharpDrawingContext>(
             this, config => config.UseDefaults(), canvas.CanvasCore, zoomingSection);
         legend = new SKDefaultLegend(); // Template.FindName("legend", this) as IChartLegend<SkiaSharpDrawingContext>;
-        tooltip = new SKDefaultTooltip(); // Template.FindName("tooltip", this) as IChartTooltip<SkiaSharpDrawingContext>;
 
         core.Update();
     }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/PieChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/PieChart.cs
@@ -61,6 +61,8 @@ public class PieChart : Chart, IPieChartView<SkiaSharpDrawingContext>
         SetCurrentValue(SeriesProperty, new ObservableCollection<ISeries>());
         SetCurrentValue(VisualElementsProperty, new ObservableCollection<ChartElement<SkiaSharpDrawingContext>>());
         MouseDown += OnMouseDown;
+
+        tooltip = new SKDefaultTooltip();
     }
 
     /// <summary>
@@ -176,7 +178,6 @@ public class PieChart : Chart, IPieChartView<SkiaSharpDrawingContext>
         if (canvas is null) throw new Exception("canvas not found");
         core = new PieChart<SkiaSharpDrawingContext>(this, config => config.UseDefaults(), canvas.CanvasCore);
         legend = new SKDefaultLegend(); // Template.FindName("legend", this) as IChartLegend<SkiaSharpDrawingContext>;
-        tooltip = new SKDefaultTooltip(); // Template.FindName("tooltip", this) as IChartTooltip<SkiaSharpDrawingContext>;
         core.Update();
     }
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/PolarChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/PolarChart.cs
@@ -77,6 +77,8 @@ public class PolarChart : Chart, IPolarChartView<SkiaSharpDrawingContext>
         MouseWheel += OnMouseWheel;
         MouseDown += OnMouseDown;
         MouseUp += OnMouseUp;
+
+        tooltip = new SKDefaultTooltip();
     }
 
     #region dependency properties
@@ -292,7 +294,6 @@ public class PolarChart : Chart, IPolarChartView<SkiaSharpDrawingContext>
 
         core = new PolarChart<SkiaSharpDrawingContext>(this, config => config.UseDefaults(), canvas.CanvasCore);
         legend = new SKDefaultLegend(); // Template.FindName("legend", this) as IChartLegend<SkiaSharpDrawingContext>;
-        tooltip = new SKDefaultTooltip(); // Template.FindName("tooltip", this) as IChartTooltip<SkiaSharpDrawingContext>;
         core.Update();
     }
 


### PR DESCRIPTION
User wouldn't be able to set custom tooltip. Just provide default value in constructor.