### PR TITLE
improve bounce logic

### DIFF
--- a/src/LiveChartsCore/CartesianChart.cs
+++ b/src/LiveChartsCore/CartesianChart.cs
@@ -317,21 +317,6 @@ public class CartesianChart<TDrawingContext> : Chart<TDrawingContext>
                 var max = limits.Max;
                 var min = limits.Min;
 
-                var xm = max - min;
-                xm = isActive ? xm * MaxAxisActiveBound : xm * MaxAxisBound;
-
-                if (max + dx > limits.DataMax && delta.X < 0)
-                {
-                    xi.SetLimits(limits.DataMax - (max - xm - min), limits.DataMax + xm);
-                    continue;
-                }
-
-                if (min + dx < limits.DataMin && delta.X > 0)
-                {
-                    xi.SetLimits(limits.DataMin - xm, limits.DataMin + max - min - xm);
-                    continue;
-                }
-
                 xi.SetLimits(min + dx, max + dx);
             }
         }
@@ -348,21 +333,6 @@ public class CartesianChart<TDrawingContext> : Chart<TDrawingContext>
 
                 var max = limits.Max;
                 var min = limits.Min;
-
-                var ym = max - min;
-                ym = isActive ? ym * MaxAxisActiveBound : ym * MaxAxisBound;
-
-                if (max + dy > limits.DataMax)
-                {
-                    yi.SetLimits(limits.DataMax - (max - ym - min), limits.DataMax + ym);
-                    continue;
-                }
-
-                if (min + dy < limits.DataMin)
-                {
-                    yi.SetLimits(limits.DataMin - ym, limits.DataMin + max - min - ym);
-                    continue;
-                }
 
                 yi.SetLimits(min + dy, max + dy);
             }
@@ -1097,6 +1067,7 @@ public class CartesianChart<TDrawingContext> : Chart<TDrawingContext>
             return;
         }
 
+        BouncePanningBack();
         base.InvokePointerUp(point, isSecondaryAction);
     }
 
@@ -1121,6 +1092,53 @@ public class CartesianChart<TDrawingContext> : Chart<TDrawingContext>
 
         _sharedEvents = instance;
         _ = _sharedEvents.Add(this);
+    }
+
+    private void BouncePanningBack()
+    {
+        // this method ensures that the current panning is inside the data bounds.
+
+        if ((_zoomMode & ZoomAndPanMode.PanX) == ZoomAndPanMode.PanX)
+        {
+            for (var index = 0; index < XAxes.Length; index++)
+            {
+                var xi = XAxes[index];
+
+                var limits = xi.GetLimits();
+
+                var max = limits.Max;
+                var min = limits.Min;
+
+                var xm = max - min;
+
+                if (xi.MinLimit < limits.DataMin)
+                    xi.SetLimits(limits.DataMin, limits.DataMin + xm);
+
+                if (xi.MaxLimit > limits.DataMax)
+                    xi.SetLimits(limits.DataMax - xm, limits.DataMax);
+            }
+        }
+
+        if ((_zoomMode & ZoomAndPanMode.PanY) == ZoomAndPanMode.PanY)
+        {
+            for (var index = 0; index < YAxes.Length; index++)
+            {
+                var yi = YAxes[index];
+
+                var limits = yi.GetLimits();
+
+                var max = limits.Max;
+                var min = limits.Min;
+
+                var ym = max - min;
+
+                if (yi.MinLimit < limits.DataMin)
+                    yi.SetLimits(limits.DataMin, limits.DataMin + ym);
+
+                if (yi.MaxLimit > limits.DataMax)
+                    yi.SetLimits(limits.DataMax - ym, limits.DataMax);
+            }
+        }
     }
 
     private void OnPointerLeft() => base.InvokePointerLeft();

--- a/src/LiveChartsCore/Chart.cs
+++ b/src/LiveChartsCore/Chart.cs
@@ -710,11 +710,6 @@ public abstract class Chart<TDrawingContext> : IChart
                     var dx = _pointerPanningPosition.X - _pointerPreviousPanningPosition.X;
                     var dy = _pointerPanningPosition.Y - _pointerPreviousPanningPosition.Y;
 
-                    // we need to send a dummy value indicating the direction (val > 0)
-                    // so the core is able to bounce the panning when the user reaches the limit.
-                    if (dx == 0) dx = _pointerPanningStartPosition.X - _pointerPanningPosition.X > 0 ? -0.01f : 0.01f;
-                    if (dy == 0) dy = _pointerPanningStartPosition.Y - _pointerPanningPosition.Y > 0 ? -0.01f : 0.01f;
-
                     cartesianChart.Pan(new LvcPoint(dx, dy), _isPanning);
                     _pointerPreviousPanningPosition = new LvcPoint(_pointerPanningPosition.X, _pointerPanningPosition.Y);
                 }


### PR DESCRIPTION
This PR fixes #1513 

The issue was caused by the logic that bounces back to the chart data when the panning goes out of the limits in the chart, now bouncing behaves much better.

![improve bounce](https://github.com/user-attachments/assets/3b8e9052-68b3-403a-8eca-58ee9261a3f3)
