### PR TITLE
Update Samples to CommunityToolkit.Mvvm 8.1.0. Fix Breaking Changes

### DIFF
--- a/samples/ViewModelsSamples/Axes/ColorsAndPosition/ViewModel.cs
+++ b/samples/ViewModelsSamples/Axes/ColorsAndPosition/ViewModel.cs
@@ -11,8 +11,7 @@ using SkiaSharp;
 
 namespace ViewModelsSamples.Axes.ColorsAndPosition;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     private AxisPosition _selectedPosition = AxisPosition.End;
     private int _selectedColor = 0;
@@ -57,7 +56,7 @@ public partial class ViewModel
         }
     };
 
-    [ICommand]
+    [RelayCommand]
     public void SetNewColor()
     {
         var nextColor = _colors[_selectedColor++ % _colors.Length];
@@ -65,7 +64,7 @@ public partial class ViewModel
         XAxes[0].SeparatorsPaint = new SolidColorPaint(new SKColor(nextColor.R, nextColor.G, nextColor.B), 3);
     }
 
-    [ICommand]
+    [RelayCommand]
     public void TogglePosition()
     {
         _selectedPosition = _selectedPosition == AxisPosition.End ? AxisPosition.Start : AxisPosition.End;

--- a/samples/ViewModelsSamples/Axes/Crosshairs/ViewModel.cs
+++ b/samples/ViewModelsSamples/Axes/Crosshairs/ViewModel.cs
@@ -29,8 +29,7 @@ using SkiaSharp;
 
 namespace ViewModelsSamples.Axes.Crosshairs;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public ISeries[] Series { get; set; } =
     {

--- a/samples/ViewModelsSamples/Axes/DateTimeScaled/ViewModel.cs
+++ b/samples/ViewModelsSamples/Axes/DateTimeScaled/ViewModel.cs
@@ -7,8 +7,7 @@ using LiveChartsCore.SkiaSharpView;
 
 namespace ViewModelsSamples.Axes.DateTimeScaled;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public ISeries[] Series { get; set; } =
     {

--- a/samples/ViewModelsSamples/Axes/LabelsFormat/ViewModel.cs
+++ b/samples/ViewModelsSamples/Axes/LabelsFormat/ViewModel.cs
@@ -6,8 +6,7 @@ using SkiaSharp;
 
 namespace ViewModelsSamples.Axes.LabelsFormat;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public ISeries[] Series { get; set; } =
     {

--- a/samples/ViewModelsSamples/Axes/LabelsFormat2/ViewModel.cs
+++ b/samples/ViewModelsSamples/Axes/LabelsFormat2/ViewModel.cs
@@ -6,8 +6,7 @@ using SkiaSharp;
 
 namespace ViewModelsSamples.Axes.LabelsFormat2;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public ISeries[] Series { get; set; } =
     {

--- a/samples/ViewModelsSamples/Axes/LabelsRotation/ViewModel.cs
+++ b/samples/ViewModelsSamples/Axes/LabelsRotation/ViewModel.cs
@@ -8,8 +8,7 @@ using SkiaSharp;
 
 namespace ViewModelsSamples.Axes.LabelsRotation;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     private double _sliderValue = 15;
 

--- a/samples/ViewModelsSamples/Axes/Logarithmic/ViewModel.cs
+++ b/samples/ViewModelsSamples/Axes/Logarithmic/ViewModel.cs
@@ -5,8 +5,7 @@ using LiveChartsCore.SkiaSharpView;
 
 namespace ViewModelsSamples.Axes.Logarithmic;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     // base 10 log, change the base if you require it.
     // or use any custom scale the logic is the same.

--- a/samples/ViewModelsSamples/Axes/Multiple/ViewModel.cs
+++ b/samples/ViewModelsSamples/Axes/Multiple/ViewModel.cs
@@ -7,8 +7,7 @@ using SkiaSharp;
 
 namespace ViewModelsSamples.Axes.Multiple;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     private static readonly SKColor s_blue = new(25, 118, 210);
     private static readonly SKColor s_red = new(229, 57, 53);

--- a/samples/ViewModelsSamples/Axes/NamedLabels/ViewModel.cs
+++ b/samples/ViewModelsSamples/Axes/NamedLabels/ViewModel.cs
@@ -6,8 +6,7 @@ using SkiaSharp;
 
 namespace ViewModelsSamples.Axes.NamedLabels;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public ISeries[] Series { get; set; } =
     {

--- a/samples/ViewModelsSamples/Axes/Paging/ViewModel.cs
+++ b/samples/ViewModelsSamples/Axes/Paging/ViewModel.cs
@@ -7,8 +7,7 @@ using LiveChartsCore.SkiaSharpView;
 
 namespace ViewModelsSamples.Axes.Paging;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     private readonly Random _random = new();
 
@@ -38,7 +37,7 @@ public partial class ViewModel
 
     public Axis[] XAxes { get; }
 
-    [ICommand]
+    [RelayCommand]
     public void GoToPage1()
     {
         var axis = XAxes[0];
@@ -46,7 +45,7 @@ public partial class ViewModel
         axis.MaxLimit = 10.5;
     }
 
-    [ICommand]
+    [RelayCommand]
     public void GoToPage2()
     {
         var axis = XAxes[0];
@@ -54,7 +53,7 @@ public partial class ViewModel
         axis.MaxLimit = 20.5;
     }
 
-    [ICommand]
+    [RelayCommand]
     public void GoToPage3()
     {
         var axis = XAxes[0];
@@ -62,7 +61,7 @@ public partial class ViewModel
         axis.MaxLimit = 30.5;
     }
 
-    [ICommand]
+    [RelayCommand]
     public void SeeAll()
     {
         var axis = XAxes[0];

--- a/samples/ViewModelsSamples/Axes/Shared/ViewModel.cs
+++ b/samples/ViewModelsSamples/Axes/Shared/ViewModel.cs
@@ -6,8 +6,7 @@ using LiveChartsCore.SkiaSharpView;
 
 namespace ViewModelsSamples.Axes.Shared;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public ViewModel()
     {

--- a/samples/ViewModelsSamples/Axes/Style/ViewModel.cs
+++ b/samples/ViewModelsSamples/Axes/Style/ViewModel.cs
@@ -10,8 +10,7 @@ using SkiaSharp;
 
 namespace ViewModelsSamples.Axes.Style;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     private static readonly SKColor s_gray = new(195, 195, 195);
     private static readonly SKColor s_gray1 = new(160, 160, 160);

--- a/samples/ViewModelsSamples/Axes/TimeSpanScaled/ViewModel.cs
+++ b/samples/ViewModelsSamples/Axes/TimeSpanScaled/ViewModel.cs
@@ -7,8 +7,7 @@ using LiveChartsCore.SkiaSharpView;
 
 namespace ViewModelsSamples.Axes.TimeSpanScaled;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public ISeries[] Series { get; set; } =
     {

--- a/samples/ViewModelsSamples/Bars/AutoUpdate/ViewModel.cs
+++ b/samples/ViewModelsSamples/Bars/AutoUpdate/ViewModel.cs
@@ -9,8 +9,7 @@ using LiveChartsCore.SkiaSharpView;
 
 namespace ViewModelsSamples.Bars.AutoUpdate;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     private int _index = 0;
     private readonly Random _random = new();
@@ -55,7 +54,7 @@ public partial class ViewModel
 
     public ObservableCollection<ISeries> Series { get; set; }
 
-    [ICommand]
+    [RelayCommand]
     public void AddItem()
     {
         // for this sample only 50 items are supported.
@@ -65,7 +64,7 @@ public partial class ViewModel
         _observableValues.Add(new ObservablePoint(_index++, randomValue));
     }
 
-    [ICommand]
+    [RelayCommand]
     public void RemoveItem()
     {
         if (_observableValues.Count < 2) return;
@@ -73,7 +72,7 @@ public partial class ViewModel
         _observableValues.RemoveAt(0);
     }
 
-    [ICommand]
+    [RelayCommand]
     public void ReplaceItem()
     {
         var randomValue = _random.Next(1, 10);
@@ -82,7 +81,7 @@ public partial class ViewModel
     }
 
 
-    [ICommand]
+    [RelayCommand]
     public void AddSeries()
     {
         //  for this sample only 5 series are supported.
@@ -100,7 +99,7 @@ public partial class ViewModel
             });
     }
 
-    [ICommand]
+    [RelayCommand]
     public void RemoveSeries()
     {
         if (Series.Count == 1) return;

--- a/samples/ViewModelsSamples/Bars/Basic/ViewModel.cs
+++ b/samples/ViewModelsSamples/Bars/Basic/ViewModel.cs
@@ -6,8 +6,7 @@ using SkiaSharp;
 
 namespace ViewModelsSamples.Bars.Basic;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public ISeries[] Series { get; set; } =
     {

--- a/samples/ViewModelsSamples/Bars/Custom/ViewModel.cs
+++ b/samples/ViewModelsSamples/Bars/Custom/ViewModel.cs
@@ -7,8 +7,7 @@ using SkiaSharp;
 
 namespace ViewModelsSamples.Bars.Custom;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public ISeries[] Series { get; set; } =
     {

--- a/samples/ViewModelsSamples/Bars/DelayedAnimation/ViewModel.cs
+++ b/samples/ViewModelsSamples/Bars/DelayedAnimation/ViewModel.cs
@@ -8,8 +8,7 @@ using LiveChartsCore.SkiaSharpView.Drawing.Geometries;
 
 namespace ViewModelsSamples.Bars.DelayedAnimation;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public ViewModel()
     {

--- a/samples/ViewModelsSamples/Bars/Layered/ViewModel.cs
+++ b/samples/ViewModelsSamples/Bars/Layered/ViewModel.cs
@@ -4,8 +4,7 @@ using LiveChartsCore.SkiaSharpView;
 
 namespace ViewModelsSamples.Bars.Layered;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public ISeries[] Series { get; set; } =
     {

--- a/samples/ViewModelsSamples/Bars/Race/ViewModel.cs
+++ b/samples/ViewModelsSamples/Bars/Race/ViewModel.cs
@@ -12,8 +12,7 @@ using SkiaSharp;
 
 namespace ViewModelsSamples.Bars.Race;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     private readonly Random _r = new();
     private static readonly (string, double)[] s_initialData =

--- a/samples/ViewModelsSamples/Bars/RowsWithLabels/ViewModel.cs
+++ b/samples/ViewModelsSamples/Bars/RowsWithLabels/ViewModel.cs
@@ -8,8 +8,7 @@ using SkiaSharp;
 
 namespace ViewModelsSamples.Bars.RowsWithLabels;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public ISeries[] Series { get; set; } =
     {

--- a/samples/ViewModelsSamples/Bars/Spacing/ViewModel.cs
+++ b/samples/ViewModelsSamples/Bars/Spacing/ViewModel.cs
@@ -7,8 +7,7 @@ using SkiaSharp;
 
 namespace ViewModelsSamples.Bars.Spacing;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public ISeries[] Series { get; set; } =
     {

--- a/samples/ViewModelsSamples/Bars/WithBackground/ViewModel.cs
+++ b/samples/ViewModelsSamples/Bars/WithBackground/ViewModel.cs
@@ -6,8 +6,7 @@ using SkiaSharp;
 
 namespace ViewModelsSamples.Bars.WithBackground;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public ISeries[] Series { get; set; } =
     {

--- a/samples/ViewModelsSamples/Design/LinearGradients/ViewModel.cs
+++ b/samples/ViewModelsSamples/Design/LinearGradients/ViewModel.cs
@@ -6,8 +6,7 @@ using SkiaSharp;
 
 namespace ViewModelsSamples.Design.LinearGradients;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     // linear gradients are based on SkiaSharp linear gradients
     // for more info please see:

--- a/samples/ViewModelsSamples/Design/RadialGradients/ViewModel.cs
+++ b/samples/ViewModelsSamples/Design/RadialGradients/ViewModel.cs
@@ -6,8 +6,7 @@ using SkiaSharp;
 
 namespace ViewModelsSamples.Design.RadialGradients;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     // radial gradients are based on SkiaSharp circular gradients
     // for more info please see:

--- a/samples/ViewModelsSamples/Design/StrokeDashArray/ViewModel.cs
+++ b/samples/ViewModelsSamples/Design/StrokeDashArray/ViewModel.cs
@@ -7,8 +7,7 @@ using SkiaSharp;
 
 namespace ViewModelsSamples.Design.StrokeDashArray;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public ViewModel()
     {

--- a/samples/ViewModelsSamples/Events/AddPointOnClick/ViewModel.cs
+++ b/samples/ViewModelsSamples/Events/AddPointOnClick/ViewModel.cs
@@ -6,8 +6,7 @@ using LiveChartsCore.SkiaSharpView;
 
 namespace ViewModelsSamples.Events.AddPointOnClick;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public ViewModel()
     {

--- a/samples/ViewModelsSamples/Events/Cartesian/ViewModel.cs
+++ b/samples/ViewModelsSamples/Events/Cartesian/ViewModel.cs
@@ -11,8 +11,7 @@ using SkiaSharp;
 
 namespace ViewModelsSamples.Events.Cartesian;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public ViewModel()
     {

--- a/samples/ViewModelsSamples/Events/Pie/ViewModel.cs
+++ b/samples/ViewModelsSamples/Events/Pie/ViewModel.cs
@@ -11,8 +11,7 @@ using LiveChartsCore.SkiaSharpView.Drawing.Geometries;
 
 namespace ViewModelsSamples.Events.Pie;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public ViewModel()
     {
@@ -57,7 +56,7 @@ public partial class ViewModel
         }
     }
 
-    [ICommand]
+    [RelayCommand]
     public void DataPointerDown(IEnumerable<ChartPoint>? points)
     {
         if (points is null) return;

--- a/samples/ViewModelsSamples/Events/Polar/ViewModel.cs
+++ b/samples/ViewModelsSamples/Events/Polar/ViewModel.cs
@@ -8,8 +8,7 @@ using LiveChartsCore.SkiaSharpView;
 
 namespace ViewModelsSamples.Events.Polar;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public ViewModel()
     {
@@ -43,7 +42,7 @@ public partial class ViewModel
 
     public ISeries[] Series { get; set; }
 
-    [ICommand]
+    [RelayCommand]
     public void DataPointerDown(IEnumerable<ChartPoint>? points)
     {
         if (points is null) return;

--- a/samples/ViewModelsSamples/Financial/BasicCandlesticks/ViewModel.cs
+++ b/samples/ViewModelsSamples/Financial/BasicCandlesticks/ViewModel.cs
@@ -8,8 +8,7 @@ using LiveChartsCore.SkiaSharpView;
 
 namespace ViewModelsSamples.Financial.BasicCandlesticks;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     // we have to let the chart know that the X axis in days.
     public Axis[] XAxes { get; set; } =

--- a/samples/ViewModelsSamples/General/Animations/ViewModel.cs
+++ b/samples/ViewModelsSamples/General/Animations/ViewModel.cs
@@ -5,8 +5,7 @@ using LiveChartsCore.SkiaSharpView;
 
 namespace ViewModelsSamples.General.Animations;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     private (string, Func<float, float>) _selectedCurve;
     private (string, TimeSpan) _selectedSpeed;

--- a/samples/ViewModelsSamples/General/ChartToImage/ViewModel.cs
+++ b/samples/ViewModelsSamples/General/ChartToImage/ViewModel.cs
@@ -6,8 +6,7 @@ using LiveChartsCore.SkiaSharpView.Drawing.Geometries;
 
 namespace ViewModelsSamples.General.ChartToImage;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public ISeries[] CatesianSeries { get; set; } =
     {

--- a/samples/ViewModelsSamples/General/ConditionalDraw/City.cs
+++ b/samples/ViewModelsSamples/General/ConditionalDraw/City.cs
@@ -2,8 +2,7 @@
 
 namespace ViewModelsSamples.General.ConditionalDraw;
 
-[ObservableObject]
-public partial class City
+public partial class City : ObservableObject
 {
     public City(double population)
     {

--- a/samples/ViewModelsSamples/General/ConditionalDraw/ViewModel.cs
+++ b/samples/ViewModelsSamples/General/ConditionalDraw/ViewModel.cs
@@ -11,8 +11,7 @@ using SkiaSharp;
 
 namespace ViewModelsSamples.General.ConditionalDraw;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public ViewModel()
     {

--- a/samples/ViewModelsSamples/General/MultiThreading/ViewModel.cs
+++ b/samples/ViewModelsSamples/General/MultiThreading/ViewModel.cs
@@ -11,8 +11,7 @@ using SkiaSharp;
 
 namespace ViewModelsSamples.General.MultiThreading;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     private readonly Random _r = new();
     private readonly int _delay = 100;

--- a/samples/ViewModelsSamples/General/MultiThreading2/ViewModel.cs
+++ b/samples/ViewModelsSamples/General/MultiThreading2/ViewModel.cs
@@ -10,8 +10,7 @@ using SkiaSharp;
 
 namespace ViewModelsSamples.General.MultiThreading2;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     private readonly Random _r = new();
     private readonly int _delay = 100;

--- a/samples/ViewModelsSamples/General/NullPoints/ViewModel.cs
+++ b/samples/ViewModelsSamples/General/NullPoints/ViewModel.cs
@@ -6,8 +6,7 @@ using LiveChartsCore.SkiaSharpView;
 
 namespace ViewModelsSamples.General.NullPoints;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public ISeries[] Series { get; set; } = new ISeries[]
     {

--- a/samples/ViewModelsSamples/General/Sections/ViewModel.cs
+++ b/samples/ViewModelsSamples/General/Sections/ViewModel.cs
@@ -71,7 +71,7 @@ public partial class ViewModel
         }
     };
 
-    [ICommand]
+    [RelayCommand]
     public void ToggleFirst()
     {
         Sections[0].IsVisible = !Sections[0].IsVisible;

--- a/samples/ViewModelsSamples/General/Sections2/ViewModel.cs
+++ b/samples/ViewModelsSamples/General/Sections2/ViewModel.cs
@@ -8,8 +8,7 @@ using SkiaSharp;
 
 namespace ViewModelsSamples.General.Sections2;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public RectangularSection[] Sections { get; set; } =
     {

--- a/samples/ViewModelsSamples/General/TemplatedLegends/ViewModel.cs
+++ b/samples/ViewModelsSamples/General/TemplatedLegends/ViewModel.cs
@@ -5,8 +5,7 @@ using LiveChartsCore.SkiaSharpView;
 
 namespace ViewModelsSamples.General.TemplatedLegends;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public ISeries[] Series { get; set; } =
     {

--- a/samples/ViewModelsSamples/General/TemplatedTooltips/ViewModel.cs
+++ b/samples/ViewModelsSamples/General/TemplatedTooltips/ViewModel.cs
@@ -5,8 +5,7 @@ using LiveChartsCore.SkiaSharpView;
 
 namespace ViewModelsSamples.General.TemplatedTooltips;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public ISeries[] Series { get; set; } =
     {

--- a/samples/ViewModelsSamples/General/UserDefinedTypes/ViewModel.cs
+++ b/samples/ViewModelsSamples/General/UserDefinedTypes/ViewModel.cs
@@ -4,8 +4,7 @@ using LiveChartsCore.SkiaSharpView;
 
 namespace ViewModelsSamples.General.UserDefinedTypes;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public ViewModel()
     {

--- a/samples/ViewModelsSamples/General/Visibility/ViewModel.cs
+++ b/samples/ViewModelsSamples/General/Visibility/ViewModel.cs
@@ -6,8 +6,7 @@ using LiveChartsCore.SkiaSharpView;
 
 namespace ViewModelsSamples.General.Visibility;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public ISeries[] Series { get; set; } =
     {
@@ -28,19 +27,19 @@ public partial class ViewModel
         }
     };
 
-    [ICommand]
+    [RelayCommand]
     public void ToggleSeries0()
     {
         Series[0].IsVisible = !Series[0].IsVisible;
     }
 
-    [ICommand]
+    [RelayCommand]
     public void ToggleSeries1()
     {
         Series[1].IsVisible = !Series[1].IsVisible;
     }
 
-    [ICommand]
+    [RelayCommand]
     public void ToggleSeries2()
     {
         Series[2].IsVisible = !Series[2].IsVisible;

--- a/samples/ViewModelsSamples/General/VisualElements/ViewModel.cs
+++ b/samples/ViewModelsSamples/General/VisualElements/ViewModel.cs
@@ -15,8 +15,7 @@ using SkiaSharp;
 
 namespace ViewModelsSamples.General.VisualElements;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public IEnumerable<ChartElement<SkiaSharpDrawingContext>> VisualElements { get; set; } = new List<ChartElement<SkiaSharpDrawingContext>>
     {

--- a/samples/ViewModelsSamples/Heat/Basic/ViewModel.cs
+++ b/samples/ViewModelsSamples/Heat/Basic/ViewModel.cs
@@ -7,8 +7,7 @@ using SkiaSharp;
 
 namespace ViewModelsSamples.Heat.Basic;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public ISeries[] Series { get; set; } =
     {

--- a/samples/ViewModelsSamples/Lines/Area/ViewModel.cs
+++ b/samples/ViewModelsSamples/Lines/Area/ViewModel.cs
@@ -6,8 +6,7 @@ using SkiaSharp;
 
 namespace ViewModelsSamples.Lines.Area;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public ISeries[] Series { get; set; } =
     {

--- a/samples/ViewModelsSamples/Lines/AutoUpdate/ViewModel.cs
+++ b/samples/ViewModelsSamples/Lines/AutoUpdate/ViewModel.cs
@@ -10,8 +10,7 @@ using LiveChartsCore.SkiaSharpView;
 
 namespace ViewModelsSamples.Lines.AutoUpdate;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     private readonly Random _random = new();
     private readonly ObservableCollection<ObservableValue> _observableValues;
@@ -56,21 +55,21 @@ public partial class ViewModel
 
     public ObservableCollection<ISeries> Series { get; set; }
 
-    [ICommand]
+    [RelayCommand]
     public void AddItem()
     {
         var randomValue = _random.Next(1, 10);
         _observableValues.Add(new(randomValue));
     }
 
-    [ICommand]
+    [RelayCommand]
     public void RemoveItem()
     {
         if (_observableValues.Count == 0) return;
         _observableValues.RemoveAt(0);
     }
 
-    [ICommand]
+    [RelayCommand]
     public void UpdateItem()
     {
         var randomValue = _random.Next(1, 10);
@@ -82,7 +81,7 @@ public partial class ViewModel
         lastInstance.Value = randomValue;
     }
 
-    [ICommand]
+    [RelayCommand]
     public void ReplaceItem()
     {
         var randomValue = _random.Next(1, 10);
@@ -90,7 +89,7 @@ public partial class ViewModel
         _observableValues[randomIndex] = new(randomValue);
     }
 
-    [ICommand]
+    [RelayCommand]
     public void AddSeries()
     {
         //  for this sample only 5 series are supported.
@@ -108,7 +107,7 @@ public partial class ViewModel
             });
     }
 
-    [ICommand]
+    [RelayCommand]
     public void RemoveSeries()
     {
         if (Series.Count == 1) return;

--- a/samples/ViewModelsSamples/Lines/Basic/ViewModel.cs
+++ b/samples/ViewModelsSamples/Lines/Basic/ViewModel.cs
@@ -7,8 +7,7 @@ using SkiaSharp;
 
 namespace ViewModelsSamples.Lines.Basic;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public ISeries[] Series { get; set; } =
     {

--- a/samples/ViewModelsSamples/Lines/Custom/ViewModel.cs
+++ b/samples/ViewModelsSamples/Lines/Custom/ViewModel.cs
@@ -6,8 +6,7 @@ using SkiaSharp;
 
 namespace ViewModelsSamples.Lines.Custom;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public ISeries[] Series { get; set; } =
     {

--- a/samples/ViewModelsSamples/Lines/Padding/ViewModel.cs
+++ b/samples/ViewModelsSamples/Lines/Padding/ViewModel.cs
@@ -8,8 +8,7 @@ using SkiaSharp;
 
 namespace ViewModelsSamples.Lines.Padding;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public ISeries[] Series { get; set; } =
     {

--- a/samples/ViewModelsSamples/Lines/Properties/ViewModel.cs
+++ b/samples/ViewModelsSamples/Lines/Properties/ViewModel.cs
@@ -12,8 +12,7 @@ using SkiaSharp;
 
 namespace ViewModelsSamples.Lines.Properties;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     private readonly LvcColor[] _colors = ColorPalletes.FluentDesign;
     private readonly Random _random = new();
@@ -34,7 +33,7 @@ public partial class ViewModel
     [ObservableProperty]
     private ISeries[] _series;
 
-    [ICommand]
+    [RelayCommand]
     public void ChangeValuesInstance()
     {
         var t = 0;
@@ -48,7 +47,7 @@ public partial class ViewModel
         _lineSeries.Values = values;
     }
 
-    [ICommand]
+    [RelayCommand]
     public void ChangeSeriesInstance()
     {
         _lineSeries = new LineSeries<double>
@@ -60,7 +59,7 @@ public partial class ViewModel
         Series = new ISeries[] { _lineSeries };
     }
 
-    [ICommand]
+    [RelayCommand]
     public void NewStroke()
     {
         var nextColorIndex = _currentColor++ % _colors.Length;
@@ -68,7 +67,7 @@ public partial class ViewModel
         _lineSeries.Stroke = new SolidColorPaint(new SKColor(color.R, color.G, color.B)) { StrokeThickness = 3 };
     }
 
-    [ICommand]
+    [RelayCommand]
     public void NewFill()
     {
         var nextColorIndex = _currentColor++ % _colors.Length;
@@ -77,7 +76,7 @@ public partial class ViewModel
         _lineSeries.Fill = new SolidColorPaint(new SKColor(color.R, color.G, color.B, 90));
     }
 
-    [ICommand]
+    [RelayCommand]
     public void NewGeometryFill()
     {
         var nextColorIndex = _currentColor++ % _colors.Length;
@@ -86,7 +85,7 @@ public partial class ViewModel
         _lineSeries.GeometryFill = new SolidColorPaint(new SKColor(color.R, color.G, color.B));
     }
 
-    [ICommand]
+    [RelayCommand]
     public void NewGeometryStroke()
     {
         var nextColorIndex = _currentColor++ % _colors.Length;
@@ -95,7 +94,7 @@ public partial class ViewModel
         _lineSeries.GeometryStroke = new SolidColorPaint(new SKColor(color.R, color.G, color.B)) { StrokeThickness = 3 };
     }
 
-    [ICommand]
+    [RelayCommand]
     public void IncreaseLineSmoothness()
     {
         if (_lineSeries.LineSmoothness == 1) return;
@@ -103,7 +102,7 @@ public partial class ViewModel
         _lineSeries.LineSmoothness += 0.1;
     }
 
-    [ICommand]
+    [RelayCommand]
     public void DecreaseLineSmoothness()
     {
         if (_lineSeries.LineSmoothness == 0) return;
@@ -111,7 +110,7 @@ public partial class ViewModel
         _lineSeries.LineSmoothness -= 0.1;
     }
 
-    [ICommand]
+    [RelayCommand]
     public void IncreaseGeometrySize()
     {
         if (_lineSeries.GeometrySize == 60) return;
@@ -119,7 +118,7 @@ public partial class ViewModel
         _lineSeries.GeometrySize += 10;
     }
 
-    [ICommand]
+    [RelayCommand]
     public void DecreaseGeometrySize()
     {
         if (_lineSeries.GeometrySize == 0) return;

--- a/samples/ViewModelsSamples/Lines/Straight/ViewModel.cs
+++ b/samples/ViewModelsSamples/Lines/Straight/ViewModel.cs
@@ -4,8 +4,7 @@ using LiveChartsCore.SkiaSharpView;
 
 namespace ViewModelsSamples.Lines.Straight;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public ISeries[] Series { get; set; } =
     {

--- a/samples/ViewModelsSamples/Lines/XY/ViewModel.cs
+++ b/samples/ViewModelsSamples/Lines/XY/ViewModel.cs
@@ -5,8 +5,7 @@ using LiveChartsCore.SkiaSharpView;
 
 namespace ViewModelsSamples.Lines.XY;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public ISeries[] Series { get; set; } =
     {

--- a/samples/ViewModelsSamples/Lines/Zoom/ViewModel.cs
+++ b/samples/ViewModelsSamples/Lines/Zoom/ViewModel.cs
@@ -5,8 +5,7 @@ using LiveChartsCore.SkiaSharpView;
 
 namespace ViewModelsSamples.Lines.Zoom;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public ViewModel()
     {

--- a/samples/ViewModelsSamples/Maps/World/ViewModel.cs
+++ b/samples/ViewModelsSamples/Maps/World/ViewModel.cs
@@ -9,7 +9,6 @@ using LiveChartsCore.SkiaSharpView.Drawing.Geometries;
 
 namespace ViewModelsSamples.Maps.World;
 
-[ObservableObject]
 public  partial class ViewModel
 {
     private bool _isBrazilInChart = true;
@@ -48,7 +47,7 @@ public  partial class ViewModel
 
     public HeatLandSeries[] Series { get; set; }
 
-    [ICommand]
+    [RelayCommand]
     public void ToggleBrazil()
     {
         var lands = Series[0].Lands;

--- a/samples/ViewModelsSamples/Pies/AutoUpdate/ViewModel.cs
+++ b/samples/ViewModelsSamples/Pies/AutoUpdate/ViewModel.cs
@@ -8,8 +8,7 @@ using LiveChartsCore.SkiaSharpView;
 
 namespace ViewModelsSamples.Pies.AutoUpdate;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     private readonly Random _random = new();
 
@@ -31,7 +30,7 @@ public partial class ViewModel
 
     public ObservableCollection<ISeries> Series { get; set; }
 
-    [ICommand]
+    [RelayCommand]
     public void AddSeries()
     {
         //  for this sample only 15 series are supported.
@@ -44,7 +43,7 @@ public partial class ViewModel
             });
     }
 
-    [ICommand]
+    [RelayCommand]
     public void UpdateAll()
     {
         foreach (var series in Series)
@@ -59,7 +58,7 @@ public partial class ViewModel
         }
     }
 
-    [ICommand]
+    [RelayCommand]
     public void RemoveSeries()
     {
         if (Series.Count == 1) return;

--- a/samples/ViewModelsSamples/Pies/Basic/ViewModel.cs
+++ b/samples/ViewModelsSamples/Pies/Basic/ViewModel.cs
@@ -8,8 +8,7 @@ using LiveChartsCore.SkiaSharpView.VisualElements;
 
 namespace ViewModelsSamples.Pies.Basic;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public ViewModel()
     {

--- a/samples/ViewModelsSamples/Pies/Custom/ViewModel.cs
+++ b/samples/ViewModelsSamples/Pies/Custom/ViewModel.cs
@@ -5,8 +5,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace ViewModelsSamples.Pies.Custom;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public ISeries[] Series { get; set; } =
     {

--- a/samples/ViewModelsSamples/Pies/Doughnut/ViewModel.cs
+++ b/samples/ViewModelsSamples/Pies/Doughnut/ViewModel.cs
@@ -5,8 +5,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace ViewModelsSamples.Pies.Doughnut;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public ISeries[] Series { get; set; } = new ISeries[]
     {

--- a/samples/ViewModelsSamples/Pies/Gauge1/ViewModel.cs
+++ b/samples/ViewModelsSamples/Pies/Gauge1/ViewModel.cs
@@ -5,8 +5,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace ViewModelsSamples.Pies.Gauge1;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public IEnumerable<ISeries> Series { get; set; }
         = new GaugeBuilder()

--- a/samples/ViewModelsSamples/Pies/Gauge2/ViewModel.cs
+++ b/samples/ViewModelsSamples/Pies/Gauge2/ViewModel.cs
@@ -8,8 +8,7 @@ using SkiaSharp;
 
 namespace ViewModelsSamples.Pies.Gauge2;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public IEnumerable<ISeries> Series { get; set; }
         = new GaugeBuilder()

--- a/samples/ViewModelsSamples/Pies/Gauge3/ViewModel.cs
+++ b/samples/ViewModelsSamples/Pies/Gauge3/ViewModel.cs
@@ -6,8 +6,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace ViewModelsSamples.Pies.Gauge3;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public IEnumerable<ISeries> Series { get; set; }
         = new GaugeBuilder()

--- a/samples/ViewModelsSamples/Pies/Gauge4/ViewModel.cs
+++ b/samples/ViewModelsSamples/Pies/Gauge4/ViewModel.cs
@@ -6,7 +6,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace ViewModelsSamples.Pies.Gauge4;
 
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public IEnumerable<ISeries> Series { get; set; }
         = new GaugeBuilder()

--- a/samples/ViewModelsSamples/Pies/Gauge5/ViewModel.cs
+++ b/samples/ViewModelsSamples/Pies/Gauge5/ViewModel.cs
@@ -9,8 +9,7 @@ using CommunityToolkit.Mvvm.Input;
 
 namespace ViewModelsSamples.Pies.Gauge5;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     private readonly Random _random = new();
 
@@ -31,7 +30,7 @@ public partial class ViewModel
     public ObservableValue ObservableValue2 { get; set; }
     public IEnumerable<ISeries> Series { get; set; }
 
-    [ICommand]
+    [RelayCommand]
     public void DoRandomChange()
     {
         // modifying the Value property updates and animates the chart automatically

--- a/samples/ViewModelsSamples/Pies/Gauges/ViewModel.cs
+++ b/samples/ViewModelsSamples/Pies/Gauges/ViewModel.cs
@@ -9,8 +9,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace ViewModelsSamples.Pies.Gauges;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public ViewModel()
     {

--- a/samples/ViewModelsSamples/Pies/NightingaleRose/ViewModel.cs
+++ b/samples/ViewModelsSamples/Pies/NightingaleRose/ViewModel.cs
@@ -5,8 +5,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace ViewModelsSamples.Pies.NightingaleRose;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public ISeries[] Series { get; set; } =
     {

--- a/samples/ViewModelsSamples/Pies/Processing/ViewModel.cs
+++ b/samples/ViewModelsSamples/Pies/Processing/ViewModel.cs
@@ -8,8 +8,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace ViewModelsSamples.Pies.Processing;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     private readonly ObservableValue _processing;
     private readonly ObservableValue _completed;
@@ -100,8 +99,8 @@ public partial class ViewModel
                     new() { Value = _failed, Series = Series[1] },
                     new() { Value = _completed, Series = Series[2] }
             };
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(ValueSeries)));
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Value)));
+            OnPropertyChanged(nameof(ValueSeries));
+            OnPropertyChanged(nameof(Value));
             isProcessing = _completed.Value < 1000;
         }
     }

--- a/samples/ViewModelsSamples/Pies/Pushout/ViewModel.cs
+++ b/samples/ViewModelsSamples/Pies/Pushout/ViewModel.cs
@@ -5,8 +5,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace ViewModelsSamples.Pies.Pushout;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public ISeries[] Series { get; set; } =
     {

--- a/samples/ViewModelsSamples/Polar/Basic/ViewModel.cs
+++ b/samples/ViewModelsSamples/Polar/Basic/ViewModel.cs
@@ -9,8 +9,7 @@ using SkiaSharp;
 
 namespace ViewModelsSamples.Polar.Basic;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public ISeries[] Series { get; set; } =
     {

--- a/samples/ViewModelsSamples/Polar/Coordinates/ViewModel.cs
+++ b/samples/ViewModelsSamples/Polar/Coordinates/ViewModel.cs
@@ -5,8 +5,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace ViewModelsSamples.Polar.Coordinates;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public ISeries[] Series { get; set; } =
     {

--- a/samples/ViewModelsSamples/Polar/RadialArea/ViewModel.cs
+++ b/samples/ViewModelsSamples/Polar/RadialArea/ViewModel.cs
@@ -6,8 +6,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace ViewModelsSamples.Polar.RadialArea;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public ISeries[] Series { get; set; } =
     {

--- a/samples/ViewModelsSamples/Scatter/AutoUpdate/ViewModel.cs
+++ b/samples/ViewModelsSamples/Scatter/AutoUpdate/ViewModel.cs
@@ -9,8 +9,7 @@ using LiveChartsCore.SkiaSharpView;
 
 namespace ViewModelsSamples.Scatter.AutoUpdate;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     private int _index = 0;
     private readonly Random _random = new();
@@ -52,7 +51,7 @@ public partial class ViewModel
 
     public ObservableCollection<ISeries> Series { get; set; }
 
-    [ICommand]
+    [RelayCommand]
     public void AddItem()
     {
         // for this sample only 50 items are supported.
@@ -63,7 +62,7 @@ public partial class ViewModel
         _observableValues.Add(new WeightedPoint(_index++, randomValue, randomWeight));
     }
 
-    [ICommand]
+    [RelayCommand]
     public void RemoveItem()
     {
         if (_observableValues.Count < 2) return;
@@ -71,7 +70,7 @@ public partial class ViewModel
         _observableValues.RemoveAt(0);
     }
 
-    [ICommand]
+    [RelayCommand]
     public void ReplaceItem()
     {
         var randomValue = _random.Next(1, 10);
@@ -80,7 +79,7 @@ public partial class ViewModel
         _observableValues[randomIndex] = new WeightedPoint(_observableValues[randomIndex].X, randomValue, randomWeight);
     }
 
-    [ICommand]
+    [RelayCommand]
     public void AddSeries()
     {
         //  for this sample only 5 series are supported.
@@ -93,7 +92,7 @@ public partial class ViewModel
             });
     }
 
-    [ICommand]
+    [RelayCommand]
     public void RemoveSeries()
     {
         if (Series.Count == 1) return;

--- a/samples/ViewModelsSamples/Scatter/Basic/ViewModel.cs
+++ b/samples/ViewModelsSamples/Scatter/Basic/ViewModel.cs
@@ -6,8 +6,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace ViewModelsSamples.Scatter.Basic;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public ISeries[] Series { get; set; } =
     {

--- a/samples/ViewModelsSamples/Scatter/Bubbles/ViewModel.cs
+++ b/samples/ViewModelsSamples/Scatter/Bubbles/ViewModel.cs
@@ -8,8 +8,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace ViewModelsSamples.Scatter.Bubbles;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public ViewModel()
     {

--- a/samples/ViewModelsSamples/Scatter/Custom/ViewModel.cs
+++ b/samples/ViewModelsSamples/Scatter/Custom/ViewModel.cs
@@ -10,8 +10,7 @@ using SkiaSharp;
 
 namespace ViewModelsSamples.Scatter.Custom;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public ViewModel()
     {

--- a/samples/ViewModelsSamples/StackedArea/Basic/ViewModel.cs
+++ b/samples/ViewModelsSamples/StackedArea/Basic/ViewModel.cs
@@ -5,8 +5,7 @@ using LiveChartsCore.SkiaSharpView;
 
 namespace ViewModelsSamples.StackedArea.Basic;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public ISeries[] Series { get; set; } =
     {

--- a/samples/ViewModelsSamples/StackedArea/StepArea/ViewModel.cs
+++ b/samples/ViewModelsSamples/StackedArea/StepArea/ViewModel.cs
@@ -5,8 +5,7 @@ using LiveChartsCore.SkiaSharpView;
 
 namespace ViewModelsSamples.StackedArea.StepArea;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public ISeries[] Series { get; set; } =
     {

--- a/samples/ViewModelsSamples/StackedBars/Basic/ViewModel.cs
+++ b/samples/ViewModelsSamples/StackedBars/Basic/ViewModel.cs
@@ -8,8 +8,7 @@ using SkiaSharp;
 
 namespace ViewModelsSamples.StackedBars.Basic;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public ISeries[] Series { get; set; } =
     {

--- a/samples/ViewModelsSamples/StackedBars/Groups/ViewModel.cs
+++ b/samples/ViewModelsSamples/StackedBars/Groups/ViewModel.cs
@@ -6,8 +6,7 @@ using LiveChartsCore.SkiaSharpView;
 
 namespace ViewModelsSamples.StackedBars.Groups;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public ISeries[] Series { get; set; } =
     {

--- a/samples/ViewModelsSamples/StepLines/Area/ViewModel.cs
+++ b/samples/ViewModelsSamples/StepLines/Area/ViewModel.cs
@@ -6,8 +6,7 @@ using SkiaSharp;
 
 namespace ViewModelsSamples.StepLines.Area;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public ISeries[] Series { get; set; } =
     {

--- a/samples/ViewModelsSamples/StepLines/AutoUpdate/ViewModel.cs
+++ b/samples/ViewModelsSamples/StepLines/AutoUpdate/ViewModel.cs
@@ -9,8 +9,7 @@ using LiveChartsCore.SkiaSharpView;
 
 namespace ViewModelsSamples.StepLines.AutoUpdate;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     private int _index = 0;
     private readonly Random _random = new();
@@ -56,7 +55,7 @@ public partial class ViewModel
 
     public ObservableCollection<ISeries> Series { get; set; }
 
-    [ICommand]
+    [RelayCommand]
     public void AddItem()
     {
         var randomValue = _random.Next(1, 10);
@@ -64,20 +63,20 @@ public partial class ViewModel
             new ObservablePoint { X = _index++, Y = randomValue });
     }
 
-    [ICommand]
+    [RelayCommand]
     public void RemoveItem()
     {
         _observableValues.RemoveAt(0);
     }
 
-    [ICommand]
+    [RelayCommand]
     public void UpdateItem()
     {
         var randomValue = _random.Next(1, 10);
         _observableValues[_observableValues.Count - 1].Y = randomValue;
     }
 
-    [ICommand]
+    [RelayCommand]
     public void ReplaceItem()
     {
         var randomValue = _random.Next(1, 10);
@@ -86,7 +85,7 @@ public partial class ViewModel
             new ObservablePoint { X = _observableValues[randomIndex].X, Y = randomValue };
     }
 
-    [ICommand]
+    [RelayCommand]
     public void AddSeries()
     {
         //  for this sample only 5 series are supported.
@@ -104,7 +103,7 @@ public partial class ViewModel
             });
     }
 
-    [ICommand]
+    [RelayCommand]
     public void RemoveSeries()
     {
         if (Series.Count == 1) return;

--- a/samples/ViewModelsSamples/StepLines/Basic/ViewModel.cs
+++ b/samples/ViewModelsSamples/StepLines/Basic/ViewModel.cs
@@ -5,8 +5,7 @@ using LiveChartsCore.SkiaSharpView;
 
 namespace ViewModelsSamples.StepLines.Basic;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public ISeries[] Series { get; set; } =
     {

--- a/samples/ViewModelsSamples/StepLines/Custom/ViewModel.cs
+++ b/samples/ViewModelsSamples/StepLines/Custom/ViewModel.cs
@@ -7,8 +7,7 @@ using SkiaSharp;
 
 namespace ViewModelsSamples.StepLines.Custom;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public ISeries[] Series { get; set; } =
     {

--- a/samples/ViewModelsSamples/StepLines/Properties/ViewModel.cs
+++ b/samples/ViewModelsSamples/StepLines/Properties/ViewModel.cs
@@ -11,8 +11,7 @@ using SkiaSharp;
 
 namespace ViewModelsSamples.StepLines.Properties;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     private readonly LvcColor[] _colors = ColorPalletes.FluentDesign;
     private readonly Random _random = new();
@@ -32,7 +31,7 @@ public partial class ViewModel
     [ObservableProperty]
     private ISeries[] _series;
 
-    [ICommand]
+    [RelayCommand]
     public void ChangeValuesInstance()
     {
         var t = 0;
@@ -56,7 +55,7 @@ public partial class ViewModel
         Series = new ISeries[] { _lineSeries };
     }
 
-    [ICommand]
+    [RelayCommand]
     public void NewStroke()
     {
         var nextColorIndex = _currentColor++ % _colors.Length;
@@ -64,7 +63,7 @@ public partial class ViewModel
         _lineSeries.Stroke = new SolidColorPaint(new SKColor(color.R, color.G, color.B)) { StrokeThickness = 3 };
     }
 
-    [ICommand]
+    [RelayCommand]
     public void NewFill()
     {
         var nextColorIndex = _currentColor++ % _colors.Length;
@@ -73,7 +72,7 @@ public partial class ViewModel
         _lineSeries.Fill = new SolidColorPaint(new SKColor(color.R, color.G, color.B, 90));
     }
 
-    [ICommand]
+    [RelayCommand]
     public void NewGeometryFill()
     {
         var nextColorIndex = _currentColor++ % _colors.Length;
@@ -82,7 +81,7 @@ public partial class ViewModel
         _lineSeries.GeometryFill = new SolidColorPaint(new SKColor(color.R, color.G, color.B));
     }
 
-    [ICommand]
+    [RelayCommand]
     public void NewGeometryStroke()
     {
         var nextColorIndex = _currentColor++ % _colors.Length;
@@ -91,7 +90,7 @@ public partial class ViewModel
         _lineSeries.GeometryStroke = new SolidColorPaint(new SKColor(color.R, color.G, color.B)) { StrokeThickness = 3 };
     }
 
-    [ICommand]
+    [RelayCommand]
     public void IncreaseGeometrySize()
     {
         if (_lineSeries.GeometrySize == 60) return;
@@ -99,7 +98,7 @@ public partial class ViewModel
         _lineSeries.GeometrySize += 10;
     }
 
-    [ICommand]
+    [RelayCommand]
     public void DecreaseGeometrySize()
     {
         if (_lineSeries.GeometrySize == 0) return;

--- a/samples/ViewModelsSamples/StepLines/Zoom/ViewModel.cs
+++ b/samples/ViewModelsSamples/StepLines/Zoom/ViewModel.cs
@@ -6,8 +6,7 @@ using LiveChartsCore.SkiaSharpView;
 
 namespace ViewModelsSamples.StepLines.Zoom;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public ViewModel()
     {

--- a/samples/ViewModelsSamples/Test/ChangeSeriesInstance/ViewModel.cs
+++ b/samples/ViewModelsSamples/Test/ChangeSeriesInstance/ViewModel.cs
@@ -10,8 +10,7 @@ using LiveChartsCore.SkiaSharpView.Drawing.Geometries;
 
 namespace ViewModelsSamples.Test.ChangeSeriesInstance;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     private readonly Random _r = new();
 
@@ -32,7 +31,7 @@ public partial class ViewModel
     [ObservableProperty]
     private IGeoSeries[]? _geoSeries;
 
-    [ICommand]
+    [RelayCommand]
     public void GenerateData()
     {
         var data = new double[] { _r.Next(0, 10), _r.Next(0, 10), _r.Next(0, 10) };

--- a/samples/ViewModelsSamples/Test/Dispose/ViewModel.cs
+++ b/samples/ViewModelsSamples/Test/Dispose/ViewModel.cs
@@ -9,8 +9,7 @@ using LiveChartsCore.SkiaSharpView.Drawing.Geometries;
 
 namespace ViewModelsSamples.Test.Dispose;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     private readonly Random _r = new();
 

--- a/samples/ViewModelsSamples/Test/MotionCanvasDispose/ViewModel.cs
+++ b/samples/ViewModelsSamples/Test/MotionCanvasDispose/ViewModel.cs
@@ -10,8 +10,7 @@ using SkiaSharp;
 
 namespace ViewModelsSamples.Test.MotionCanvasDispose;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public static void Generate(MotionCanvas<SkiaSharpDrawingContext> canvas)
     {

--- a/samples/ViewModelsSamples/ViewModelsSamples.csproj
+++ b/samples/ViewModelsSamples/ViewModelsSamples.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.0.0-preview3" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ViewModelsSamples/VisualTest/DataTemplate/ViewModel.cs
+++ b/samples/ViewModelsSamples/VisualTest/DataTemplate/ViewModel.cs
@@ -7,8 +7,7 @@ using LiveChartsCore.SkiaSharpView;
 namespace ViewModelsSamples.VisualTest.DataTemplate;
 
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public IEnumerable<IEnumerable<ISeries>> Models { get; set; } = new List<IEnumerable<ISeries>>
     {

--- a/samples/ViewModelsSamples/VisualTest/ReattachVisual/ViewModel.cs
+++ b/samples/ViewModelsSamples/VisualTest/ReattachVisual/ViewModel.cs
@@ -8,8 +8,7 @@ using SkiaSharp;
 
 namespace ViewModelsSamples.VisualTest.ReattachVisual;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public IEnumerable<ISeries> Series { get; set; } = new ObservableCollection<ISeries>
     {

--- a/samples/ViewModelsSamples/VisualTest/Tabs/ViewModel.cs
+++ b/samples/ViewModelsSamples/VisualTest/Tabs/ViewModel.cs
@@ -6,8 +6,7 @@ using LiveChartsCore.SkiaSharpView;
 
 namespace ViewModelsSamples.VisualTest.Tabs;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public IEnumerable<ISeries> LineSeries { get; set; } = new ObservableCollection<ISeries>
     {

--- a/samples/ViewModelsSamples/VisualTest/TwoChartsOneSeries/ViewModel.cs
+++ b/samples/ViewModelsSamples/VisualTest/TwoChartsOneSeries/ViewModel.cs
@@ -6,8 +6,7 @@ using LiveChartsCore.SkiaSharpView;
 
 namespace ViewModelsSamples.VisualTest.TwoChartsOneSeries;
 
-[ObservableObject]
-public partial class ViewModel
+public partial class ViewModel : ObservableObject
 {
     public ViewModel()
     {


### PR DESCRIPTION
This upgrades CommunityToolkit.Mvvm from 8.0.0-preview3 to 8.1.0.
There were some breaking changes:
[ICommand] -> [RelayCommand]
ViewModels now inherit from ObservableObject

I was kinda confused for a moment when I wanted to try the samples on lvcharts.com so I figured it would be a good idea to upgrade.