### PR TITLE
Drop duplicated phrase

### DIFF
--- a/samples/BlazorSample/Pages/Hello.razor
+++ b/samples/BlazorSample/Pages/Hello.razor
@@ -60,8 +60,7 @@
                 <p class="text-center text-muted">
                     LiveCharts provides controls for any UI framework (console and server-side is also supported). <br />
                     <small class="text-center text-muted">
-                        The minimum requirement for .Net framework is .Net 4.6.2 and is compatible with is compatible
-                        with .NET standard 2.0.
+                        The minimum requirement for .Net framework is .Net 4.6.2 and is compatible with .NET standard 2.0.
                     </small>
                 </p>
 


### PR DESCRIPTION
It seems like 'is compatible with' phase somehow got duplicated.