### PR TITLE
Use ICollection interface instead

### DIFF
--- a/src/LiveChartsCore/ISeries.cs
+++ b/src/LiveChartsCore/ISeries.cs
@@ -62,7 +62,7 @@ public interface ISeries
     /// <value>
     /// The values.
     /// </value>
-    IEnumerable? Values { get; set; }
+    ICollection? Values { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether this instance is visible.
@@ -224,12 +224,4 @@ public interface ISeries<TModel> : ISeries
     /// The mapping.
     /// </value>
     Func<TModel, int, Coordinate>? Mapping { get; set; }
-
-    /// <summary>
-    /// Gets or sets the values.
-    /// </summary>
-    /// <value>
-    /// The values.
-    /// </value>
-    new IEnumerable<TModel>? Values { get; set; }
 }

--- a/src/LiveChartsCore/Kernel/CollectionDeepObserver.cs
+++ b/src/LiveChartsCore/Kernel/CollectionDeepObserver.cs
@@ -71,7 +71,7 @@ public class CollectionDeepObserver<T>
     /// </summary>
     /// <param name="instance">The instance.</param>
     /// <returns></returns>
-    public void Initialize(IEnumerable<T>? instance)
+    public void Initialize(IEnumerable? instance)
     {
         if (instance is null) return;
 
@@ -90,7 +90,7 @@ public class CollectionDeepObserver<T>
     /// </summary>
     /// <param name="instance">The instance.</param>
     /// <returns></returns>
-    public void Dispose(IEnumerable<T>? instance)
+    public void Dispose(IEnumerable? instance)
     {
         if (instance is null) return;
 

--- a/src/LiveChartsCore/Kernel/Providers/DataFactory.cs
+++ b/src/LiveChartsCore/Kernel/Providers/DataFactory.cs
@@ -385,7 +385,7 @@ public class DataFactory<TModel, TDrawingContext>
         }
         var IndexEntityMap = d;
 
-        foreach (var item in series.Values)
+        foreach (var item in series.Values.Cast<TModel>())
         {
             if (item is null)
             {

--- a/src/LiveChartsCore/Series.cs
+++ b/src/LiveChartsCore/Series.cs
@@ -94,7 +94,7 @@ public abstract class Series<TModel, TVisual, TLabel, TDrawingContext>
     protected bool _geometrySvgChanged = false;
 
     private readonly CollectionDeepObserver<TModel> _observer;
-    private IEnumerable<TModel>? _values;
+    private ICollection? _values;
     private string? _name;
     private Func<TModel, int, Coordinate>? _mapping;
     private int _zIndex;
@@ -140,7 +140,7 @@ public abstract class Series<TModel, TVisual, TLabel, TDrawingContext>
     /// <summary>
     /// Gets or sets the data set to draw in the chart.
     /// </summary>
-    public IEnumerable<TModel>? Values
+    public ICollection? Values
     {
         get => _values;
         set
@@ -151,8 +151,6 @@ public abstract class Series<TModel, TVisual, TLabel, TDrawingContext>
             OnPropertyChanged();
         }
     }
-
-    IEnumerable? ISeries.Values { get => Values; set => Values = (IEnumerable<TModel>?)value; }
 
     /// <inheritdoc cref="ISeries.Pivot"/>
     public double Pivot { get => pivot; set => SetProperty(ref pivot, (float)value); }


### PR DESCRIPTION
Currently `Series.Values` is of type `IEnumerable` while this is a flexible type, it also causes some confusion, users are using LINQ expressions as the data source, Linq expressions are evaluated every time the library needs read the data in the chart, this is not optimal for performance and could also lead to some visual glitches.

This is a recurrent issue with new users, some related issues are:

- #1384
- #1323

This PR changes the `Series.Values` type to `ICollection`, this prevents users from using LINQ expressions as the data source and we can still use `List<T>`, `ObservableCollection<T>`, arrays, `Queue<T>`,`Stack<T>`, `HashSet<T>` and a lot of useful structures in dotnet.