### PR TITLE
Fix Issue with _stepCount Not Resetting, Causing Infinite Separator Exceptions

### DIFF
--- a/src/LiveChartsCore/CoreAxis.cs
+++ b/src/LiveChartsCore/CoreAxis.cs
@@ -1,4 +1,4 @@
-﻿// The MIT License(MIT)
+// The MIT License(MIT)
 //
 // Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
 //
@@ -307,8 +307,6 @@ public abstract class CoreAxis<TDrawingContext, TTextGeometry, TLineGeometry>
     /// <inheritdoc cref="ChartElement{TDrawingContext}.Invalidate(Chart{TDrawingContext})"/>
     public override void Invalidate(Chart<TDrawingContext> chart)
     {
-        _stepCount = 0;
-
         var cartesianChart = (CartesianChart<TDrawingContext>)chart;
 
         var controlSize = cartesianChart.ControlSize;
@@ -496,6 +494,7 @@ public abstract class CoreAxis<TDrawingContext, TTextGeometry, TLineGeometry>
 
         var start = Math.Truncate(min / s) * s;
 
+        _stepCount = 0;
         foreach (var i in EnumerateSeparators(start, max, s))
         {
             var separatorKey = Labelers.SixRepresentativeDigits(i - 1d + 1d);
@@ -879,6 +878,7 @@ public abstract class CoreAxis<TDrawingContext, TTextGeometry, TLineGeometry>
         var h = 0f;
         var r = (float)LabelsRotation;
 
+        _stepCount = 0;
         foreach (var i in EnumerateSeparators(start, max, s))
         {
             var textGeometry = new TTextGeometry
@@ -1031,6 +1031,7 @@ public abstract class CoreAxis<TDrawingContext, TTextGeometry, TLineGeometry>
 
         if (max - min == 0) return maxLabelSize;
 
+        _stepCount = 0;
         foreach (var i in EnumerateSeparators(min, max, s))
         {
             var textGeometry = new TTextGeometry


### PR DESCRIPTION
### Description:

#### Problem
In the WinUI application, there was an issue where the `_stepCount` variable was not being reset, despite the UI not visibly exceeding 10,000 steps. Over time, `_stepCount` accumulated due to continuous use, which eventually triggered `ThrowInfiniteSeparators()` method calls.

#### Solution
To address this issue, I implemented a change where `_stepCount` is reset to 0 before each logic check that involves this variable.

#### Verification
Post-implementation, the change was tested by monitoring the application for extended periods. The fix proved effective, as the [application](https://github.com/airtaxi/PinStats) no longer threw exceptions after approximately 10 minutes of uptime while showing graphs, a common occurrence prior to this update.

#### Related Issue
This fix also appears to resolve a similar issue reported in [Issue #1076](https://github.com/beto-rodriguez/LiveCharts2/issues/1076#issuecomment-1967245178), further indicating the effectiveness of this solution.