### PR TITLE
Update values type

### DIFF
--- a/samples/ViewModelsSamples/Bars/Race/ViewModel.cs
+++ b/samples/ViewModelsSamples/Bars/Race/ViewModel.cs
@@ -106,5 +106,5 @@ public partial class ViewModel : ObservableObject
         }
     }
 
-    private ICollection<PilotInfo> SortData() => [.. _data.OrderBy(x => x.Value)];
+    private PilotInfo[] SortData() => [.. _data.OrderBy(x => x.Value)];
 }

--- a/src/LiveChartsCore/BarSeries.cs
+++ b/src/LiveChartsCore/BarSeries.cs
@@ -47,7 +47,7 @@ namespace LiveChartsCore;
 /// <param name="values">The values.</param>
 public abstract class BarSeries<TModel, TVisual, TLabel, TDrawingContext>(
     SeriesProperties properties,
-    ICollection<TModel>? values)
+    IReadOnlyCollection<TModel>? values)
         : StrokeAndFillCartesianSeries<TModel, TVisual, TLabel, TDrawingContext>(properties, values), IBarSeries<TDrawingContext>
             where TVisual : class, ISizedGeometry<TDrawingContext>, new()
             where TDrawingContext : DrawingContext

--- a/src/LiveChartsCore/CartesianSeries.cs
+++ b/src/LiveChartsCore/CartesianSeries.cs
@@ -46,7 +46,7 @@ namespace LiveChartsCore;
 /// <param name="values">The values.</param>
 public abstract class CartesianSeries<TModel, TVisual, TLabel, TDrawingContext>(
     SeriesProperties properties,
-    ICollection<TModel>? values)
+    IReadOnlyCollection<TModel>? values)
         : ChartSeries<TModel, TVisual, TLabel, TDrawingContext>(properties, values), ICartesianSeries<TDrawingContext>
             where TDrawingContext : DrawingContext
             where TVisual : class, IGeometry<TDrawingContext>, new()

--- a/src/LiveChartsCore/ChartSeries.cs
+++ b/src/LiveChartsCore/ChartSeries.cs
@@ -43,7 +43,7 @@ namespace LiveChartsCore;
 /// <param name="values">The values.</param>
 public abstract class ChartSeries<TModel, TVisual, TLabel, TDrawingContext>(
     SeriesProperties properties,
-    ICollection<TModel>? values)
+    IReadOnlyCollection<TModel>? values)
         : Series<TModel, TVisual, TLabel, TDrawingContext>(properties, values), IChartSeries<TDrawingContext>
             where TDrawingContext : DrawingContext
             where TVisual : class, IGeometry<TDrawingContext>, new()

--- a/src/LiveChartsCore/CoreBoxSeries.cs
+++ b/src/LiveChartsCore/CoreBoxSeries.cs
@@ -56,7 +56,7 @@ public abstract class CoreBoxSeries<TModel, TVisual, TLabel, TMiniatureGeometry,
     /// <summary>
     /// Initializes a new instance of the <see cref="CoreBoxSeries{TModel, TVisual, TLabel, TMiniatureGeometry, TDrawingContext}"/> class.
     /// </summary>
-    protected CoreBoxSeries(ICollection<TModel>? values)
+    protected CoreBoxSeries(IReadOnlyCollection<TModel>? values)
         : base(GetProperties(), values)
     {
         YToolTipLabelFormatter = p =>

--- a/src/LiveChartsCore/CoreColumnSeries.cs
+++ b/src/LiveChartsCore/CoreColumnSeries.cs
@@ -50,7 +50,7 @@ public abstract class CoreColumnSeries<TModel, TVisual, TLabel, TDrawingContext,
     /// <summary>
     /// Initializes a new instance of the <see cref="CoreColumnSeries{TModel, TVisual, TLabel, TDrawingContext, TErrorGeometry}"/> class.
     /// </summary>
-    protected CoreColumnSeries(ICollection<TModel>? values, bool isStacked = false)
+    protected CoreColumnSeries(IReadOnlyCollection<TModel>? values, bool isStacked = false)
         : base(GetProperties(isStacked), values)
     {
         DataPadding = new LvcPoint(0, 1);

--- a/src/LiveChartsCore/CoreFinancialSeries.cs
+++ b/src/LiveChartsCore/CoreFinancialSeries.cs
@@ -60,7 +60,7 @@ public abstract class CoreFinancialSeries<TModel, TVisual, TLabel, TMiniatureGeo
     /// <summary>
     /// Initializes a new instance of the <see cref="CoreFinancialSeries{TModel, TVisual, TLabel, TMiniatureGeometry, TDrawingContext}"/> class.
     /// </summary>
-    protected CoreFinancialSeries(ICollection<TModel>? values)
+    protected CoreFinancialSeries(IReadOnlyCollection<TModel>? values)
         : base(GetProperties(), values)
     {
         YToolTipLabelFormatter = p =>

--- a/src/LiveChartsCore/CoreHeatSeries.cs
+++ b/src/LiveChartsCore/CoreHeatSeries.cs
@@ -62,7 +62,7 @@ public abstract class CoreHeatSeries<TModel, TVisual, TLabel, TDrawingContext>
     /// Initializes a new instance of the <see cref="CoreHeatSeries{TModel, TVisual, TLabel, TDrawingContext}"/> class.
     /// </summary>
     /// <param name="values">The values.</param>
-    protected CoreHeatSeries(ICollection<TModel>? values)
+    protected CoreHeatSeries(IReadOnlyCollection<TModel>? values)
         : base(GetProperties(), values)
     {
         DataPadding = new LvcPoint(0, 0);

--- a/src/LiveChartsCore/CoreLineSeries.cs
+++ b/src/LiveChartsCore/CoreLineSeries.cs
@@ -66,7 +66,7 @@ public class CoreLineSeries<TModel, TVisual, TLabel, TDrawingContext, TPathGeome
     /// </summary>
     /// <param name="isStacked">if set to <c>true</c> [is stacked].</param>
     /// <param name="values">The values.</param>
-    public CoreLineSeries(ICollection<TModel>? values, bool isStacked = false)
+    public CoreLineSeries(IReadOnlyCollection<TModel>? values, bool isStacked = false)
         : base(GetProperties(isStacked), values)
     {
         DataPadding = new LvcPoint(0.5f, 1f);

--- a/src/LiveChartsCore/CorePieSeries.cs
+++ b/src/LiveChartsCore/CorePieSeries.cs
@@ -44,7 +44,7 @@ namespace LiveChartsCore;
 /// Initializes a new instance of the <see cref="CorePieSeries{TModel, TVisual, TLabel, TMiniatureGeometry, TDrawingContext}"/> class.
 /// </remarks>
 public abstract class CorePieSeries<TModel, TVisual, TLabel, TMiniatureGeometry, TDrawingContext>(
-    ICollection<TModel>? values,
+    IReadOnlyCollection<TModel>? values,
     bool isGauge = false,
     bool isGaugeFill = false)
         : ChartSeries<TModel, TVisual, TLabel, TDrawingContext>(GetProperties(isGauge, isGaugeFill), values), IPieSeries<TDrawingContext>

--- a/src/LiveChartsCore/CorePolarLineSeries.cs
+++ b/src/LiveChartsCore/CorePolarLineSeries.cs
@@ -71,7 +71,7 @@ public class CorePolarLineSeries<TModel, TVisual, TLabel, TDrawingContext, TPath
     /// </summary>
     /// <param name="isStacked">if set to <c>true</c> [is stacked].</param>
     /// <param name="values">The values.</param>
-    public CorePolarLineSeries(ICollection<TModel>? values, bool isStacked = false)
+    public CorePolarLineSeries(IReadOnlyCollection<TModel>? values, bool isStacked = false)
         : base(GetProperties(isStacked), values)
     {
         DataPadding = new LvcPoint(1f, 1.5f);

--- a/src/LiveChartsCore/CoreRowSeries.cs
+++ b/src/LiveChartsCore/CoreRowSeries.cs
@@ -53,7 +53,7 @@ public class CoreRowSeries<TModel, TVisual, TLabel, TDrawingContext, TErrorGeome
     /// </summary>
     /// <param name="isStacked">if set to <c>true</c> [is stacked].</param>
     /// <param name="values">The values.</param>
-    public CoreRowSeries(ICollection<TModel>? values, bool isStacked = false)
+    public CoreRowSeries(IReadOnlyCollection<TModel>? values, bool isStacked = false)
         : base(GetProperties(isStacked), values)
     {
         DataPadding = new LvcPoint(1, 0);

--- a/src/LiveChartsCore/CoreScatterSeries.cs
+++ b/src/LiveChartsCore/CoreScatterSeries.cs
@@ -57,7 +57,7 @@ public class CoreScatterSeries<TModel, TVisual, TLabel, TDrawingContext, TErrorG
     /// Initializes a new instance of the <see cref="CoreScatterSeries{TModel, TVisual, TLabel, TDrawingContext, TErrorGeometry}"/> class.
     /// </summary>
     /// <param name="values">The values.</param>
-    public CoreScatterSeries(ICollection<TModel>? values)
+    public CoreScatterSeries(IReadOnlyCollection<TModel>? values)
         : base(GetProperties(), values)
     {
         DataPadding = new LvcPoint(1, 1);

--- a/src/LiveChartsCore/CoreStackedAreaSeries.cs
+++ b/src/LiveChartsCore/CoreStackedAreaSeries.cs
@@ -48,7 +48,7 @@ public class CoreStackedAreaSeries<TModel, TVisual, TLabel, TDrawingContext, TPa
     /// Initializes a new instance of the <see cref="CoreStackedAreaSeries{TModel, TVisual, TLabel, TDrawingContext, TPathGeometry, TBezierVisual}"/> class.
     /// </summary>
     /// <param name="values">The values.</param>
-    public CoreStackedAreaSeries(ICollection<TModel>? values)
+    public CoreStackedAreaSeries(IReadOnlyCollection<TModel>? values)
         : base(values, true)
     {
         GeometryFill = null;

--- a/src/LiveChartsCore/CoreStackedColumnSeries.cs
+++ b/src/LiveChartsCore/CoreStackedColumnSeries.cs
@@ -39,7 +39,7 @@ namespace LiveChartsCore;
 /// Initializes a new instance of the <see cref="CoreStackedColumnSeries{TModel, TVisual, TLabel, TDrawingContext, TErrorGeometry}"/> class.
 /// </remarks>
 /// <param name="values">The values.</param>
-public class CoreStackedColumnSeries<TModel, TVisual, TLabel, TDrawingContext, TErrorGeometry>(ICollection<TModel>? values)
+public class CoreStackedColumnSeries<TModel, TVisual, TLabel, TDrawingContext, TErrorGeometry>(IReadOnlyCollection<TModel>? values)
     : CoreColumnSeries<TModel, TVisual, TLabel, TDrawingContext, TErrorGeometry>(values, true), IStackedBarSeries<TDrawingContext>
         where TVisual : class, ISizedGeometry<TDrawingContext>, new()
         where TLabel : class, ILabelGeometry<TDrawingContext>, new()

--- a/src/LiveChartsCore/CoreStackedRowSeries.cs
+++ b/src/LiveChartsCore/CoreStackedRowSeries.cs
@@ -38,7 +38,7 @@ namespace LiveChartsCore;
 /// Initializes a new instance of the <see cref="CoreStackedRowSeries{TModel, TVisual, TLabel, TDrawingContext, TErrorGeometry}"/> class.
 /// </remarks>
 /// <param name="values">The values.</param>
-public class CoreStackedRowSeries<TModel, TVisual, TLabel, TDrawingContext, TErrorGeometry>(ICollection<TModel>? values)
+public class CoreStackedRowSeries<TModel, TVisual, TLabel, TDrawingContext, TErrorGeometry>(IReadOnlyCollection<TModel>? values)
     : CoreRowSeries<TModel, TVisual, TLabel, TDrawingContext, TErrorGeometry>(values, true), IStackedBarSeries<TDrawingContext>
         where TVisual : class, ISizedGeometry<TDrawingContext>, new()
         where TLabel : class, ILabelGeometry<TDrawingContext>, new()

--- a/src/LiveChartsCore/CoreStackedStepAreaSeries.cs
+++ b/src/LiveChartsCore/CoreStackedStepAreaSeries.cs
@@ -48,7 +48,7 @@ public class CoreStackedStepAreaSeries<TModel, TVisual, TLabel, TDrawingContext,
     /// Initializes a new instance of the <see cref="CoreStackedAreaSeries{TModel, TVisual, TLabel, TDrawingContext, TPathGeometry, TVisualPoint}"/> class.
     /// </summary>
     /// <param name="values">The values.</param>
-    public CoreStackedStepAreaSeries(ICollection<TModel>? values)
+    public CoreStackedStepAreaSeries(IReadOnlyCollection<TModel>? values)
         : base(values, true)
     {
         GeometryFill = null;

--- a/src/LiveChartsCore/CoreStepLineSeries.cs
+++ b/src/LiveChartsCore/CoreStepLineSeries.cs
@@ -63,7 +63,7 @@ public class CoreStepLineSeries<TModel, TVisual, TLabel, TDrawingContext, TPathG
     /// </summary>
     /// <param name="isStacked">if set to <c>true</c> [is stacked].</param>
     /// <param name="values">The values.</param>
-    public CoreStepLineSeries(ICollection<TModel>? values, bool isStacked = false)
+    public CoreStepLineSeries(IReadOnlyCollection<TModel>? values, bool isStacked = false)
         : base(GetProperties(isStacked), values)
     {
         DataPadding = new LvcPoint(0.5f, 1f);

--- a/src/LiveChartsCore/ISeries.cs
+++ b/src/LiveChartsCore/ISeries.cs
@@ -209,7 +209,7 @@ public interface ISeries<TModel> : ISeries
     /// <value>
     /// The values.
     /// </value>
-    new ICollection<TModel>? Values { get; set; }
+    new IReadOnlyCollection<TModel>? Values { get; set; }
 
     /// <summary>
     /// Gets or sets the mapping.

--- a/src/LiveChartsCore/Series.cs
+++ b/src/LiveChartsCore/Series.cs
@@ -95,7 +95,7 @@ public abstract class Series<TModel, TVisual, TLabel, TDrawingContext>
     protected bool _geometrySvgChanged = false;
 
     private readonly CollectionDeepObserver<TModel> _observer;
-    private ICollection<TModel>? _values;
+    private IReadOnlyCollection<TModel>? _values;
     private string? _name;
     private Func<TModel, int, Coordinate>? _mapping;
     private int _zIndex;
@@ -114,7 +114,7 @@ public abstract class Series<TModel, TVisual, TLabel, TDrawingContext>
     /// </summary>
     /// <param name="properties">The properties.</param>
     /// <param name="values">The values.</param>
-    protected Series(SeriesProperties properties, ICollection<TModel>? values)
+    protected Series(SeriesProperties properties, IReadOnlyCollection<TModel>? values)
     {
         SeriesProperties = properties;
 
@@ -143,7 +143,7 @@ public abstract class Series<TModel, TVisual, TLabel, TDrawingContext>
     /// <summary>
     /// Gets or sets the data set to draw in the chart.
     /// </summary>
-    public ICollection<TModel>? Values
+    public IReadOnlyCollection<TModel>? Values
     {
         get => _values;
         set
@@ -158,7 +158,7 @@ public abstract class Series<TModel, TVisual, TLabel, TDrawingContext>
     IEnumerable? ISeries.Values
     {
         get => Values;
-        set => Values = (ICollection<TModel>?)value;
+        set => Values = (IReadOnlyCollection<TModel>?)value;
     }
 
     /// <inheritdoc cref="ISeries.Pivot"/>

--- a/src/LiveChartsCore/StrokeAndFillCartesianSeries.cs
+++ b/src/LiveChartsCore/StrokeAndFillCartesianSeries.cs
@@ -40,7 +40,7 @@ namespace LiveChartsCore;
 /// <param name="values">The values.</param>
 public abstract class StrokeAndFillCartesianSeries<TModel, TVisual, TLabel, TDrawingContext>(
     SeriesProperties properties,
-    ICollection<TModel>? values)
+    IReadOnlyCollection<TModel>? values)
         : CartesianSeries<TModel, TVisual, TLabel, TDrawingContext>(properties, values)
             where TDrawingContext : DrawingContext
             where TVisual : class, IGeometry<TDrawingContext>, new()

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/BoxSeries.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/BoxSeries.cs
@@ -53,7 +53,7 @@ public class BoxSeries<TModel>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public BoxSeries(ICollection<TModel>? values)
+    public BoxSeries(IReadOnlyCollection<TModel>? values)
         : base(values)
     { }
 
@@ -96,7 +96,7 @@ public class BoxSeries<TModel, TVisual>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public BoxSeries(ICollection<TModel>? values)
+    public BoxSeries(IReadOnlyCollection<TModel>? values)
         : base(values)
     { }
 
@@ -143,7 +143,7 @@ public class BoxSeries<TModel, TVisual, TLabel>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public BoxSeries(ICollection<TModel>? values)
+    public BoxSeries(IReadOnlyCollection<TModel>? values)
         : base(values)
     { }
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/CandlesticksSeries.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/CandlesticksSeries.cs
@@ -53,7 +53,7 @@ public class CandlesticksSeries<TModel>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public CandlesticksSeries(ICollection<TModel>? values)
+    public CandlesticksSeries(IReadOnlyCollection<TModel>? values)
         : base(values)
     { }
 
@@ -96,7 +96,7 @@ public class CandlesticksSeries<TModel, TVisual>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public CandlesticksSeries(ICollection<TModel>? values)
+    public CandlesticksSeries(IReadOnlyCollection<TModel>? values)
         : base(values)
     { }
 
@@ -143,7 +143,7 @@ public class CandlesticksSeries<TModel, TVisual, TLabel>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public CandlesticksSeries(ICollection<TModel>? values)
+    public CandlesticksSeries(IReadOnlyCollection<TModel>? values)
         : base(values)
     { }
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/ColumnSeries.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/ColumnSeries.cs
@@ -53,7 +53,7 @@ public class ColumnSeries<TModel>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public ColumnSeries(ICollection<TModel>? values)
+    public ColumnSeries(IReadOnlyCollection<TModel>? values)
         : base(values)
     { }
 
@@ -96,7 +96,7 @@ public class ColumnSeries<TModel, TVisual>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public ColumnSeries(ICollection<TModel>? values)
+    public ColumnSeries(IReadOnlyCollection<TModel>? values)
         : base(values)
     { }
 
@@ -143,7 +143,7 @@ public class ColumnSeries<TModel, TVisual, TLabel>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public ColumnSeries(ICollection<TModel>? values)
+    public ColumnSeries(IReadOnlyCollection<TModel>? values)
         : base(values)
     { }
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/HeatSeries.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/HeatSeries.cs
@@ -53,7 +53,7 @@ public class HeatSeries<TModel>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public HeatSeries(ICollection<TModel>? values)
+    public HeatSeries(IReadOnlyCollection<TModel>? values)
         : base(values)
     { }
 
@@ -96,7 +96,7 @@ public class HeatSeries<TModel, TVisual>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public HeatSeries(ICollection<TModel>? values)
+    public HeatSeries(IReadOnlyCollection<TModel>? values)
         : base(values)
     { }
 
@@ -143,7 +143,7 @@ public class HeatSeries<TModel, TVisual, TLabel>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public HeatSeries(ICollection<TModel>? values)
+    public HeatSeries(IReadOnlyCollection<TModel>? values)
         : base(values)
     { }
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/LineSeries.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/LineSeries.cs
@@ -53,7 +53,7 @@ public class LineSeries<TModel>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public LineSeries(ICollection<TModel>? values)
+    public LineSeries(IReadOnlyCollection<TModel>? values)
         : base(values)
     { }
 
@@ -96,7 +96,7 @@ public class LineSeries<TModel, TVisual>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public LineSeries(ICollection<TModel>? values)
+    public LineSeries(IReadOnlyCollection<TModel>? values)
         : base(values)
     { }
 
@@ -143,7 +143,7 @@ public class LineSeries<TModel, TVisual, TLabel>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public LineSeries(ICollection<TModel>? values)
+    public LineSeries(IReadOnlyCollection<TModel>? values)
         : base(values)
     { }
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/PieSeries.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/PieSeries.cs
@@ -53,7 +53,7 @@ public class PieSeries<TModel>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public PieSeries(ICollection<TModel>? values)
+    public PieSeries(IReadOnlyCollection<TModel>? values)
         : base(values)
     { }
 
@@ -103,7 +103,7 @@ public class PieSeries<TModel, TVisual>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public PieSeries(ICollection<TModel>? values)
+    public PieSeries(IReadOnlyCollection<TModel>? values)
         : base(values)
     { }
 
@@ -157,7 +157,7 @@ public class PieSeries<TModel, TVisual, TLabel>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public PieSeries(ICollection<TModel>? values)
+    public PieSeries(IReadOnlyCollection<TModel>? values)
         : base(values, false, false)
     { }
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/PolarLineSeries.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/PolarLineSeries.cs
@@ -53,7 +53,7 @@ public class PolarLineSeries<TModel>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public PolarLineSeries(ICollection<TModel>? values)
+    public PolarLineSeries(IReadOnlyCollection<TModel>? values)
         : base(values)
     { }
 
@@ -96,7 +96,7 @@ public class PolarLineSeries<TModel, TVisual>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public PolarLineSeries(ICollection<TModel>? values)
+    public PolarLineSeries(IReadOnlyCollection<TModel>? values)
         : base(values)
     { }
 
@@ -143,7 +143,7 @@ public class PolarLineSeries<TModel, TVisual, TLabel>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public PolarLineSeries(ICollection<TModel>? values)
+    public PolarLineSeries(IReadOnlyCollection<TModel>? values)
         : base(values)
     { }
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/RowSeries.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/RowSeries.cs
@@ -53,7 +53,7 @@ public class RowSeries<TModel>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public RowSeries(ICollection<TModel>? values)
+    public RowSeries(IReadOnlyCollection<TModel>? values)
         : base(values)
     { }
 
@@ -96,7 +96,7 @@ public class RowSeries<TModel, TVisual>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public RowSeries(ICollection<TModel>? values)
+    public RowSeries(IReadOnlyCollection<TModel>? values)
         : base(values)
     { }
 
@@ -143,7 +143,7 @@ public class RowSeries<TModel, TVisual, TLabel>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public RowSeries(ICollection<TModel>? values)
+    public RowSeries(IReadOnlyCollection<TModel>? values)
         : base(values)
     { }
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/ScatterSeries.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/ScatterSeries.cs
@@ -53,7 +53,7 @@ public class ScatterSeries<TModel>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public ScatterSeries(ICollection<TModel>? values)
+    public ScatterSeries(IReadOnlyCollection<TModel>? values)
         : base(values)
     { }
 
@@ -96,7 +96,7 @@ public class ScatterSeries<TModel, TVisual>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public ScatterSeries(ICollection<TModel>? values)
+    public ScatterSeries(IReadOnlyCollection<TModel>? values)
         : base(values)
     { }
 
@@ -143,7 +143,7 @@ public class ScatterSeries<TModel, TVisual, TLabel>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public ScatterSeries(ICollection<TModel>? values)
+    public ScatterSeries(IReadOnlyCollection<TModel>? values)
         : base(values)
     { }
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/StackedAreaSeries.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/StackedAreaSeries.cs
@@ -53,7 +53,7 @@ public class StackedAreaSeries<TModel>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public StackedAreaSeries(ICollection<TModel>? values)
+    public StackedAreaSeries(IReadOnlyCollection<TModel>? values)
         : base(values)
     { }
 
@@ -96,7 +96,7 @@ public class StackedAreaSeries<TModel, TVisual>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public StackedAreaSeries(ICollection<TModel>? values)
+    public StackedAreaSeries(IReadOnlyCollection<TModel>? values)
         : base(values)
     { }
 
@@ -143,7 +143,7 @@ public class StackedAreaSeries<TModel, TVisual, TLabel>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public StackedAreaSeries(ICollection<TModel>? values)
+    public StackedAreaSeries(IReadOnlyCollection<TModel>? values)
         : base(values)
     { }
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/StackedColumnSeries.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/StackedColumnSeries.cs
@@ -53,7 +53,7 @@ public class StackedColumnSeries<TModel>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public StackedColumnSeries(ICollection<TModel>? values)
+    public StackedColumnSeries(IReadOnlyCollection<TModel>? values)
         : base(values)
     { }
 
@@ -96,7 +96,7 @@ public class StackedColumnSeries<TModel, TVisual>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public StackedColumnSeries(ICollection<TModel>? values)
+    public StackedColumnSeries(IReadOnlyCollection<TModel>? values)
         : base(values)
     { }
 
@@ -143,7 +143,7 @@ public class StackedColumnSeries<TModel, TVisual, TLabel>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public StackedColumnSeries(ICollection<TModel>? values)
+    public StackedColumnSeries(IReadOnlyCollection<TModel>? values)
         : base(values)
     { }
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/StackedRowSeries.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/StackedRowSeries.cs
@@ -53,7 +53,7 @@ public class StackedRowSeries<TModel>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public StackedRowSeries(ICollection<TModel>? values)
+    public StackedRowSeries(IReadOnlyCollection<TModel>? values)
         : base(values)
     { }
 
@@ -96,7 +96,7 @@ public class StackedRowSeries<TModel, TVisual>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public StackedRowSeries(ICollection<TModel>? values)
+    public StackedRowSeries(IReadOnlyCollection<TModel>? values)
         : base(values)
     { }
 
@@ -143,7 +143,7 @@ public class StackedRowSeries<TModel, TVisual, TLabel>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public StackedRowSeries(ICollection<TModel>? values)
+    public StackedRowSeries(IReadOnlyCollection<TModel>? values)
         : base(values)
     { }
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/StackedStepAreaSeries.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/StackedStepAreaSeries.cs
@@ -53,7 +53,7 @@ public class StackedStepAreaSeries<TModel>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public StackedStepAreaSeries(ICollection<TModel>? values)
+    public StackedStepAreaSeries(IReadOnlyCollection<TModel>? values)
         : base(values)
     { }
 
@@ -96,7 +96,7 @@ public class StackedStepAreaSeries<TModel, TVisual>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public StackedStepAreaSeries(ICollection<TModel>? values)
+    public StackedStepAreaSeries(IReadOnlyCollection<TModel>? values)
         : base(values)
     { }
 
@@ -143,7 +143,7 @@ public class StackedStepAreaSeries<TModel, TVisual, TLabel>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public StackedStepAreaSeries(ICollection<TModel>? values)
+    public StackedStepAreaSeries(IReadOnlyCollection<TModel>? values)
         : base(values)
     { }
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/StepLineSeries.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/StepLineSeries.cs
@@ -52,7 +52,7 @@ public class StepLineSeries<TModel> : StepLineSeries<TModel, CircleGeometry, Lab
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public StepLineSeries(ICollection<TModel>? values)
+    public StepLineSeries(IReadOnlyCollection<TModel>? values)
         : base(values)
     { }
 
@@ -95,7 +95,7 @@ public class StepLineSeries<TModel, TVisual>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public StepLineSeries(ICollection<TModel>? values)
+    public StepLineSeries(IReadOnlyCollection<TModel>? values)
         : base(values)
     { }
 
@@ -142,7 +142,7 @@ public class StepLineSeries<TModel, TVisual, TLabel>
     /// with a given collection of values.
     /// </summary>
     /// <param name="values">The values to plot.</param>
-    public StepLineSeries(ICollection<TModel>? values)
+    public StepLineSeries(IReadOnlyCollection<TModel>? values)
         : base(values)
     { }
 


### PR DESCRIPTION
in #1386, we changed from `IEnumerable` to `ICollection`

then in #1634 the type was changed to `ICollection<T>`, this is great because now the Series.Values property is aware of the type of the collection, the problem as reported in #1673, is that some collections like `Queue<T>` and `Stack<T>` do not implement `ICollection<T>`

This PR changes the type again to `IReadOnlyCollection<T>`, this interface seems to fit perfectly for the case of the library.
