### PR TITLE
add customPoints sample

### DIFF
--- a/samples/AvaloniaSample/Lines/CustomPoints/View.axaml
+++ b/samples/AvaloniaSample/Lines/CustomPoints/View.axaml
@@ -1,0 +1,10 @@
+<UserControl x:Class="AvaloniaSample.Lines.CustomPoints.View"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:lvc="using:LiveChartsCore.SkiaSharpView.Avalonia"
+             xmlns:vms="using:ViewModelsSamples.Lines.CustomPoints">
+  <UserControl.DataContext>
+    <vms:ViewModel/>
+  </UserControl.DataContext>
+  <lvc:CartesianChart Series="{Binding Series}"/>
+</UserControl>

--- a/samples/AvaloniaSample/Lines/CustomPoints/View.axaml.cs
+++ b/samples/AvaloniaSample/Lines/CustomPoints/View.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace AvaloniaSample.Lines.CustomPoints;
+
+public partial class View : UserControl
+{
+    public View()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/BlazorSample/Pages/Lines/CustomPoints.razor
+++ b/samples/BlazorSample/Pages/Lines/CustomPoints.razor
@@ -1,0 +1,11 @@
+﻿@page "/Lines/CustomPoints"
+@using LiveChartsCore.SkiaSharpView.Blazor
+@using ViewModelsSamples.Lines.CustomPoints
+
+<CartesianChart
+	Series="ViewModel.Series">
+</CartesianChart>
+
+@code {
+	public ViewModel ViewModel { get; set; } = new();
+}

--- a/samples/EtoFormsSample/Lines/CustomPoints/View.cs
+++ b/samples/EtoFormsSample/Lines/CustomPoints/View.cs
@@ -1,0 +1,22 @@
+﻿using Eto.Forms;
+using LiveChartsCore.SkiaSharpView.Eto;
+using ViewModelsSamples.Lines.CustomPoints;
+
+namespace EtoFormsSample.Lines.CustomPoints;
+
+public class View : Panel
+{
+    private readonly CartesianChart cartesianChart;
+
+    public View()
+    {
+        var viewModel = new ViewModel();
+
+        cartesianChart = new CartesianChart
+        {
+            Series = viewModel.Series,
+        };
+
+        Content = cartesianChart;
+    }
+}

--- a/samples/MauiSample/Lines/CustomPoints/View.xaml
+++ b/samples/MauiSample/Lines/CustomPoints/View.xaml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage x:Class="MauiSample.Lines.CustomPoints.View"
+             xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:lvc="clr-namespace:LiveChartsCore.SkiaSharpView.Maui;assembly=LiveChartsCore.SkiaSharpView.Maui"
+             xmlns:vms="clr-namespace:ViewModelsSamples.Lines.CustomPoints;assembly=ViewModelsSamples">
+    <ContentPage.BindingContext>
+        <vms:ViewModel/>
+    </ContentPage.BindingContext>
+    <lvc:CartesianChart Series="{Binding Series}"/>
+</ContentPage>

--- a/samples/MauiSample/Lines/CustomPoints/View.xaml.cs
+++ b/samples/MauiSample/Lines/CustomPoints/View.xaml.cs
@@ -1,0 +1,10 @@
+﻿namespace MauiSample.Lines.CustomPoints;
+
+[XamlCompilation(XamlCompilationOptions.Compile)]
+public partial class View : ContentPage
+{
+    public View()
+    {
+        InitializeComponent();
+    }
+}

--- a/samples/UnoPlatform_v5/UnoPlatform_v5/LiveChartsSamples/Lines/CustomPoints/View.xaml
+++ b/samples/UnoPlatform_v5/UnoPlatform_v5/LiveChartsSamples/Lines/CustomPoints/View.xaml
@@ -1,0 +1,13 @@
+﻿<UserControl x:Class="UnoWinUISample.Lines.CustomPoints.View"
+            xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+            xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+            xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+            xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+            xmlns:lvc="using:LiveChartsCore.SkiaSharpView.WinUI"
+            xmlns:vms="using:ViewModelsSamples.Lines.CustomPoints"
+            mc:Ignorable="d">
+    <UserControl.DataContext>
+        <vms:ViewModel/>
+    </UserControl.DataContext>
+    <lvc:CartesianChart Series="{Binding Series}"/>
+</UserControl>

--- a/samples/UnoPlatform_v5/UnoPlatform_v5/LiveChartsSamples/Lines/CustomPoints/View.xaml.cs
+++ b/samples/UnoPlatform_v5/UnoPlatform_v5/LiveChartsSamples/Lines/CustomPoints/View.xaml.cs
@@ -1,0 +1,11 @@
+using Microsoft.UI.Xaml.Controls;
+
+namespace UnoWinUISample.Lines.CustomPoints;
+
+public sealed partial class View : UserControl
+{
+    public View()
+    {
+        InitializeComponent();
+    }
+}

--- a/samples/ViewModelsSamples/Index.cs
+++ b/samples/ViewModelsSamples/Index.cs
@@ -13,6 +13,7 @@ public static class Index
         "Lines/Properties",
         "Lines/Area",
         "Lines/Custom",
+        "Lines/CustomPoints",
         "Lines/Padding",
         "Lines/XY",
         "Lines/Zoom",

--- a/samples/ViewModelsSamples/Lines/CustomPoints/ViewModel.cs
+++ b/samples/ViewModelsSamples/Lines/CustomPoints/ViewModel.cs
@@ -1,0 +1,76 @@
+﻿using LiveChartsCore;
+using LiveChartsCore.ConditionalDraw;
+using LiveChartsCore.SkiaSharpView;
+using LiveChartsCore.SkiaSharpView.Drawing.Geometries;
+using LiveChartsCore.SkiaSharpView.Painting;
+using SkiaSharp;
+
+namespace ViewModelsSamples.Lines.CustomPoints;
+
+public class ViewModel
+{
+    public ISeries[] Series { get; }
+
+    public ViewModel()
+    {
+        var lineSeries = new LineSeries<DataPoint, ArrowGeometry>(Fetch());
+
+        // we use the OnPointMeasured event to rotate the arrow // mark
+        // according to the Rotation property in the DataPoint class // mark
+        _ = lineSeries
+            .OnPointMeasured(point =>
+            {
+                point.Visual!.TransformOrigin = new(0f, 0f);
+                point.Visual!.RotateTransform = point.Model!.Rotation;
+            });
+
+        lineSeries.GeometrySize = 50;
+        lineSeries.GeometryStroke = null;
+        lineSeries.GeometryFill = new SolidColorPaint(SKColors.MediumVioletRed);
+        lineSeries.Fill = null;
+
+        // The Mapping property is used to map the data points to the series
+        // to learn more about the Mapping property visit:
+        // https://livecharts.dev/docs/{{ platform }}/{{ version }}/Overview.Mappers
+        lineSeries.Mapping = (dataPoint, index) => new(index, dataPoint.Value);
+
+        Series = [lineSeries];
+    }
+
+    public DataPoint[] Fetch()
+    {
+        return [
+            new DataPoint { Value = 4, Rotation = 0 },
+            new DataPoint { Value = 6, Rotation = 20 },
+            new DataPoint { Value = 8, Rotation = 90 },
+            new DataPoint { Value = 2, Rotation = 176 },
+            new DataPoint { Value = 7, Rotation = 55 },
+            new DataPoint { Value = 9, Rotation = 226 },
+            new DataPoint { Value = 3, Rotation = 320 }
+        ];
+    }
+}
+
+public class DataPoint
+{
+    public int Value { get; set; }
+    public float Rotation { get; set; }
+}
+
+
+public class ArrowGeometry : BaseSVGPathGeometry
+{
+    // svg path from:
+    // https://www.svgrepo.com/svg/525637/arrow-up
+
+    private static SKPath _path = SKPath.ParseSvgPathData(
+        "M12.75 20C12.75 20.4142 12.4142 20.75 12 20.75C11.5858 20.75 11.25 20.4142 11.25 " +
+        "20L11.25 10.75H6.00002C5.69668 10.75 5.4232 10.5673 5.30711 10.287C5.19103 10.0068 " +
+        "5.25519 9.68417 5.46969 9.46967L11.4697 3.46967C11.6103 3.32902 11.8011 3.25 12 " +
+        "3.25C12.1989 3.25 12.3897 3.32902 12.5304 3.46967L18.5304 9.46967C18.7449 9.68417 " +
+        "18.809 10.0068 18.6929 10.287C18.5768 10.5673 18.3034 10.75 18 10.75H12.75L12.75 20Z");
+
+    public ArrowGeometry()
+        : base(_path)
+    { }
+}

--- a/samples/WPFSample/Lines/CustomPoints/View.xaml
+++ b/samples/WPFSample/Lines/CustomPoints/View.xaml
@@ -1,0 +1,10 @@
+﻿<UserControl x:Class="WPFSample.Lines.CustomPoints.View"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" 
+             xmlns:lvc="clr-namespace:LiveChartsCore.SkiaSharpView.WPF;assembly=LiveChartsCore.SkiaSharpView.WPF"
+             xmlns:vms="clr-namespace:ViewModelsSamples.Lines.CustomPoints;assembly=ViewModelsSamples">
+    <UserControl.DataContext>
+        <vms:ViewModel/>
+    </UserControl.DataContext>
+    <lvc:CartesianChart Series="{Binding Series}"/>
+</UserControl>

--- a/samples/WPFSample/Lines/CustomPoints/View.xaml.cs
+++ b/samples/WPFSample/Lines/CustomPoints/View.xaml.cs
@@ -1,0 +1,14 @@
+﻿using System.Windows.Controls;
+
+namespace WPFSample.Lines.CustomPoints;
+
+/// <summary>
+/// Interaction logic for View.xaml
+/// </summary>
+public partial class View : UserControl
+{
+    public View()
+    {
+        InitializeComponent();
+    }
+}

--- a/samples/WinFormsSample/Lines/CustomPoints/View.Designer.cs
+++ b/samples/WinFormsSample/Lines/CustomPoints/View.Designer.cs
@@ -1,5 +1,5 @@
 ﻿
-namespace WinFormsSample.Lines.CustomPoints
+namespace WinFormsSample.Lines.Custom
 {
     partial class View
     {

--- a/samples/WinFormsSample/Lines/CustomPoints/View.cs
+++ b/samples/WinFormsSample/Lines/CustomPoints/View.cs
@@ -1,0 +1,30 @@
+﻿using System.Windows.Forms;
+using LiveChartsCore.SkiaSharpView.WinForms;
+using ViewModelsSamples.Lines.CustomPoints;
+
+namespace WinFormsSample.Lines.CustomPoints;
+
+public partial class View : UserControl
+{
+    private readonly CartesianChart cartesianChart;
+
+    public View()
+    {
+        InitializeComponent();
+        Size = new System.Drawing.Size(50, 50);
+
+        var viewModel = new ViewModel();
+
+        cartesianChart = new CartesianChart
+        {
+            Series = viewModel.Series,
+
+            // out of livecharts properties...
+            Location = new System.Drawing.Point(0, 0),
+            Size = new System.Drawing.Size(50, 50),
+            Anchor = AnchorStyles.Left | AnchorStyles.Right | AnchorStyles.Top | AnchorStyles.Bottom
+        };
+
+        Controls.Add(cartesianChart);
+    }
+}

--- a/samples/WinFormsSample/Lines/CustomPoints/View.resx
+++ b/samples/WinFormsSample/Lines/CustomPoints/View.resx
@@ -1,0 +1,60 @@
+﻿<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/samples/WinUISample/WinUISample/Lines/CustomPoints/View.xaml
+++ b/samples/WinUISample/WinUISample/Lines/CustomPoints/View.xaml
@@ -1,0 +1,13 @@
+﻿<UserControl x:Class="WinUISample.Lines.CustomPoints.View"
+            xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+            xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+            xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+            xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+            xmlns:lvc="using:LiveChartsCore.SkiaSharpView.WinUI"
+            xmlns:vms="using:ViewModelsSamples.Lines.CustomPoints"
+            mc:Ignorable="d">
+    <UserControl.DataContext>
+        <vms:ViewModel/>
+    </UserControl.DataContext>
+    <lvc:CartesianChart Series="{Binding Series}"/>
+</UserControl>

--- a/samples/WinUISample/WinUISample/Lines/CustomPoints/View.xaml.cs
+++ b/samples/WinUISample/WinUISample/Lines/CustomPoints/View.xaml.cs
@@ -1,0 +1,11 @@
+﻿using Microsoft.UI.Xaml.Controls;
+
+namespace WinUISample.Lines.CustomPoints;
+
+public sealed partial class View : UserControl
+{
+    public View()
+    {
+        InitializeComponent();
+    }
+}

--- a/samples/XamarinSample/XamarinSample/XamarinSample/Lines/CustomPoints/View.xaml
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/Lines/CustomPoints/View.xaml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="XamarinSample.Lines.CustomPoints.View"
+             xmlns:lvc="clr-namespace:LiveChartsCore.SkiaSharpView.Xamarin.Forms;assembly=LiveChartsCore.SkiaSharpView.XamarinForms"
+             xmlns:vms="clr-namespace:ViewModelsSamples.Lines.CustomPoints;assembly=ViewModelsSamples">
+    <ContentPage.BindingContext>
+        <vms:ViewModel/>
+    </ContentPage.BindingContext>
+    <lvc:CartesianChart Series="{Binding Series}"/>
+</ContentPage>

--- a/samples/XamarinSample/XamarinSample/XamarinSample/Lines/CustomPoints/View.xaml.cs
+++ b/samples/XamarinSample/XamarinSample/XamarinSample/Lines/CustomPoints/View.xaml.cs
@@ -1,0 +1,13 @@
+﻿using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace XamarinSample.Lines.CustomPoints;
+
+[XamlCompilation(XamlCompilationOptions.Compile)]
+public partial class View : ContentPage
+{
+    public View()
+    {
+        InitializeComponent();
+    }
+}


### PR DESCRIPTION
Adds the next example to the repo and web site:

![image](https://github.com/user-attachments/assets/07620911-bf28-4a0e-a7d5-eb80b3debfeb)

This sample explains how to create a relation between the DataPoint and the drawn geometry.

Even this was supported from older version, this is now documented and will explain how to solve the next issues:

- #1527
- #1122