### PR TITLE
Simplify miniatures

### DIFF
--- a/samples/ViewModelsSamples/General/TemplatedLegends/CustomLegend.cs
+++ b/samples/ViewModelsSamples/General/TemplatedLegends/CustomLegend.cs
@@ -70,6 +70,7 @@ public class CustomLegend : IChartLegend<SkiaSharpDrawingContext>
                             ZIndex = s_zIndex + 1
                         }
                     },
+                    // series.GetMiniature(s_zIndex), or get the miniature defined in the series.
                     new LabelVisual
                     {
                         Text = series.Name ?? string.Empty,

--- a/samples/ViewModelsSamples/General/TemplatedTooltips/CustomTooltip.cs
+++ b/samples/ViewModelsSamples/General/TemplatedTooltips/CustomTooltip.cs
@@ -50,8 +50,7 @@ public class CustomTooltip : IChartTooltip<SkiaSharpDrawingContext>
 
         foreach (var point in foundPoints)
         {
-            var sketch = ((IChartSeries<SkiaSharpDrawingContext>)point.Context.Series).GetMiniaturesSketch();
-            var relativePanel = sketch.AsDrawnControl(s_zIndex);
+            var skiaSeries = (IChartSeries<SkiaSharpDrawingContext>)point.Context.Series;
 
             var label = new LabelVisual
             {
@@ -71,7 +70,7 @@ public class CustomTooltip : IChartTooltip<SkiaSharpDrawingContext>
                 HorizontalAlignment = Align.Middle,
                 Children =
                 {
-                    relativePanel,
+                    skiaSeries.GetMiniature(s_zIndex),
                     label
                 }
             };

--- a/src/LiveChartsCore/BarSeries.cs
+++ b/src/LiveChartsCore/BarSeries.cs
@@ -27,6 +27,7 @@ using LiveChartsCore.Kernel;
 using LiveChartsCore.Kernel.Drawing;
 using LiveChartsCore.Kernel.Sketches;
 using LiveChartsCore.Measure;
+using LiveChartsCore.VisualElements;
 
 namespace LiveChartsCore;
 
@@ -93,6 +94,18 @@ public abstract class BarSeries<TModel, TVisual, TLabel, TDrawingContext>(
         return new Sketch<TDrawingContext>(MiniatureShapeSize, MiniatureShapeSize, GeometrySvg)
         {
             PaintSchedules = schedules
+        };
+    }
+
+    /// <inheritdoc cref="Series{TModel, TVisual, TLabel, TDrawingContext}.GetMiniature"/>"/>
+    public override VisualElement<TDrawingContext> GetMiniature()
+    {
+        return new GeometryVisual<TVisual, TLabel, TDrawingContext>
+        {
+            Fill = Fill,
+            Stroke = Stroke,
+            Width = MiniatureShapeSize,
+            Height = MiniatureShapeSize,
         };
     }
 

--- a/src/LiveChartsCore/BarSeries.cs
+++ b/src/LiveChartsCore/BarSeries.cs
@@ -103,7 +103,7 @@ public abstract class BarSeries<TModel, TVisual, TLabel, TDrawingContext>(
         return new GeometryVisual<TVisual, TLabel, TDrawingContext>
         {
             Fill = Fill.Clone(zindex),
-            Stroke = Stroke.Clone(zindex),
+            Stroke = Stroke.Clone(zindex + 1),
             Width = MiniatureShapeSize,
             Height = MiniatureShapeSize,
         };

--- a/src/LiveChartsCore/BarSeries.cs
+++ b/src/LiveChartsCore/BarSeries.cs
@@ -98,12 +98,12 @@ public abstract class BarSeries<TModel, TVisual, TLabel, TDrawingContext>(
     }
 
     /// <inheritdoc cref="Series{TModel, TVisual, TLabel, TDrawingContext}.GetMiniature"/>"/>
-    public override VisualElement<TDrawingContext> GetMiniature()
+    public override VisualElement<TDrawingContext> GetMiniature(int zindex = 0)
     {
         return new GeometryVisual<TVisual, TLabel, TDrawingContext>
         {
-            Fill = Fill,
-            Stroke = Stroke,
+            Fill = Fill.Clone(zindex),
+            Stroke = Stroke.Clone(zindex),
             Width = MiniatureShapeSize,
             Height = MiniatureShapeSize,
         };

--- a/src/LiveChartsCore/BarSeries.cs
+++ b/src/LiveChartsCore/BarSeries.cs
@@ -82,6 +82,7 @@ public abstract class BarSeries<TModel, TVisual, TLabel, TDrawingContext>(
     }
 
     /// <inheritdoc cref="Series{TModel, TVisual, TLabel, TDrawingContext}.GetMiniaturesSketch"/>
+    [System.Obsolete]
     public override Sketch<TDrawingContext> GetMiniaturesSketch()
     {
         var schedules = new List<PaintSchedule<TDrawingContext>>();

--- a/src/LiveChartsCore/CoreBoxSeries.cs
+++ b/src/LiveChartsCore/CoreBoxSeries.cs
@@ -339,6 +339,7 @@ public abstract class CoreBoxSeries<TModel, TVisual, TLabel, TMiniatureGeometry,
     }
 
     /// <inheritdoc cref="Series{TModel, TVisual, TLabel, TDrawingContext}.GetMiniaturesSketch"/>
+    [Obsolete]
     public override Sketch<TDrawingContext> GetMiniaturesSketch()
     {
         var schedules = new List<PaintSchedule<TDrawingContext>>();

--- a/src/LiveChartsCore/CoreBoxSeries.cs
+++ b/src/LiveChartsCore/CoreBoxSeries.cs
@@ -355,12 +355,12 @@ public abstract class CoreBoxSeries<TModel, TVisual, TLabel, TMiniatureGeometry,
     }
 
     /// <inheritdoc cref="Series{TModel, TVisual, TLabel, TDrawingContext}.GetMiniature"/>"/>
-    public override VisualElement<TDrawingContext> GetMiniature()
+    public override VisualElement<TDrawingContext> GetMiniature(int zindex = 0)
     {
         return new GeometryVisual<TMiniatureGeometry, TLabel, TDrawingContext>
         {
-            Fill = Fill,
-            Stroke = Stroke,
+            Fill = Fill.Clone(zindex),
+            Stroke = Stroke.Clone(zindex),
             Width = MiniatureShapeSize,
             Height = MiniatureShapeSize,
         };

--- a/src/LiveChartsCore/CoreBoxSeries.cs
+++ b/src/LiveChartsCore/CoreBoxSeries.cs
@@ -28,6 +28,7 @@ using LiveChartsCore.Kernel;
 using LiveChartsCore.Kernel.Drawing;
 using LiveChartsCore.Kernel.Sketches;
 using LiveChartsCore.Measure;
+using LiveChartsCore.VisualElements;
 
 namespace LiveChartsCore;
 
@@ -350,6 +351,18 @@ public abstract class CoreBoxSeries<TModel, TVisual, TLabel, TMiniatureGeometry,
         return new Sketch<TDrawingContext>(MiniatureShapeSize, MiniatureShapeSize, GeometrySvg)
         {
             PaintSchedules = schedules
+        };
+    }
+
+    /// <inheritdoc cref="Series{TModel, TVisual, TLabel, TDrawingContext}.GetMiniature"/>"/>
+    public override VisualElement<TDrawingContext> GetMiniature()
+    {
+        return new GeometryVisual<TMiniatureGeometry, TLabel, TDrawingContext>
+        {
+            Fill = Fill,
+            Stroke = Stroke,
+            Width = MiniatureShapeSize,
+            Height = MiniatureShapeSize,
         };
     }
 

--- a/src/LiveChartsCore/CoreBoxSeries.cs
+++ b/src/LiveChartsCore/CoreBoxSeries.cs
@@ -360,7 +360,7 @@ public abstract class CoreBoxSeries<TModel, TVisual, TLabel, TMiniatureGeometry,
         return new GeometryVisual<TMiniatureGeometry, TLabel, TDrawingContext>
         {
             Fill = Fill.Clone(zindex),
-            Stroke = Stroke.Clone(zindex),
+            Stroke = Stroke.Clone(zindex + 1),
             Width = MiniatureShapeSize,
             Height = MiniatureShapeSize,
         };

--- a/src/LiveChartsCore/CoreFinancialSeries.cs
+++ b/src/LiveChartsCore/CoreFinancialSeries.cs
@@ -496,7 +496,7 @@ public abstract class CoreFinancialSeries<TModel, TVisual, TLabel, TMiniatureGeo
         return new GeometryVisual<TMiniatureGeometry, TLabel, TDrawingContext>
         {
             Fill = DownStroke.Clone(zindex),
-            Stroke = UpStroke.Clone(zindex),
+            Stroke = UpStroke.Clone(zindex + 1),
             Width = MiniatureShapeSize,
             Height = MiniatureShapeSize,
         };

--- a/src/LiveChartsCore/CoreFinancialSeries.cs
+++ b/src/LiveChartsCore/CoreFinancialSeries.cs
@@ -476,6 +476,7 @@ public abstract class CoreFinancialSeries<TModel, TVisual, TLabel, TMiniatureGeo
     }
 
     /// <inheritdoc cref="Series{TModel, TVisual, TLabel, TDrawingContext}.GetMiniaturesSketch"/>
+    [Obsolete]
     public override Sketch<TDrawingContext> GetMiniaturesSketch()
     {
         var schedules = new List<PaintSchedule<TDrawingContext>>();

--- a/src/LiveChartsCore/CoreFinancialSeries.cs
+++ b/src/LiveChartsCore/CoreFinancialSeries.cs
@@ -29,6 +29,7 @@ using LiveChartsCore.Kernel;
 using LiveChartsCore.Kernel.Drawing;
 using LiveChartsCore.Kernel.Sketches;
 using LiveChartsCore.Measure;
+using LiveChartsCore.VisualElements;
 
 namespace LiveChartsCore;
 
@@ -486,6 +487,18 @@ public abstract class CoreFinancialSeries<TModel, TVisual, TLabel, TMiniatureGeo
         return new Sketch<TDrawingContext>(MiniatureShapeSize, MiniatureShapeSize, GeometrySvg)
         {
             PaintSchedules = schedules
+        };
+    }
+
+    /// <inheritdoc cref="Series{TModel, TVisual, TLabel, TDrawingContext}.GetMiniature"/>"/>
+    public override VisualElement<TDrawingContext> GetMiniature()
+    {
+        return new GeometryVisual<TMiniatureGeometry, TLabel, TDrawingContext>
+        {
+            Fill = DownStroke,
+            Stroke = UpStroke,
+            Width = MiniatureShapeSize,
+            Height = MiniatureShapeSize,
         };
     }
 

--- a/src/LiveChartsCore/CoreFinancialSeries.cs
+++ b/src/LiveChartsCore/CoreFinancialSeries.cs
@@ -491,12 +491,12 @@ public abstract class CoreFinancialSeries<TModel, TVisual, TLabel, TMiniatureGeo
     }
 
     /// <inheritdoc cref="Series{TModel, TVisual, TLabel, TDrawingContext}.GetMiniature"/>"/>
-    public override VisualElement<TDrawingContext> GetMiniature()
+    public override VisualElement<TDrawingContext> GetMiniature(int zindex = 0)
     {
         return new GeometryVisual<TMiniatureGeometry, TLabel, TDrawingContext>
         {
-            Fill = DownStroke,
-            Stroke = UpStroke,
+            Fill = DownStroke.Clone(zindex),
+            Stroke = UpStroke.Clone(zindex),
             Width = MiniatureShapeSize,
             Height = MiniatureShapeSize,
         };

--- a/src/LiveChartsCore/CoreHeatSeries.cs
+++ b/src/LiveChartsCore/CoreHeatSeries.cs
@@ -322,6 +322,7 @@ public abstract class CoreHeatSeries<TModel, TVisual, TLabel, TDrawingContext>
     }
 
     /// <inheritdoc cref="Series{TModel, TVisual, TLabel, TDrawingContext}.GetMiniaturesSketch"/>
+    [Obsolete]
     public override Sketch<TDrawingContext> GetMiniaturesSketch()
     {
         var schedules = new List<PaintSchedule<TDrawingContext>>();

--- a/src/LiveChartsCore/CoreHeatSeries.cs
+++ b/src/LiveChartsCore/CoreHeatSeries.cs
@@ -28,6 +28,7 @@ using LiveChartsCore.Kernel;
 using LiveChartsCore.Kernel.Drawing;
 using LiveChartsCore.Kernel.Sketches;
 using LiveChartsCore.Measure;
+using LiveChartsCore.VisualElements;
 
 namespace LiveChartsCore;
 
@@ -350,6 +351,19 @@ public abstract class CoreHeatSeries<TModel, TVisual, TLabel, TDrawingContext>
         return new Sketch<TDrawingContext>(MiniatureShapeSize, MiniatureShapeSize, GeometrySvg)
         {
             PaintSchedules = schedules
+        };
+    }
+
+
+    /// <inheritdoc cref="Series{TModel, TVisual, TLabel, TDrawingContext}.GetMiniature"/>"/>
+    public override VisualElement<TDrawingContext> GetMiniature()
+    {
+        // ToDo <- draw the gradient?
+        // what to show in the legend?
+        return new GeometryVisual<TVisual, TLabel, TDrawingContext>
+        {
+            Width = 0,
+            Height = 0,
         };
     }
 

--- a/src/LiveChartsCore/CoreHeatSeries.cs
+++ b/src/LiveChartsCore/CoreHeatSeries.cs
@@ -356,7 +356,7 @@ public abstract class CoreHeatSeries<TModel, TVisual, TLabel, TDrawingContext>
 
 
     /// <inheritdoc cref="Series{TModel, TVisual, TLabel, TDrawingContext}.GetMiniature"/>"/>
-    public override VisualElement<TDrawingContext> GetMiniature()
+    public override VisualElement<TDrawingContext> GetMiniature(int zindex = 0)
     {
         // ToDo <- draw the gradient?
         // what to show in the legend?

--- a/src/LiveChartsCore/CoreLineSeries.cs
+++ b/src/LiveChartsCore/CoreLineSeries.cs
@@ -544,12 +544,12 @@ public class CoreLineSeries<TModel, TVisual, TLabel, TDrawingContext, TPathGeome
     }
 
     /// <inheritdoc cref="Series{TModel, TVisual, TLabel, TDrawingContext}.GetMiniature"/>"/>
-    public override VisualElement<TDrawingContext> GetMiniature()
+    public override VisualElement<TDrawingContext> GetMiniature(int zindex = 0)
     {
         return new GeometryVisual<TVisual, TLabel, TDrawingContext>
         {
-            Fill = Fill,
-            Stroke = Stroke,
+            Fill = Fill.Clone(zindex),
+            Stroke = Stroke.Clone(zindex),
             Width = MiniatureShapeSize,
             Height = MiniatureShapeSize,
         };

--- a/src/LiveChartsCore/CoreLineSeries.cs
+++ b/src/LiveChartsCore/CoreLineSeries.cs
@@ -549,7 +549,7 @@ public class CoreLineSeries<TModel, TVisual, TLabel, TDrawingContext, TPathGeome
         return new GeometryVisual<TVisual, TLabel, TDrawingContext>
         {
             Fill = Fill.Clone(zindex),
-            Stroke = Stroke.Clone(zindex),
+            Stroke = Stroke.Clone(zindex + 1),
             Width = MiniatureShapeSize,
             Height = MiniatureShapeSize,
         };

--- a/src/LiveChartsCore/CoreLineSeries.cs
+++ b/src/LiveChartsCore/CoreLineSeries.cs
@@ -29,6 +29,7 @@ using LiveChartsCore.Kernel;
 using LiveChartsCore.Kernel.Drawing;
 using LiveChartsCore.Kernel.Sketches;
 using LiveChartsCore.Measure;
+using LiveChartsCore.VisualElements;
 
 namespace LiveChartsCore;
 
@@ -539,6 +540,18 @@ public class CoreLineSeries<TModel, TVisual, TLabel, TDrawingContext, TPathGeome
         return new Sketch<TDrawingContext>(MiniatureShapeSize, MiniatureShapeSize, GeometrySvg)
         {
             PaintSchedules = schedules
+        };
+    }
+
+    /// <inheritdoc cref="Series{TModel, TVisual, TLabel, TDrawingContext}.GetMiniature"/>"/>
+    public override VisualElement<TDrawingContext> GetMiniature()
+    {
+        return new GeometryVisual<TVisual, TLabel, TDrawingContext>
+        {
+            Fill = Fill,
+            Stroke = Stroke,
+            Width = MiniatureShapeSize,
+            Height = MiniatureShapeSize,
         };
     }
 

--- a/src/LiveChartsCore/CoreLineSeries.cs
+++ b/src/LiveChartsCore/CoreLineSeries.cs
@@ -525,6 +525,7 @@ public class CoreLineSeries<TModel, TVisual, TLabel, TDrawingContext, TPathGeome
     }
 
     /// <inheritdoc cref="Series{TModel, TVisual, TLabel, TDrawingContext}.GetMiniaturesSketch"/>
+    [Obsolete]
     public override Sketch<TDrawingContext> GetMiniaturesSketch()
     {
         var schedules = new List<PaintSchedule<TDrawingContext>>();

--- a/src/LiveChartsCore/CoreLineSeries.cs
+++ b/src/LiveChartsCore/CoreLineSeries.cs
@@ -546,13 +546,22 @@ public class CoreLineSeries<TModel, TVisual, TLabel, TDrawingContext, TPathGeome
     /// <inheritdoc cref="Series{TModel, TVisual, TLabel, TDrawingContext}.GetMiniature"/>"/>
     public override VisualElement<TDrawingContext> GetMiniature(int zindex = 0)
     {
-        return new GeometryVisual<TVisual, TLabel, TDrawingContext>
-        {
-            Fill = Fill.Clone(zindex),
-            Stroke = Stroke.Clone(zindex + 1),
-            Width = MiniatureShapeSize,
-            Height = MiniatureShapeSize,
-        };
+        var usesLine = GeometrySize < 1 || GeometryStroke is null;
+
+        return usesLine
+            ? new LineVisual<TErrorGeometry, TDrawingContext>
+            {
+                Stroke = Stroke.Clone(zindex + 1),
+                Width = MiniatureShapeSize,
+                Height = 0
+            }
+            : new GeometryVisual<TVisual, TLabel, TDrawingContext>
+            {
+                Fill = Fill.Clone(zindex),
+                Stroke = Stroke.Clone(zindex + 1),
+                Width = MiniatureShapeSize,
+                Height = MiniatureShapeSize,
+            };
     }
 
     /// <inheritdoc cref="Series{TModel, TVisual, TLabel, TDrawingContext}.SoftDeleteOrDispose(IChartView)"/>

--- a/src/LiveChartsCore/CorePieSeries.cs
+++ b/src/LiveChartsCore/CorePieSeries.cs
@@ -28,6 +28,7 @@ using LiveChartsCore.Kernel;
 using LiveChartsCore.Kernel.Drawing;
 using LiveChartsCore.Kernel.Sketches;
 using LiveChartsCore.Measure;
+using LiveChartsCore.VisualElements;
 
 namespace LiveChartsCore;
 
@@ -464,6 +465,18 @@ public abstract class CorePieSeries<TModel, TVisual, TLabel, TMiniatureGeometry,
         return new Sketch<TDrawingContext>(MiniatureShapeSize, MiniatureShapeSize, GeometrySvg)
         {
             PaintSchedules = schedules
+        };
+    }
+
+    /// <inheritdoc cref="Series{TModel, TVisual, TLabel, TDrawingContext}.GetMiniature"/>"/>
+    public override VisualElement<TDrawingContext> GetMiniature()
+    {
+        return new GeometryVisual<TMiniatureGeometry, TLabel, TDrawingContext>
+        {
+            Fill = Fill,
+            Stroke = Stroke,
+            Width = MiniatureShapeSize,
+            Height = MiniatureShapeSize,
         };
     }
 

--- a/src/LiveChartsCore/CorePieSeries.cs
+++ b/src/LiveChartsCore/CorePieSeries.cs
@@ -474,7 +474,7 @@ public abstract class CorePieSeries<TModel, TVisual, TLabel, TMiniatureGeometry,
         return new GeometryVisual<TMiniatureGeometry, TLabel, TDrawingContext>
         {
             Fill = Fill.Clone(zindex),
-            Stroke = Stroke.Clone(zindex),
+            Stroke = Stroke.Clone(zindex + 1),
             Width = MiniatureShapeSize,
             Height = MiniatureShapeSize,
         };

--- a/src/LiveChartsCore/CorePieSeries.cs
+++ b/src/LiveChartsCore/CorePieSeries.cs
@@ -469,12 +469,12 @@ public abstract class CorePieSeries<TModel, TVisual, TLabel, TMiniatureGeometry,
     }
 
     /// <inheritdoc cref="Series{TModel, TVisual, TLabel, TDrawingContext}.GetMiniature"/>"/>
-    public override VisualElement<TDrawingContext> GetMiniature()
+    public override VisualElement<TDrawingContext> GetMiniature(int zindex = 0)
     {
         return new GeometryVisual<TMiniatureGeometry, TLabel, TDrawingContext>
         {
-            Fill = Fill,
-            Stroke = Stroke,
+            Fill = Fill.Clone(zindex),
+            Stroke = Stroke.Clone(zindex),
             Width = MiniatureShapeSize,
             Height = MiniatureShapeSize,
         };

--- a/src/LiveChartsCore/CorePieSeries.cs
+++ b/src/LiveChartsCore/CorePieSeries.cs
@@ -453,6 +453,7 @@ public abstract class CorePieSeries<TModel, TVisual, TLabel, TMiniatureGeometry,
     }
 
     /// <inheritdoc cref="Series{TModel, TVisual, TLabel, TDrawingContext}.GetMiniaturesSketch"/>
+    [Obsolete]
     public override Sketch<TDrawingContext> GetMiniaturesSketch()
     {
         var schedules = new List<PaintSchedule<TDrawingContext>>();

--- a/src/LiveChartsCore/CorePolarLineSeries.cs
+++ b/src/LiveChartsCore/CorePolarLineSeries.cs
@@ -529,12 +529,12 @@ public class CorePolarLineSeries<TModel, TVisual, TLabel, TDrawingContext, TPath
     }
 
     /// <inheritdoc cref="Series{TModel, TVisual, TLabel, TDrawingContext}.GetMiniature"/>"/>
-    public override VisualElement<TDrawingContext> GetMiniature()
+    public override VisualElement<TDrawingContext> GetMiniature(int zindex = 0)
     {
         return new GeometryVisual<TVisual, TLabel, TDrawingContext>
         {
-            Fill = Fill,
-            Stroke = Stroke,
+            Fill = Fill.Clone(zindex),
+            Stroke = Stroke.Clone(zindex),
             Width = MiniatureShapeSize,
             Height = MiniatureShapeSize,
         };

--- a/src/LiveChartsCore/CorePolarLineSeries.cs
+++ b/src/LiveChartsCore/CorePolarLineSeries.cs
@@ -534,7 +534,7 @@ public class CorePolarLineSeries<TModel, TVisual, TLabel, TDrawingContext, TPath
         return new GeometryVisual<TVisual, TLabel, TDrawingContext>
         {
             Fill = Fill.Clone(zindex),
-            Stroke = Stroke.Clone(zindex),
+            Stroke = Stroke.Clone(zindex + 1),
             Width = MiniatureShapeSize,
             Height = MiniatureShapeSize,
         };

--- a/src/LiveChartsCore/CorePolarLineSeries.cs
+++ b/src/LiveChartsCore/CorePolarLineSeries.cs
@@ -29,6 +29,7 @@ using LiveChartsCore.Kernel;
 using LiveChartsCore.Kernel.Drawing;
 using LiveChartsCore.Kernel.Sketches;
 using LiveChartsCore.Measure;
+using LiveChartsCore.VisualElements;
 
 namespace LiveChartsCore;
 
@@ -524,6 +525,18 @@ public class CorePolarLineSeries<TModel, TVisual, TLabel, TDrawingContext, TPath
         return new Sketch<TDrawingContext>(MiniatureShapeSize, MiniatureShapeSize, GeometrySvg)
         {
             PaintSchedules = schedules
+        };
+    }
+
+    /// <inheritdoc cref="Series{TModel, TVisual, TLabel, TDrawingContext}.GetMiniature"/>"/>
+    public override VisualElement<TDrawingContext> GetMiniature()
+    {
+        return new GeometryVisual<TVisual, TLabel, TDrawingContext>
+        {
+            Fill = Fill,
+            Stroke = Stroke,
+            Width = MiniatureShapeSize,
+            Height = MiniatureShapeSize,
         };
     }
 

--- a/src/LiveChartsCore/CorePolarLineSeries.cs
+++ b/src/LiveChartsCore/CorePolarLineSeries.cs
@@ -510,6 +510,7 @@ public class CorePolarLineSeries<TModel, TVisual, TLabel, TDrawingContext, TPath
     }
 
     /// <inheritdoc cref="Series{TModel, TVisual, TLabel, TDrawingContext}.GetMiniaturesSketch"/>
+    [Obsolete]
     public override Sketch<TDrawingContext> GetMiniaturesSketch()
     {
         var schedules = new List<PaintSchedule<TDrawingContext>>();

--- a/src/LiveChartsCore/CoreScatterSeries.cs
+++ b/src/LiveChartsCore/CoreScatterSeries.cs
@@ -340,12 +340,12 @@ public class CoreScatterSeries<TModel, TVisual, TLabel, TDrawingContext, TErrorG
     }
 
     /// <inheritdoc cref="Series{TModel, TVisual, TLabel, TDrawingContext}.GetMiniature"/>"/>
-    public override VisualElement<TDrawingContext> GetMiniature()
+    public override VisualElement<TDrawingContext> GetMiniature(int zindex = 0)
     {
         return new GeometryVisual<TVisual, TLabel, TDrawingContext>
         {
-            Fill = Fill,
-            Stroke = Stroke,
+            Fill = Fill.Clone(zindex),
+            Stroke = Stroke.Clone(zindex),
             Width = MiniatureShapeSize,
             Height = MiniatureShapeSize,
         };

--- a/src/LiveChartsCore/CoreScatterSeries.cs
+++ b/src/LiveChartsCore/CoreScatterSeries.cs
@@ -324,6 +324,7 @@ public class CoreScatterSeries<TModel, TVisual, TLabel, TDrawingContext, TErrorG
     }
 
     /// <inheritdoc cref="Series{TModel, TVisual, TLabel, TDrawingContext}.GetMiniaturesSketch"/>
+    [Obsolete]
     public override Sketch<TDrawingContext> GetMiniaturesSketch()
     {
         var schedules = new List<PaintSchedule<TDrawingContext>>();

--- a/src/LiveChartsCore/CoreScatterSeries.cs
+++ b/src/LiveChartsCore/CoreScatterSeries.cs
@@ -27,6 +27,7 @@ using LiveChartsCore.Kernel;
 using LiveChartsCore.Kernel.Drawing;
 using LiveChartsCore.Kernel.Sketches;
 using LiveChartsCore.Measure;
+using LiveChartsCore.VisualElements;
 
 namespace LiveChartsCore;
 
@@ -335,6 +336,18 @@ public class CoreScatterSeries<TModel, TVisual, TLabel, TDrawingContext, TErrorG
         return new Sketch<TDrawingContext>(MiniatureShapeSize, MiniatureShapeSize, GeometrySvg)
         {
             PaintSchedules = schedules
+        };
+    }
+
+    /// <inheritdoc cref="Series{TModel, TVisual, TLabel, TDrawingContext}.GetMiniature"/>"/>
+    public override VisualElement<TDrawingContext> GetMiniature()
+    {
+        return new GeometryVisual<TVisual, TLabel, TDrawingContext>
+        {
+            Fill = Fill,
+            Stroke = Stroke,
+            Width = MiniatureShapeSize,
+            Height = MiniatureShapeSize,
         };
     }
 

--- a/src/LiveChartsCore/CoreScatterSeries.cs
+++ b/src/LiveChartsCore/CoreScatterSeries.cs
@@ -345,7 +345,7 @@ public class CoreScatterSeries<TModel, TVisual, TLabel, TDrawingContext, TErrorG
         return new GeometryVisual<TVisual, TLabel, TDrawingContext>
         {
             Fill = Fill.Clone(zindex),
-            Stroke = Stroke.Clone(zindex),
+            Stroke = Stroke.Clone(zindex + 1),
             Width = MiniatureShapeSize,
             Height = MiniatureShapeSize,
         };

--- a/src/LiveChartsCore/CoreStepLineSeries.cs
+++ b/src/LiveChartsCore/CoreStepLineSeries.cs
@@ -451,12 +451,12 @@ public class CoreStepLineSeries<TModel, TVisual, TLabel, TDrawingContext, TPathG
     }
 
     /// <inheritdoc cref="Series{TModel, TVisual, TLabel, TDrawingContext}.GetMiniature"/>"/>
-    public override VisualElement<TDrawingContext> GetMiniature()
+    public override VisualElement<TDrawingContext> GetMiniature(int zindex = 0)
     {
         return new GeometryVisual<TVisual, TLabel, TDrawingContext>
         {
-            Fill = Fill,
-            Stroke = Stroke,
+            Fill = Fill.Clone(zindex),
+            Stroke = Stroke.Clone(zindex),
             Width = MiniatureShapeSize,
             Height = MiniatureShapeSize,
         };

--- a/src/LiveChartsCore/CoreStepLineSeries.cs
+++ b/src/LiveChartsCore/CoreStepLineSeries.cs
@@ -30,6 +30,7 @@ using LiveChartsCore.Kernel;
 using LiveChartsCore.Kernel.Drawing;
 using LiveChartsCore.Kernel.Sketches;
 using LiveChartsCore.Measure;
+using LiveChartsCore.VisualElements;
 
 namespace LiveChartsCore;
 
@@ -446,6 +447,18 @@ public class CoreStepLineSeries<TModel, TVisual, TLabel, TDrawingContext, TPathG
         return new Sketch<TDrawingContext>(MiniatureShapeSize, MiniatureShapeSize, GeometrySvg)
         {
             PaintSchedules = schedules
+        };
+    }
+
+    /// <inheritdoc cref="Series{TModel, TVisual, TLabel, TDrawingContext}.GetMiniature"/>"/>
+    public override VisualElement<TDrawingContext> GetMiniature()
+    {
+        return new GeometryVisual<TVisual, TLabel, TDrawingContext>
+        {
+            Fill = Fill,
+            Stroke = Stroke,
+            Width = MiniatureShapeSize,
+            Height = MiniatureShapeSize,
         };
     }
 

--- a/src/LiveChartsCore/CoreStepLineSeries.cs
+++ b/src/LiveChartsCore/CoreStepLineSeries.cs
@@ -432,6 +432,7 @@ public class CoreStepLineSeries<TModel, TVisual, TLabel, TDrawingContext, TPathG
     }
 
     /// <inheritdoc cref="Series{TModel, TVisual, TLabel, TDrawingContext}.GetMiniaturesSketch"/>
+    [Obsolete]
     public override Sketch<TDrawingContext> GetMiniaturesSketch()
     {
         var schedules = new List<PaintSchedule<TDrawingContext>>();

--- a/src/LiveChartsCore/CoreStepLineSeries.cs
+++ b/src/LiveChartsCore/CoreStepLineSeries.cs
@@ -456,7 +456,7 @@ public class CoreStepLineSeries<TModel, TVisual, TLabel, TDrawingContext, TPathG
         return new GeometryVisual<TVisual, TLabel, TDrawingContext>
         {
             Fill = Fill.Clone(zindex),
-            Stroke = Stroke.Clone(zindex),
+            Stroke = Stroke.Clone(zindex + 1),
             Width = MiniatureShapeSize,
             Height = MiniatureShapeSize,
         };

--- a/src/LiveChartsCore/Kernel/Extensions.cs
+++ b/src/LiveChartsCore/Kernel/Extensions.cs
@@ -600,6 +600,24 @@ public static class Extensions
     }
 
     /// <summary>
+    /// Clones the paint and sets the given zindex.
+    /// </summary>
+    /// <typeparam name="TDrawingContext">The drawing context.</typeparam>
+    /// <param name="paint">the paint.</param>
+    /// <param name="zIndex">the z index.</param>
+    /// <returns>A paint clone.</returns>
+    public static IPaint<TDrawingContext>? Clone<TDrawingContext>(this IPaint<TDrawingContext>? paint, int zIndex)
+        where TDrawingContext : DrawingContext
+    {
+        if (paint is null) return null;
+
+        var clone = paint.CloneTask();
+        clone.ZIndex = zIndex;
+
+        return clone;
+    }
+
+    /// <summary>
     /// Returns an enumeration with only the first element.
     /// </summary>
     /// <typeparam name="T">The source type.</typeparam>

--- a/src/LiveChartsCore/Kernel/Sketches/IChartSeries.cs
+++ b/src/LiveChartsCore/Kernel/Sketches/IChartSeries.cs
@@ -100,8 +100,9 @@ public interface IChartSeries<TDrawingContext> : ISeries, IChartElement<TDrawing
     /// <summary>
     /// Return the visual element shown in tooltips and legends.
     /// </summary>
+    /// <param name="zindex">The zindex.</param>
     /// <returns></returns>
-    VisualElement<TDrawingContext> GetMiniature();
+    VisualElement<TDrawingContext> GetMiniature(int zindex = 0);
 
     /// <summary>
     /// Called when the pointer goes down on a data point or points.

--- a/src/LiveChartsCore/Kernel/Sketches/IChartSeries.cs
+++ b/src/LiveChartsCore/Kernel/Sketches/IChartSeries.cs
@@ -20,9 +20,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using System;
 using System.Collections.Generic;
 using LiveChartsCore.Drawing;
 using LiveChartsCore.Kernel.Drawing;
+using LiveChartsCore.VisualElements;
 
 namespace LiveChartsCore.Kernel.Sketches;
 
@@ -80,6 +82,7 @@ public interface IChartSeries<TDrawingContext> : ISeries, IChartElement<TDrawing
     /// <value>
     /// The default paint context.
     /// </value>
+    [Obsolete($"Replaced by ${nameof(GetMiniature)}")]
     Sketch<TDrawingContext> CanvasSchedule { get; }
 
     /// <summary>
@@ -89,10 +92,16 @@ public interface IChartSeries<TDrawingContext> : ISeries, IChartElement<TDrawing
     int GetStackGroup();
 
     /// <summary>
-    /// 
     /// </summary>
     /// <returns></returns>
+    [Obsolete($"Replaced by ${nameof(GetMiniature)}")]
     Sketch<TDrawingContext> GetMiniaturesSketch();
+
+    /// <summary>
+    /// Return the visual element shown in tooltips and legends.
+    /// </summary>
+    /// <returns></returns>
+    VisualElement<TDrawingContext> GetMiniature();
 
     /// <summary>
     /// Called when the pointer goes down on a data point or points.

--- a/src/LiveChartsCore/Series.cs
+++ b/src/LiveChartsCore/Series.cs
@@ -34,6 +34,7 @@ using LiveChartsCore.Kernel.Events;
 using LiveChartsCore.Kernel.Providers;
 using LiveChartsCore.Kernel.Sketches;
 using LiveChartsCore.Measure;
+using LiveChartsCore.VisualElements;
 namespace LiveChartsCore;
 
 /// <summary>
@@ -289,6 +290,7 @@ public abstract class Series<TModel, TVisual, TLabel, TDrawingContext>
     }
 
     /// <inheritdoc cref="IChartSeries{TDrawingContext}.CanvasSchedule"/>
+    [Obsolete($"Replaced by ${nameof(GetMiniature)}")]
     public Sketch<TDrawingContext> CanvasSchedule
     {
         get => _miniatureSketch;
@@ -394,6 +396,9 @@ public abstract class Series<TModel, TVisual, TLabel, TDrawingContext>
 
     /// <inheritdoc cref="IChartSeries{TDrawingContext}.GetMiniaturesSketch"/>
     public abstract Sketch<TDrawingContext> GetMiniaturesSketch();
+
+    /// <inheritdoc cref="IChartSeries{TDrawingContext}.GetMiniature"/>
+    public abstract VisualElement<TDrawingContext> GetMiniature();
 
     /// <summary>
     /// Builds a paint schedule.

--- a/src/LiveChartsCore/Series.cs
+++ b/src/LiveChartsCore/Series.cs
@@ -399,7 +399,7 @@ public abstract class Series<TModel, TVisual, TLabel, TDrawingContext>
     public abstract Sketch<TDrawingContext> GetMiniaturesSketch();
 
     /// <inheritdoc cref="IChartSeries{TDrawingContext}.GetMiniature"/>
-    public abstract VisualElement<TDrawingContext> GetMiniature();
+    public abstract VisualElement<TDrawingContext> GetMiniature(int zindex = 0);
 
     /// <summary>
     /// Builds a paint schedule.

--- a/src/LiveChartsCore/Series.cs
+++ b/src/LiveChartsCore/Series.cs
@@ -395,6 +395,7 @@ public abstract class Series<TModel, TVisual, TLabel, TDrawingContext>
     public abstract void SoftDeleteOrDispose(IChartView chart);
 
     /// <inheritdoc cref="IChartSeries{TDrawingContext}.GetMiniaturesSketch"/>
+    [Obsolete($"Replaced by ${nameof(GetMiniature)}")]
     public abstract Sketch<TDrawingContext> GetMiniaturesSketch();
 
     /// <inheritdoc cref="IChartSeries{TDrawingContext}.GetMiniature"/>

--- a/src/LiveChartsCore/VisualElements/LineVisual.cs
+++ b/src/LiveChartsCore/VisualElements/LineVisual.cs
@@ -1,0 +1,112 @@
+﻿// The MIT License(MIT)
+//
+// Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
+using LiveChartsCore.Drawing;
+using LiveChartsCore.Kernel;
+using LiveChartsCore.Measure;
+
+namespace LiveChartsCore.VisualElements;
+
+/// <summary>
+/// Defines a visual element in a chart that draws a sized geometry in the user interface.
+/// </summary>
+/// <typeparam name="TGeometry">The type of the geometry.</typeparam>
+/// <typeparam name="TDrawingContext">The type of the drawing context.</typeparam>
+public class LineVisual<TGeometry, TDrawingContext> : BaseGeometryVisual<TDrawingContext>
+    where TDrawingContext : DrawingContext
+    where TGeometry : ILineGeometry<TDrawingContext>, new()
+{
+    internal TGeometry? _geometry;
+
+    /// <inheritdoc cref="ChartElement{TDrawingContext}.GetPaintTasks"/>
+    protected internal override IAnimatable?[] GetDrawnGeometries() => [_geometry];
+
+    /// <inheritdoc cref="VisualElement{TDrawingContext}.OnInvalidated(Chart{TDrawingContext})"/>
+    protected internal override void OnInvalidated(Chart<TDrawingContext> chart)
+    {
+        var l = GetActualCoordinate();
+        var size = Measure(chart);
+        var clipping = Clipping.GetClipRectangle(ClippingMode, chart);
+
+        if (_geometry is null)
+        {
+            _geometry = new()
+            {
+                X = l.X,
+                Y = l.Y,
+                X1 = l.X + size.Width,
+                Y1 = l.Y + size.Height
+            };
+            _geometry.Animate(chart);
+        }
+
+        _geometry.X = l.X;
+        _geometry.Y = l.Y;
+        _geometry.X1 = l.X + size.Width;
+        _geometry.Y1 = l.Y + size.Height;
+        _geometry.RotateTransform = (float)Rotation;
+        _geometry.TranslateTransform = Translate;
+
+        if (Fill is not null)
+        {
+            chart.Canvas.AddDrawableTask(Fill);
+            Fill.AddGeometryToPaintTask(chart.Canvas, _geometry);
+            Fill.SetClipRectangle(chart.Canvas, clipping);
+        }
+
+        if (Stroke is not null)
+        {
+            chart.Canvas.AddDrawableTask(Stroke);
+            Stroke.AddGeometryToPaintTask(chart.Canvas, _geometry);
+            Stroke.SetClipRectangle(chart.Canvas, clipping);
+        }
+    }
+
+    /// <inheritdoc cref="VisualElement{TDrawingContext}.SetParent(IGeometry{TDrawingContext})"/>
+    protected internal override void SetParent(IGeometry<TDrawingContext> parent)
+    {
+        if (_geometry is null) return;
+        _geometry.Parent = parent;
+    }
+
+    /// <inheritdoc cref="VisualElement{TDrawingContext}.Measure(Chart{TDrawingContext})"/>
+    public override LvcSize Measure(Chart<TDrawingContext> chart)
+    {
+        var w = (float)Width;
+        var h = (float)Height;
+
+        if (SizeUnit == MeasureUnit.ChartValues)
+        {
+            if (PrimaryScaler is null || SecondaryScaler is null)
+                throw new Exception($"You can not use {MeasureUnit.ChartValues} scale at this element.");
+
+            w = SecondaryScaler.MeasureInPixels(w);
+            h = PrimaryScaler.MeasureInPixels(h);
+        }
+
+        return new LvcSize(w, h);
+    }
+
+    /// <inheritdoc cref="ChartElement{TDrawingContext}.GetPaintTasks"/>
+    protected internal override IPaint<TDrawingContext>?[] GetPaintTasks() => [Fill, Stroke];
+}

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/Geometries/LineGeometry.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/Geometries/LineGeometry.cs
@@ -43,10 +43,22 @@ public class LineGeometry : Geometry, ILineGeometry<SkiaSharpDrawingContext>
     }
 
     /// <inheritdoc cref="ILineGeometry{TDrawingContext}.X1" />
-    public float X1 { get => _x1.GetMovement(this); set => _x1.SetMovement(value, this); }
+    public float X1
+    {
+        get => Parent is null
+            ? _x1.GetMovement(this)
+            : _x1.GetMovement(this) + Parent.X;
+        set => _x1.SetMovement(value, this);
+    }
 
     /// <inheritdoc cref="ILineGeometry{TDrawingContext}.Y1" />
-    public float Y1 { get => _y1.GetMovement(this); set => _y1.SetMovement(value, this); }
+    public float Y1
+    {
+        get => Parent is null
+            ? _y1.GetMovement(this)
+            : _y1.GetMovement(this) + Parent.Y;
+        set => _y1.SetMovement(value, this);
+    }
 
     /// <inheritdoc cref="Geometry.OnDraw(SkiaSharpDrawingContext, SKPaint)" />
     public override void OnDraw(SkiaSharpDrawingContext context, SKPaint paint)

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/SKCharts/SKDefaultLegend.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/SKCharts/SKDefaultLegend.cs
@@ -143,7 +143,7 @@ public class SKDefaultLegend : IChartLegend<SkiaSharpDrawingContext>
                 HorizontalAlignment = Align.Middle,
                 Children =
                 {
-                    series.GetMiniaturesSketch().AsDrawnControl(s_zIndex),
+                    series.GetMiniature(s_zIndex),
                     new LabelVisual
                     {
                         Text = series.Name ?? string.Empty,

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/SKCharts/SKDefaultTooltip.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/SKCharts/SKDefaultTooltip.cs
@@ -163,7 +163,7 @@ public class SKDefaultTooltip : IChartTooltip<SkiaSharpDrawingContext>
 
             if (content != LiveCharts.IgnoreToolTipLabel)
             {
-                tableLayout.AddChild(series.GetMiniaturesSketch().AsDrawnControl(s_zIndex), i, ltr ? 3 : 0);
+                tableLayout.AddChild(series.GetMiniature(s_zIndex), i, ltr ? 3 : 0);
 
                 if (point.Context.Series.Name != LiveCharts.IgnoreSeriesName)
                     tableLayout.AddChild(


### PR DESCRIPTION
The shape of the series shown in legends/tooltips uses an old api, now the library has better ways to handle that.

This PR updates the library and uses `VisualElements` to define the shapes in the miniature geommetry in tooltips/legends.

It also fixes:

- fixes #1331

That issue has caused confusion in the library, like #1507, #913