### PR TITLE
PieChart (and PolarChart) custom legend support (#1489)

### DIFF
--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/PieChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/PieChart.cs
@@ -64,6 +64,7 @@ public class PieChart : Chart, IPieChartView<SkiaSharpDrawingContext>
         MouseDown += OnMouseDown;
 
         tooltip = new SKDefaultTooltip();
+        legend = new SKDefaultLegend();
     }
 
     /// <summary>
@@ -200,7 +201,6 @@ public class PieChart : Chart, IPieChartView<SkiaSharpDrawingContext>
     {
         if (canvas is null) throw new Exception("canvas not found");
         core = new PieChart<SkiaSharpDrawingContext>(this, config => config.UseDefaults(), canvas.CanvasCore);
-        legend = new SKDefaultLegend(); // Template.FindName("legend", this) as IChartLegend<SkiaSharpDrawingContext>;
         core.Update();
     }
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/PolarChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/PolarChart.cs
@@ -80,6 +80,7 @@ public class PolarChart : Chart, IPolarChartView<SkiaSharpDrawingContext>
         MouseUp += OnMouseUp;
 
         tooltip = new SKDefaultTooltip();
+        legend = new SKDefaultLegend();
     }
 
     #region dependency properties
@@ -294,7 +295,6 @@ public class PolarChart : Chart, IPolarChartView<SkiaSharpDrawingContext>
         if (canvas is null) throw new Exception("canvas not found");
 
         core = new PolarChart<SkiaSharpDrawingContext>(this, config => config.UseDefaults(), canvas.CanvasCore);
-        legend = new SKDefaultLegend(); // Template.FindName("legend", this) as IChartLegend<SkiaSharpDrawingContext>;
         core.Update();
     }
 


### PR DESCRIPTION
Fixes #1489 

The default `legend` assignment in `InitializeCore` was overwriting the user-provided legend.  Moving this to the constructor, similar to how the `tooltip` is managed, yields the desired results.

Example using the [Custom Legend](https://livecharts.dev/docs/WPF/2.0.0-rc2/CartesianChart.Legends#customlegend.cs) example in the `WPFSample` project:

**Before:**
![image](https://github.com/user-attachments/assets/8744d9f3-394b-4b8d-8d9b-6b5e517253cd)

![image](https://github.com/user-attachments/assets/5ad9d985-0b55-486c-8dd2-ccb202aee140)

**After:**
![image](https://github.com/user-attachments/assets/7fed41cd-2173-43e0-b0e4-d8b571eb2130)

![image](https://github.com/user-attachments/assets/019030f6-acc1-407b-849a-8fa09fe2133a)
