### PR TITLE
Fixing stuck _isInternalSet flag

### DIFF
--- a/src/LiveChartsCore/CartesianChart.cs
+++ b/src/LiveChartsCore/CartesianChart.cs
@@ -476,7 +476,11 @@ public class CartesianChart<TDrawingContext> : Chart<TDrawingContext>
             var yAxis = YAxes[series.ScalesYAt];
 
             var seriesBounds = series.GetBounds(this, xAxis, yAxis).Bounds;
-            if (seriesBounds.IsEmpty) continue;
+            if (seriesBounds.IsEmpty)
+            {
+                ce._isInternalSet = false;
+                continue;
+            }
 
             AppendLimits(xAxis, yAxis, seriesBounds);
 

--- a/src/LiveChartsCore/PolarChart.cs
+++ b/src/LiveChartsCore/PolarChart.cs
@@ -237,12 +237,17 @@ public class PolarChart<TDrawingContext> : Chart<TDrawingContext>
 
             var seriesBounds = series.GetBounds(this, secondaryAxis, primaryAxis).Bounds;
 
-            if (seriesBounds.IsEmpty) continue;
+            if (seriesBounds.IsEmpty)
+            {
+                ce._isThemeSet = false;
+                continue;
+            }
 
             secondaryAxis.DataBounds.AppendValue(seriesBounds.SecondaryBounds);
             primaryAxis.DataBounds.AppendValue(seriesBounds.PrimaryBounds);
             secondaryAxis.VisibleDataBounds.AppendValue(seriesBounds.SecondaryBounds);
             primaryAxis.VisibleDataBounds.AppendValue(seriesBounds.PrimaryBounds);
+            ce._isThemeSet = false;
         }
 
         #region empty bounds


### PR DESCRIPTION
Fixes three cases where logic can flag that internal changes are being made to ChartElement objects and escape the scope without reverting the _isInternalSet flag.  I was actually encountering this on a project where I set the stroke color of a LineSeries based on a condition in the code.  Due to the timing involved, there was a race condition where I was updating the stroke color after the CartesianChart escaped due to the empty bounds with the flag still set, preventing my change from ever being applied.