### PR TITLE
makes Series.Values property model-typed

### DIFF
--- a/src/LiveChartsCore/BarSeries.cs
+++ b/src/LiveChartsCore/BarSeries.cs
@@ -46,7 +46,7 @@ namespace LiveChartsCore;
 /// <param name="values">The values.</param>
 public abstract class BarSeries<TModel, TVisual, TLabel, TDrawingContext>(
     SeriesProperties properties,
-    ICollection? values)
+    ICollection<TModel>? values)
         : StrokeAndFillCartesianSeries<TModel, TVisual, TLabel, TDrawingContext>(properties, values), IBarSeries<TDrawingContext>
             where TVisual : class, ISizedGeometry<TDrawingContext>, new()
             where TDrawingContext : DrawingContext

--- a/src/LiveChartsCore/CartesianSeries.cs
+++ b/src/LiveChartsCore/CartesianSeries.cs
@@ -47,7 +47,7 @@ namespace LiveChartsCore;
 /// <param name="values">The values.</param>
 public abstract class CartesianSeries<TModel, TVisual, TLabel, TDrawingContext>(
     SeriesProperties properties,
-    ICollection? values)
+    ICollection<TModel>? values)
         : ChartSeries<TModel, TVisual, TLabel, TDrawingContext>(properties, values), ICartesianSeries<TDrawingContext>
             where TDrawingContext : DrawingContext
             where TVisual : class, IGeometry<TDrawingContext>, new()

--- a/src/LiveChartsCore/ChartSeries.cs
+++ b/src/LiveChartsCore/ChartSeries.cs
@@ -20,7 +20,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Collections;
 using System.Collections.Generic;
 using LiveChartsCore.Drawing;
 using LiveChartsCore.Kernel;
@@ -44,7 +43,7 @@ namespace LiveChartsCore;
 /// <param name="values">The values.</param>
 public abstract class ChartSeries<TModel, TVisual, TLabel, TDrawingContext>(
     SeriesProperties properties,
-    ICollection? values)
+    ICollection<TModel>? values)
         : Series<TModel, TVisual, TLabel, TDrawingContext>(properties, values), IChartSeries<TDrawingContext>
             where TDrawingContext : DrawingContext
             where TVisual : class, IGeometry<TDrawingContext>, new()

--- a/src/LiveChartsCore/CoreBoxSeries.cs
+++ b/src/LiveChartsCore/CoreBoxSeries.cs
@@ -55,7 +55,7 @@ public abstract class CoreBoxSeries<TModel, TVisual, TLabel, TMiniatureGeometry,
     /// <summary>
     /// Initializes a new instance of the <see cref="CoreBoxSeries{TModel, TVisual, TLabel, TMiniatureGeometry, TDrawingContext}"/> class.
     /// </summary>
-    protected CoreBoxSeries(ICollection? values)
+    protected CoreBoxSeries(ICollection<TModel>? values)
         : base(GetProperties(), values)
     {
         YToolTipLabelFormatter = p =>

--- a/src/LiveChartsCore/CoreColumnSeries.cs
+++ b/src/LiveChartsCore/CoreColumnSeries.cs
@@ -21,7 +21,7 @@
 // SOFTWARE.
 
 using System;
-using System.Collections;
+using System.Collections.Generic;
 using LiveChartsCore.Drawing;
 using LiveChartsCore.Kernel;
 using LiveChartsCore.Kernel.Drawing;
@@ -38,18 +38,19 @@ namespace LiveChartsCore;
 /// <typeparam name="TLabel">the type of the label.</typeparam>
 /// <typeparam name="TDrawingContext">The type of the drawing context.</typeparam>
 /// <typeparam name="TErrorGeometry">The type of the error geometry.</typeparam>
-public abstract class CoreColumnSeries<TModel, TVisual, TLabel, TDrawingContext, TErrorGeometry> : BarSeries<TModel, TVisual, TLabel, TDrawingContext>
-    where TVisual : class, ISizedGeometry<TDrawingContext>, new()
-    where TDrawingContext : DrawingContext
-    where TLabel : class, ILabelGeometry<TDrawingContext>, new()
-    where TErrorGeometry : class, ILineGeometry<TDrawingContext>, new()
+public abstract class CoreColumnSeries<TModel, TVisual, TLabel, TDrawingContext, TErrorGeometry>
+    : BarSeries<TModel, TVisual, TLabel, TDrawingContext>
+        where TVisual : class, ISizedGeometry<TDrawingContext>, new()
+        where TDrawingContext : DrawingContext
+        where TLabel : class, ILabelGeometry<TDrawingContext>, new()
+        where TErrorGeometry : class, ILineGeometry<TDrawingContext>, new()
 {
     private readonly bool _isRounded = false;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CoreColumnSeries{TModel, TVisual, TLabel, TDrawingContext, TErrorGeometry}"/> class.
     /// </summary>
-    protected CoreColumnSeries(ICollection? values, bool isStacked = false)
+    protected CoreColumnSeries(ICollection<TModel>? values, bool isStacked = false)
         : base(GetProperties(isStacked), values)
     {
         DataPadding = new LvcPoint(0, 1);

--- a/src/LiveChartsCore/CoreFinancialSeries.cs
+++ b/src/LiveChartsCore/CoreFinancialSeries.cs
@@ -59,7 +59,7 @@ public abstract class CoreFinancialSeries<TModel, TVisual, TLabel, TMiniatureGeo
     /// <summary>
     /// Initializes a new instance of the <see cref="CoreFinancialSeries{TModel, TVisual, TLabel, TMiniatureGeometry, TDrawingContext}"/> class.
     /// </summary>
-    protected CoreFinancialSeries(ICollection? values)
+    protected CoreFinancialSeries(ICollection<TModel>? values)
         : base(GetProperties(), values)
     {
         YToolTipLabelFormatter = p =>

--- a/src/LiveChartsCore/CoreHeatSeries.cs
+++ b/src/LiveChartsCore/CoreHeatSeries.cs
@@ -60,7 +60,7 @@ public abstract class CoreHeatSeries<TModel, TVisual, TLabel, TDrawingContext>
     /// Initializes a new instance of the <see cref="CoreHeatSeries{TModel, TVisual, TLabel, TDrawingContext}"/> class.
     /// </summary>
     /// <param name="values">The values.</param>
-    protected CoreHeatSeries(ICollection? values)
+    protected CoreHeatSeries(ICollection<TModel>? values)
         : base(GetProperties(), values)
     {
         DataPadding = new LvcPoint(0, 0);

--- a/src/LiveChartsCore/CoreLineSeries.cs
+++ b/src/LiveChartsCore/CoreLineSeries.cs
@@ -21,7 +21,6 @@
 // SOFTWARE.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using LiveChartsCore.Drawing;
@@ -66,7 +65,7 @@ public class CoreLineSeries<TModel, TVisual, TLabel, TDrawingContext, TPathGeome
     /// </summary>
     /// <param name="isStacked">if set to <c>true</c> [is stacked].</param>
     /// <param name="values">The values.</param>
-    public CoreLineSeries(ICollection? values, bool isStacked = false)
+    public CoreLineSeries(ICollection<TModel>? values, bool isStacked = false)
         : base(GetProperties(isStacked), values)
     {
         DataPadding = new LvcPoint(0.5f, 1f);

--- a/src/LiveChartsCore/CorePieSeries.cs
+++ b/src/LiveChartsCore/CorePieSeries.cs
@@ -20,10 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-// Ignore Spelling: Gauge Pushout
-
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using LiveChartsCore.Drawing;
@@ -46,10 +43,10 @@ namespace LiveChartsCore;
 /// Initializes a new instance of the <see cref="CorePieSeries{TModel, TVisual, TLabel, TMiniatureGeometry, TDrawingContext}"/> class.
 /// </remarks>
 public abstract class CorePieSeries<TModel, TVisual, TLabel, TMiniatureGeometry, TDrawingContext>(
-    ICollection? values,
+    ICollection<TModel>? values,
     bool isGauge = false,
     bool isGaugeFill = false)
-    : ChartSeries<TModel, TVisual, TLabel, TDrawingContext>(GetProperties(isGauge, isGaugeFill), values), IPieSeries<TDrawingContext>
+        : ChartSeries<TModel, TVisual, TLabel, TDrawingContext>(GetProperties(isGauge, isGaugeFill), values), IPieSeries<TDrawingContext>
             where TDrawingContext : DrawingContext
             where TVisual : class, IDoughnutGeometry<TDrawingContext>, new()
             where TLabel : class, ILabelGeometry<TDrawingContext>, new()

--- a/src/LiveChartsCore/CorePolarLineSeries.cs
+++ b/src/LiveChartsCore/CorePolarLineSeries.cs
@@ -21,7 +21,6 @@
 // SOFTWARE.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using LiveChartsCore.Drawing;
@@ -69,7 +68,7 @@ public class CorePolarLineSeries<TModel, TVisual, TLabel, TDrawingContext, TPath
     /// </summary>
     /// <param name="isStacked">if set to <c>true</c> [is stacked].</param>
     /// <param name="values">The values.</param>
-    public CorePolarLineSeries(ICollection? values, bool isStacked = false)
+    public CorePolarLineSeries(ICollection<TModel>? values, bool isStacked = false)
         : base(GetProperties(isStacked), values)
     {
         DataPadding = new LvcPoint(1f, 1.5f);

--- a/src/LiveChartsCore/CoreRowSeries.cs
+++ b/src/LiveChartsCore/CoreRowSeries.cs
@@ -21,7 +21,7 @@
 // SOFTWARE.
 
 using System;
-using System.Collections;
+using System.Collections.Generic;
 using LiveChartsCore.Drawing;
 using LiveChartsCore.Kernel;
 using LiveChartsCore.Kernel.Drawing;
@@ -39,11 +39,12 @@ namespace LiveChartsCore;
 /// <typeparam name="TDrawingContext">The type of the drawing context.</typeparam>
 /// <seealso cref="BarSeries{TModel, TVisual, TLabel, TDrawingContext}" />
 /// <typeparam name="TErrorGeometry">The type of the error geometry.</typeparam>
-public class CoreRowSeries<TModel, TVisual, TLabel, TDrawingContext, TErrorGeometry> : BarSeries<TModel, TVisual, TLabel, TDrawingContext>
-    where TVisual : class, ISizedGeometry<TDrawingContext>, new()
-    where TLabel : class, ILabelGeometry<TDrawingContext>, new()
-    where TErrorGeometry : class, ILineGeometry<TDrawingContext>, new()
-    where TDrawingContext : DrawingContext
+public class CoreRowSeries<TModel, TVisual, TLabel, TDrawingContext, TErrorGeometry>
+    : BarSeries<TModel, TVisual, TLabel, TDrawingContext>
+        where TVisual : class, ISizedGeometry<TDrawingContext>, new()
+        where TLabel : class, ILabelGeometry<TDrawingContext>, new()
+        where TErrorGeometry : class, ILineGeometry<TDrawingContext>, new()
+        where TDrawingContext : DrawingContext
 {
     private readonly bool _isRounded = false;
 
@@ -52,7 +53,7 @@ public class CoreRowSeries<TModel, TVisual, TLabel, TDrawingContext, TErrorGeome
     /// </summary>
     /// <param name="isStacked">if set to <c>true</c> [is stacked].</param>
     /// <param name="values">The values.</param>
-    public CoreRowSeries(ICollection? values, bool isStacked = false)
+    public CoreRowSeries(ICollection<TModel>? values, bool isStacked = false)
         : base(GetProperties(isStacked), values)
     {
         DataPadding = new LvcPoint(1, 0);

--- a/src/LiveChartsCore/CoreScatterSeries.cs
+++ b/src/LiveChartsCore/CoreScatterSeries.cs
@@ -55,7 +55,7 @@ public class CoreScatterSeries<TModel, TVisual, TLabel, TDrawingContext, TErrorG
     /// Initializes a new instance of the <see cref="CoreScatterSeries{TModel, TVisual, TLabel, TDrawingContext, TErrorGeometry}"/> class.
     /// </summary>
     /// <param name="values">The values.</param>
-    public CoreScatterSeries(ICollection? values)
+    public CoreScatterSeries(ICollection<TModel>? values)
         : base(GetProperties(), values)
     {
         DataPadding = new LvcPoint(1, 1);

--- a/src/LiveChartsCore/CoreStackedAreaSeries.cs
+++ b/src/LiveChartsCore/CoreStackedAreaSeries.cs
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Collections;
+using System.Collections.Generic;
 using LiveChartsCore.Drawing;
 using LiveChartsCore.Drawing.Segments;
 
@@ -48,7 +48,7 @@ public class CoreStackedAreaSeries<TModel, TVisual, TLabel, TDrawingContext, TPa
     /// Initializes a new instance of the <see cref="CoreStackedAreaSeries{TModel, TVisual, TLabel, TDrawingContext, TPathGeometry, TBezierVisual}"/> class.
     /// </summary>
     /// <param name="values">The values.</param>
-    public CoreStackedAreaSeries(ICollection? values)
+    public CoreStackedAreaSeries(ICollection<TModel>? values)
         : base(values, true)
     {
         GeometryFill = null;

--- a/src/LiveChartsCore/CoreStackedColumnSeries.cs
+++ b/src/LiveChartsCore/CoreStackedColumnSeries.cs
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Collections;
+using System.Collections.Generic;
 using LiveChartsCore.Drawing;
 using LiveChartsCore.Kernel.Sketches;
 
@@ -39,7 +39,7 @@ namespace LiveChartsCore;
 /// Initializes a new instance of the <see cref="CoreStackedColumnSeries{TModel, TVisual, TLabel, TDrawingContext, TErrorGeometry}"/> class.
 /// </remarks>
 /// <param name="values">The values.</param>
-public class CoreStackedColumnSeries<TModel, TVisual, TLabel, TDrawingContext, TErrorGeometry>(ICollection? values)
+public class CoreStackedColumnSeries<TModel, TVisual, TLabel, TDrawingContext, TErrorGeometry>(ICollection<TModel>? values)
     : CoreColumnSeries<TModel, TVisual, TLabel, TDrawingContext, TErrorGeometry>(values, true), IStackedBarSeries<TDrawingContext>
         where TVisual : class, ISizedGeometry<TDrawingContext>, new()
         where TLabel : class, ILabelGeometry<TDrawingContext>, new()

--- a/src/LiveChartsCore/CoreStackedRowSeries.cs
+++ b/src/LiveChartsCore/CoreStackedRowSeries.cs
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Collections;
+using System.Collections.Generic;
 using LiveChartsCore.Drawing;
 using LiveChartsCore.Kernel.Sketches;
 
@@ -38,7 +38,7 @@ namespace LiveChartsCore;
 /// Initializes a new instance of the <see cref="CoreStackedRowSeries{TModel, TVisual, TLabel, TDrawingContext, TErrorGeometry}"/> class.
 /// </remarks>
 /// <param name="values">The values.</param>
-public class CoreStackedRowSeries<TModel, TVisual, TLabel, TDrawingContext, TErrorGeometry>(ICollection? values)
+public class CoreStackedRowSeries<TModel, TVisual, TLabel, TDrawingContext, TErrorGeometry>(ICollection<TModel>? values)
     : CoreRowSeries<TModel, TVisual, TLabel, TDrawingContext, TErrorGeometry>(values, true), IStackedBarSeries<TDrawingContext>
         where TVisual : class, ISizedGeometry<TDrawingContext>, new()
         where TLabel : class, ILabelGeometry<TDrawingContext>, new()

--- a/src/LiveChartsCore/CoreStackedStepAreaSeries.cs
+++ b/src/LiveChartsCore/CoreStackedStepAreaSeries.cs
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Collections;
+using System.Collections.Generic;
 using LiveChartsCore.Drawing;
 using LiveChartsCore.Drawing.Segments;
 
@@ -46,7 +46,7 @@ public class CoreStackedStepAreaSeries<TModel, TVisual, TLabel, TDrawingContext,
     /// Initializes a new instance of the <see cref="CoreStackedAreaSeries{TModel, TVisual, TLabel, TDrawingContext, TPathGeometry, TVisualPoint}"/> class.
     /// </summary>
     /// <param name="values">The values.</param>
-    public CoreStackedStepAreaSeries(ICollection? values)
+    public CoreStackedStepAreaSeries(ICollection<TModel>? values)
         : base(values, true)
     {
         GeometryFill = null;

--- a/src/LiveChartsCore/CoreStepLineSeries.cs
+++ b/src/LiveChartsCore/CoreStepLineSeries.cs
@@ -22,7 +22,6 @@
 // SOFTWARE.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using LiveChartsCore.Drawing;
@@ -61,7 +60,7 @@ public class CoreStepLineSeries<TModel, TVisual, TLabel, TDrawingContext, TPathG
     /// </summary>
     /// <param name="isStacked">if set to <c>true</c> [is stacked].</param>
     /// <param name="values">The values.</param>
-    public CoreStepLineSeries(ICollection? values, bool isStacked = false)
+    public CoreStepLineSeries(ICollection<TModel>? values, bool isStacked = false)
         : base(GetProperties(isStacked), values)
     {
         DataPadding = new LvcPoint(0.5f, 1f);

--- a/src/LiveChartsCore/ISeries.cs
+++ b/src/LiveChartsCore/ISeries.cs
@@ -62,7 +62,7 @@ public interface ISeries
     /// <value>
     /// The values.
     /// </value>
-    ICollection? Values { get; set; }
+    IEnumerable? Values { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether this instance is visible.
@@ -214,9 +214,16 @@ public interface ISeries
 /// Defines a series.
 /// </summary>
 /// <typeparam name="TModel">The type of the model.</typeparam>
-/// <seealso cref="IDisposable" />
 public interface ISeries<TModel> : ISeries
 {
+    /// <summary>
+    /// Gets or sets the values.
+    /// </summary>
+    /// <value>
+    /// The values.
+    /// </value>
+    new ICollection<TModel>? Values { get; set; }
+
     /// <summary>
     /// Gets or sets the mapping.
     /// </summary>

--- a/src/LiveChartsCore/Kernel/Providers/DataFactory.cs
+++ b/src/LiveChartsCore/Kernel/Providers/DataFactory.cs
@@ -41,7 +41,7 @@ public class DataFactory<TModel, TDrawingContext>
 {
     private readonly bool _isTModelChartEntity = false;
     private readonly Dictionary<object, Dictionary<int, MappedChartEntity>> _chartIndexEntityMap = [];
-    private ISeries? _series;
+    private ISeries<TModel>? _series;
 
     /// <summary>
     /// Gets or sets the previous known bounds.

--- a/src/LiveChartsCore/Series.cs
+++ b/src/LiveChartsCore/Series.cs
@@ -94,7 +94,7 @@ public abstract class Series<TModel, TVisual, TLabel, TDrawingContext>
     protected bool _geometrySvgChanged = false;
 
     private readonly CollectionDeepObserver<TModel> _observer;
-    private ICollection? _values;
+    private ICollection<TModel>? _values;
     private string? _name;
     private Func<TModel, int, Coordinate>? _mapping;
     private int _zIndex;
@@ -114,7 +114,7 @@ public abstract class Series<TModel, TVisual, TLabel, TDrawingContext>
     /// </summary>
     /// <param name="properties">The properties.</param>
     /// <param name="values">The values.</param>
-    protected Series(SeriesProperties properties, ICollection? values)
+    protected Series(SeriesProperties properties, ICollection<TModel>? values)
     {
         SeriesProperties = properties;
         Values = values;
@@ -142,7 +142,7 @@ public abstract class Series<TModel, TVisual, TLabel, TDrawingContext>
     /// <summary>
     /// Gets or sets the data set to draw in the chart.
     /// </summary>
-    public ICollection? Values
+    public ICollection<TModel>? Values
     {
         get => _values;
         set
@@ -152,6 +152,12 @@ public abstract class Series<TModel, TVisual, TLabel, TDrawingContext>
             _values = value;
             OnPropertyChanged();
         }
+    }
+
+    IEnumerable? ISeries.Values
+    {
+        get => Values;
+        set => Values = (ICollection<TModel>?)value;
     }
 
     /// <inheritdoc cref="ISeries.Pivot"/>

--- a/src/LiveChartsCore/StrokeAndFillCartesianSeries.cs
+++ b/src/LiveChartsCore/StrokeAndFillCartesianSeries.cs
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Collections;
+using System.Collections.Generic;
 using LiveChartsCore.Drawing;
 using LiveChartsCore.Kernel;
 
@@ -40,7 +40,7 @@ namespace LiveChartsCore;
 /// <param name="values">The values.</param>
 public abstract class StrokeAndFillCartesianSeries<TModel, TVisual, TLabel, TDrawingContext>(
     SeriesProperties properties,
-    ICollection? values)
+    ICollection<TModel>? values)
         : CartesianSeries<TModel, TVisual, TLabel, TDrawingContext>(properties, values)
             where TDrawingContext : DrawingContext
             where TVisual : class, IGeometry<TDrawingContext>, new()

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/BoxSeries.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/BoxSeries.cs
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Collections;
+using System.Collections.Generic;
 using LiveChartsCore.Drawing;
 using LiveChartsCore.Kernel;
 using LiveChartsCore.SkiaSharpView.Drawing;
@@ -53,7 +53,7 @@ public class BoxSeries<TModel>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public BoxSeries(ICollection? values)
+    public BoxSeries(ICollection<TModel>? values)
         : base(values)
     { }
 
@@ -96,7 +96,7 @@ public class BoxSeries<TModel, TVisual>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public BoxSeries(ICollection? values)
+    public BoxSeries(ICollection<TModel>? values)
         : base(values)
     { }
 
@@ -143,7 +143,7 @@ public class BoxSeries<TModel, TVisual, TLabel>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public BoxSeries(ICollection? values)
+    public BoxSeries(ICollection<TModel>? values)
         : base(values)
     { }
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/CandlesticksSeries.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/CandlesticksSeries.cs
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Collections;
+using System.Collections.Generic;
 using LiveChartsCore.Drawing;
 using LiveChartsCore.Kernel;
 using LiveChartsCore.SkiaSharpView.Drawing;
@@ -53,7 +53,7 @@ public class CandlesticksSeries<TModel>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public CandlesticksSeries(ICollection? values)
+    public CandlesticksSeries(ICollection<TModel>? values)
         : base(values)
     { }
 
@@ -96,7 +96,7 @@ public class CandlesticksSeries<TModel, TVisual>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public CandlesticksSeries(ICollection? values)
+    public CandlesticksSeries(ICollection<TModel>? values)
         : base(values)
     { }
 
@@ -143,7 +143,7 @@ public class CandlesticksSeries<TModel, TVisual, TLabel>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public CandlesticksSeries(ICollection? values)
+    public CandlesticksSeries(ICollection<TModel>? values)
         : base(values)
     { }
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/ColumnSeries.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/ColumnSeries.cs
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Collections;
+using System.Collections.Generic;
 using LiveChartsCore.Drawing;
 using LiveChartsCore.Kernel;
 using LiveChartsCore.SkiaSharpView.Drawing;
@@ -53,7 +53,7 @@ public class ColumnSeries<TModel>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public ColumnSeries(ICollection? values)
+    public ColumnSeries(ICollection<TModel>? values)
         : base(values)
     { }
 
@@ -96,7 +96,7 @@ public class ColumnSeries<TModel, TVisual>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public ColumnSeries(ICollection? values)
+    public ColumnSeries(ICollection<TModel>? values)
         : base(values)
     { }
 
@@ -143,7 +143,7 @@ public class ColumnSeries<TModel, TVisual, TLabel>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public ColumnSeries(ICollection? values)
+    public ColumnSeries(ICollection<TModel>? values)
         : base(values)
     { }
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/HeatSeries.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/HeatSeries.cs
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Collections;
+using System.Collections.Generic;
 using LiveChartsCore.Drawing;
 using LiveChartsCore.Kernel;
 using LiveChartsCore.SkiaSharpView.Drawing;
@@ -53,7 +53,7 @@ public class HeatSeries<TModel>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public HeatSeries(ICollection? values)
+    public HeatSeries(ICollection<TModel>? values)
         : base(values)
     { }
 
@@ -96,7 +96,7 @@ public class HeatSeries<TModel, TVisual>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public HeatSeries(ICollection? values)
+    public HeatSeries(ICollection<TModel>? values)
         : base(values)
     { }
 
@@ -143,7 +143,7 @@ public class HeatSeries<TModel, TVisual, TLabel>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public HeatSeries(ICollection? values)
+    public HeatSeries(ICollection<TModel>? values)
         : base(values)
     { }
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/LineSeries.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/LineSeries.cs
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Collections;
+using System.Collections.Generic;
 using LiveChartsCore.Drawing;
 using LiveChartsCore.Kernel;
 using LiveChartsCore.SkiaSharpView.Drawing;
@@ -53,7 +53,7 @@ public class LineSeries<TModel>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public LineSeries(ICollection? values)
+    public LineSeries(ICollection<TModel>? values)
         : base(values)
     { }
 
@@ -96,7 +96,7 @@ public class LineSeries<TModel, TVisual>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public LineSeries(ICollection? values)
+    public LineSeries(ICollection<TModel>? values)
         : base(values)
     { }
 
@@ -143,7 +143,7 @@ public class LineSeries<TModel, TVisual, TLabel>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public LineSeries(ICollection? values)
+    public LineSeries(ICollection<TModel>? values)
         : base(values)
     { }
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/PieSeries.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/PieSeries.cs
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Collections;
+using System.Collections.Generic;
 using LiveChartsCore.Drawing;
 using LiveChartsCore.Kernel;
 using LiveChartsCore.SkiaSharpView.Drawing;
@@ -53,7 +53,7 @@ public class PieSeries<TModel>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public PieSeries(ICollection? values)
+    public PieSeries(ICollection<TModel>? values)
         : base(values)
     { }
 
@@ -103,7 +103,7 @@ public class PieSeries<TModel, TVisual>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public PieSeries(ICollection? values)
+    public PieSeries(ICollection<TModel>? values)
         : base(values)
     { }
 
@@ -157,7 +157,7 @@ public class PieSeries<TModel, TVisual, TLabel>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public PieSeries(ICollection? values)
+    public PieSeries(ICollection<TModel>? values)
         : base(values, false, false)
     { }
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/PolarLineSeries.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/PolarLineSeries.cs
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Collections;
+using System.Collections.Generic;
 using LiveChartsCore.Drawing;
 using LiveChartsCore.Kernel;
 using LiveChartsCore.SkiaSharpView.Drawing;
@@ -53,7 +53,7 @@ public class PolarLineSeries<TModel>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public PolarLineSeries(ICollection? values)
+    public PolarLineSeries(ICollection<TModel>? values)
         : base(values)
     { }
 
@@ -96,7 +96,7 @@ public class PolarLineSeries<TModel, TVisual>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public PolarLineSeries(ICollection? values)
+    public PolarLineSeries(ICollection<TModel>? values)
         : base(values)
     { }
 
@@ -143,7 +143,7 @@ public class PolarLineSeries<TModel, TVisual, TLabel>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public PolarLineSeries(ICollection? values)
+    public PolarLineSeries(ICollection<TModel>? values)
         : base(values)
     { }
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/RowSeries.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/RowSeries.cs
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Collections;
+using System.Collections.Generic;
 using LiveChartsCore.Drawing;
 using LiveChartsCore.Kernel;
 using LiveChartsCore.SkiaSharpView.Drawing;
@@ -53,7 +53,7 @@ public class RowSeries<TModel>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public RowSeries(ICollection? values)
+    public RowSeries(ICollection<TModel>? values)
         : base(values)
     { }
 
@@ -96,7 +96,7 @@ public class RowSeries<TModel, TVisual>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public RowSeries(ICollection? values)
+    public RowSeries(ICollection<TModel>? values)
         : base(values)
     { }
 
@@ -143,7 +143,7 @@ public class RowSeries<TModel, TVisual, TLabel>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public RowSeries(ICollection? values)
+    public RowSeries(ICollection<TModel>? values)
         : base(values)
     { }
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/ScatterSeries.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/ScatterSeries.cs
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Collections;
+using System.Collections.Generic;
 using LiveChartsCore.Drawing;
 using LiveChartsCore.Kernel;
 using LiveChartsCore.SkiaSharpView.Drawing;
@@ -53,7 +53,7 @@ public class ScatterSeries<TModel>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public ScatterSeries(ICollection? values)
+    public ScatterSeries(ICollection<TModel>? values)
         : base(values)
     { }
 
@@ -96,7 +96,7 @@ public class ScatterSeries<TModel, TVisual>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public ScatterSeries(ICollection? values)
+    public ScatterSeries(ICollection<TModel>? values)
         : base(values)
     { }
 
@@ -143,7 +143,7 @@ public class ScatterSeries<TModel, TVisual, TLabel>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public ScatterSeries(ICollection? values)
+    public ScatterSeries(ICollection<TModel>? values)
         : base(values)
     { }
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/StackedAreaSeries.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/StackedAreaSeries.cs
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Collections;
+using System.Collections.Generic;
 using LiveChartsCore.Drawing;
 using LiveChartsCore.Kernel;
 using LiveChartsCore.SkiaSharpView.Drawing;
@@ -53,7 +53,7 @@ public class StackedAreaSeries<TModel>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public StackedAreaSeries(ICollection? values)
+    public StackedAreaSeries(ICollection<TModel>? values)
         : base(values)
     { }
 
@@ -96,7 +96,7 @@ public class StackedAreaSeries<TModel, TVisual>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public StackedAreaSeries(ICollection? values)
+    public StackedAreaSeries(ICollection<TModel>? values)
         : base(values)
     { }
 
@@ -143,7 +143,7 @@ public class StackedAreaSeries<TModel, TVisual, TLabel>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public StackedAreaSeries(ICollection? values)
+    public StackedAreaSeries(ICollection<TModel>? values)
         : base(values)
     { }
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/StackedColumnSeries.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/StackedColumnSeries.cs
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Collections;
+using System.Collections.Generic;
 using LiveChartsCore.Drawing;
 using LiveChartsCore.Kernel;
 using LiveChartsCore.SkiaSharpView.Drawing;
@@ -53,7 +53,7 @@ public class StackedColumnSeries<TModel>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public StackedColumnSeries(ICollection? values)
+    public StackedColumnSeries(ICollection<TModel>? values)
         : base(values)
     { }
 
@@ -96,7 +96,7 @@ public class StackedColumnSeries<TModel, TVisual>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public StackedColumnSeries(ICollection? values)
+    public StackedColumnSeries(ICollection<TModel>? values)
         : base(values)
     { }
 
@@ -143,7 +143,7 @@ public class StackedColumnSeries<TModel, TVisual, TLabel>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public StackedColumnSeries(ICollection? values)
+    public StackedColumnSeries(ICollection<TModel>? values)
         : base(values)
     { }
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/StackedRowSeries.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/StackedRowSeries.cs
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Collections;
+using System.Collections.Generic;
 using LiveChartsCore.Drawing;
 using LiveChartsCore.Kernel;
 using LiveChartsCore.SkiaSharpView.Drawing;
@@ -53,7 +53,7 @@ public class StackedRowSeries<TModel>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public StackedRowSeries(ICollection? values)
+    public StackedRowSeries(ICollection<TModel>? values)
         : base(values)
     { }
 
@@ -96,7 +96,7 @@ public class StackedRowSeries<TModel, TVisual>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public StackedRowSeries(ICollection? values)
+    public StackedRowSeries(ICollection<TModel>? values)
         : base(values)
     { }
 
@@ -143,7 +143,7 @@ public class StackedRowSeries<TModel, TVisual, TLabel>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public StackedRowSeries(ICollection? values)
+    public StackedRowSeries(ICollection<TModel>? values)
         : base(values)
     { }
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/StackedStepAreaSeries.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/StackedStepAreaSeries.cs
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Collections;
+using System.Collections.Generic;
 using LiveChartsCore.Drawing;
 using LiveChartsCore.Kernel;
 using LiveChartsCore.SkiaSharpView.Drawing;
@@ -53,7 +53,7 @@ public class StackedStepAreaSeries<TModel>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public StackedStepAreaSeries(ICollection? values)
+    public StackedStepAreaSeries(ICollection<TModel>? values)
         : base(values)
     { }
 
@@ -96,7 +96,7 @@ public class StackedStepAreaSeries<TModel, TVisual>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public StackedStepAreaSeries(ICollection? values)
+    public StackedStepAreaSeries(ICollection<TModel>? values)
         : base(values)
     { }
 
@@ -143,7 +143,7 @@ public class StackedStepAreaSeries<TModel, TVisual, TLabel>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public StackedStepAreaSeries(ICollection? values)
+    public StackedStepAreaSeries(ICollection<TModel>? values)
         : base(values)
     { }
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/StepLineSeries.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/StepLineSeries.cs
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Collections;
+using System.Collections.Generic;
 using LiveChartsCore.Drawing;
 using LiveChartsCore.Kernel;
 using LiveChartsCore.SkiaSharpView.Drawing;
@@ -70,7 +70,7 @@ public class StepLineSeries<TModel, TVisual>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public StepLineSeries(ICollection? values)
+    public StepLineSeries(ICollection<TModel>? values)
         : base(values)
     { }
 
@@ -117,7 +117,7 @@ public class StepLineSeries<TModel, TVisual, TLabel>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public StepLineSeries(ICollection? values)
+    public StepLineSeries(ICollection<TModel>? values)
         : base(values)
     { }
 


### PR DESCRIPTION
This reduces boilerplate mainly, but could also improve performance in some cases.