### PR TITLE
feat: add global toggle for GPU rendering. closes #1645

### DIFF
--- a/src/LiveChartsCore/LiveCharts.cs
+++ b/src/LiveChartsCore/LiveCharts.cs
@@ -57,6 +57,12 @@ public static class LiveCharts
     public static double MaxFps { get; set; } = 65;
 
     /// <summary>
+    /// Gets or sets a value indicating whether LiveCharts should use a hardware graphics API
+    /// to render the charts.
+    /// </summary>
+    public static bool UseGPU { get; set; } = false;
+
+    /// <summary>
     /// Gets a value indicating whether LiveCharts has a backend registered.
     /// </summary>
     public static bool HasBackend { get; internal set; } = false;

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/CartesianChart.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/CartesianChart.xaml.cs
@@ -104,8 +104,16 @@ public partial class CartesianChart : ContentView, ICartesianChartView<SkiaSharp
         SetValue(VisualElementsProperty, new ObservableCollection<ChartElement<SkiaSharpDrawingContext>>());
         SetValue(SyncContextProperty, new object());
 
-        canvas.SkCanvasView.EnableTouchEvents = true;
-        canvas.SkCanvasView.Touch += OnSkCanvasTouched;
+        if (canvas.SkCanvasView is not null)
+        {
+            canvas.SkCanvasView.EnableTouchEvents = true;
+            canvas.SkCanvasView.Touch += OnSkCanvasTouched;
+        }
+        else if (canvas.SkGlView is not null)
+        {
+            canvas.SkGlView.EnableTouchEvents = true;
+            canvas.SkGlView.Touch += OnSkCanvasTouched;
+        }
 
         if (core is null) throw new Exception("Core not found!");
         core.Measuring += OnCoreMeasuring;

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/GeoMap.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/GeoMap.xaml.cs
@@ -58,8 +58,16 @@ public partial class GeoMap : ContentView, IGeoMapView<SkiaSharpDrawingContext>
         LiveCharts.Configure(config => config.UseDefaults());
         _core = new GeoMap<SkiaSharpDrawingContext>(this);
 
-        canvas.SkCanvasView.EnableTouchEvents = true;
-        canvas.SkCanvasView.Touch += OnSkCanvasTouched;
+        if (canvas.SkCanvasView is not null)
+        {
+            canvas.SkCanvasView.EnableTouchEvents = true;
+            canvas.SkCanvasView.Touch += OnSkCanvasTouched;
+        }
+        else if (canvas.SkGlView is not null)
+        {
+            canvas.SkGlView.EnableTouchEvents = true;
+            canvas.SkGlView.Touch += OnSkCanvasTouched;
+        }
 
         SizeChanged += GeoMap_SizeChanged;
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/MotionCanvas.xaml
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/MotionCanvas.xaml
@@ -1,9 +1,0 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
-<ContentView xmlns="http://xamarin.com/schemas/2014/forms" 
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
-             xmlns:forms="clr-namespace:SkiaSharp.Views.Forms;assembly=SkiaSharp.Views.Forms"
-             x:Class="LiveChartsCore.SkiaSharpView.Xamarin.Forms.MotionCanvas">
-    <ContentView.Content>
-        <forms:SKCanvasView x:Name="skiaElement"/>
-    </ContentView.Content>
-</ContentView>

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/PieChart.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/PieChart.xaml.cs
@@ -85,8 +85,16 @@ public partial class PieChart : ContentView, IPieChartView<SkiaSharpDrawingConte
         SetValue(VisualElementsProperty, new ObservableCollection<ChartElement<SkiaSharpDrawingContext>>());
         SetValue(SyncContextProperty, new object());
 
-        canvas.SkCanvasView.EnableTouchEvents = true;
-        canvas.SkCanvasView.Touch += OnSkCanvasTouched;
+        if (canvas.SkCanvasView is not null)
+        {
+            canvas.SkCanvasView.EnableTouchEvents = true;
+            canvas.SkCanvasView.Touch += OnSkCanvasTouched;
+        }
+        else if (canvas.SkGlView is not null)
+        {
+            canvas.SkGlView.EnableTouchEvents = true;
+            canvas.SkGlView.Touch += OnSkCanvasTouched;
+        }
 
         if (core is null) throw new Exception("Core not found!");
         core.Measuring += OnCoreMeasuring;

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/PolarChart.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/PolarChart.xaml.cs
@@ -95,8 +95,16 @@ public partial class PolarChart : ContentView, IPolarChartView<SkiaSharpDrawingC
         SetValue(VisualElementsProperty, new ObservableCollection<ChartElement<SkiaSharpDrawingContext>>());
         SetValue(SyncContextProperty, new object());
 
-        canvas.SkCanvasView.EnableTouchEvents = true;
-        canvas.SkCanvasView.Touch += OnSkCanvasTouched;
+        if (canvas.SkCanvasView is not null)
+        {
+            canvas.SkCanvasView.EnableTouchEvents = true;
+            canvas.SkCanvasView.Touch += OnSkCanvasTouched;
+        }
+        else if (canvas.SkGlView is not null)
+        {
+            canvas.SkGlView.EnableTouchEvents = true;
+            canvas.SkGlView.Touch += OnSkCanvasTouched;
+        }
 
         if (core is null) throw new Exception("Core not found!");
         core.Measuring += OnCoreMeasuring;

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Blazor/MotionCanvas.razor
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Blazor/MotionCanvas.razor
@@ -31,7 +31,7 @@
 
 @implements IDisposable
 
-@if(UseGLView)
+@if(LiveCharts.UseGPU)
 {
     <SKGLView
 	    @ref="_glView"

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Blazor/MotionCanvas.razor.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Blazor/MotionCanvas.razor.cs
@@ -53,12 +53,6 @@ public partial class MotionCanvas : IDisposable
     public MotionCanvas<SkiaSharpDrawingContext> CanvasCore { get; } = new();
 
     /// <summary>
-    /// Gets or sets whether the web GL view should be used.
-    /// </summary>
-    [Parameter]
-    public bool UseGLView { get; set; } = true;
-
-    /// <summary>
     /// Gets or sets the paint tasks.
     /// </summary>
     [Parameter]
@@ -169,7 +163,7 @@ public partial class MotionCanvas : IDisposable
 
         var ts = TimeSpan.FromSeconds(1 / LiveCharts.MaxFps);
 
-        if (UseGLView)
+        if (LiveCharts.UseGPU)
         {
             while (!CanvasCore.IsValid && !_disposing)
             {


### PR DESCRIPTION
This PR adds a global toggle to enable/disable GPU rendering, i.e. switching from SKCanvasView to SKGLView. This is primarily useful on Android where canvas rendering can be slow. Closes #1645.

~~In draft as this is currently just a prototype for the MAUI view, needs to be extended out to the others~~, but I figured I'd send this to get some feedback.
Figured it would be easier to branch off `dev` for this rather than continuing from `hardware-accelerated`, but happy to move these changes over to there if that's better.