### PR TITLE
Rename to findingstrategy

### DIFF
--- a/samples/ViewModelsSamples/Events/Tutorial/ViewModel.cs
+++ b/samples/ViewModelsSamples/Events/Tutorial/ViewModel.cs
@@ -1,0 +1,47 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics;
+using CommunityToolkit.Mvvm.Input;
+using LiveChartsCore;
+using LiveChartsCore.Kernel;
+using LiveChartsCore.Measure;
+using LiveChartsCore.SkiaSharpView;
+using LiveChartsCore.SkiaSharpView.Drawing.Geometries;
+using LiveChartsCore.SkiaSharpView.Painting;
+using SkiaSharp;
+
+namespace ViewModelsSamples.Events.Tutorial;
+
+public partial class ViewModel
+{
+    private readonly HashSet<ChartPoint> _activePoints = [];
+
+    public TooltipFindingStrategy Strategy { get; } = TooltipFindingStrategy.Automatic;
+
+    public ISeries[] SeriesCollection { get; set; } = [
+        new ColumnSeries<int>([1, 5, 4, 3]),
+        new ColumnSeries<int>([3, 2, 6, 2])
+    ];
+
+    [RelayCommand]
+    public void OnDataDown(IEnumerable<ChartPoint> foundPoints)
+    {
+        foreach (var point in foundPoints)
+        {
+            var geometry = (Geometry)point.Context.Visual!;
+
+            if (!_activePoints.Contains(point))
+            {
+                geometry.Fill = new SolidColorPaint { Color = SKColors.Yellow };
+                _activePoints.Add(point);
+            }
+            else
+            {
+                // clear the fill to the default value
+                geometry.Fill = null;
+                _activePoints.Remove(point);
+            }
+
+            Trace.WriteLine($"found {point.Context.DataSource}");
+        }
+    }
+}

--- a/samples/ViewModelsSamples/Index.cs
+++ b/samples/ViewModelsSamples/Index.cs
@@ -91,6 +91,7 @@ public static class Index
         "Axes/Style",
         "Axes/Paging",
 
+        "Events/Tutorial",
         "Events/AddPointOnClick",
         "Events/Cartesian",
         "Events/Pie",

--- a/src/LiveChartsCore/BarSeries.cs
+++ b/src/LiveChartsCore/BarSeries.cs
@@ -230,11 +230,11 @@ public abstract class BarSeries<TModel, TVisual, TLabel, TDrawingContext>(
         return [Stroke, Fill, DataLabelsPaint, _errorPaint];
     }
 
-    /// <inheritdoc cref="Series{TModel, TVisual, TLabel, TDrawingContext}.FindPointsInPosition(IChart, LvcPoint, TooltipFindingStrategy, FindPointFor)"/>
+    /// <inheritdoc cref="Series{TModel, TVisual, TLabel, TDrawingContext}.FindPointsInPosition(IChart, LvcPoint, FindingStrategy, FindPointFor)"/>
     protected override IEnumerable<ChartPoint> FindPointsInPosition(
-        IChart chart, LvcPoint pointerPosition, TooltipFindingStrategy strategy, FindPointFor findPointFor)
+        IChart chart, LvcPoint pointerPosition, FindingStrategy strategy, FindPointFor findPointFor)
     {
-        return strategy == TooltipFindingStrategy.ExactMatch
+        return strategy == FindingStrategy.ExactMatch
             ? Fetch(chart)
                 .Where(point =>
                 {

--- a/src/LiveChartsCore/CartesianChart.cs
+++ b/src/LiveChartsCore/CartesianChart.cs
@@ -124,10 +124,10 @@ public class CartesianChart<TDrawingContext> : Chart<TDrawingContext>
     /// <returns></returns>
     public override IEnumerable<ChartPoint> FindHoveredPointsBy(LvcPoint pointerPosition)
     {
-        var actualStrategy = TooltipFindingStrategy;
+        var actualStrategy = FindingStrategy;
 
-        if (actualStrategy == TooltipFindingStrategy.Automatic)
-            actualStrategy = VisibleSeries.GetTooltipFindingStrategy();
+        if (actualStrategy == FindingStrategy.Automatic)
+            actualStrategy = VisibleSeries.GetFindingStrategy();
 
         return VisibleSeries
             .Where(series => series.IsHoverable)
@@ -404,7 +404,7 @@ public class CartesianChart<TDrawingContext> : Chart<TDrawingContext>
         Legend = _chartView.Legend;
 
         TooltipPosition = _chartView.TooltipPosition;
-        TooltipFindingStrategy = _chartView.TooltipFindingStrategy;
+        FindingStrategy = _chartView.FindingStrategy;
         Tooltip = _chartView.Tooltip;
 
         AnimationsSpeed = _chartView.AnimationsSpeed;

--- a/src/LiveChartsCore/Chart.cs
+++ b/src/LiveChartsCore/Chart.cs
@@ -228,7 +228,7 @@ public abstract class Chart<TDrawingContext> : IChart
     /// <value>
     /// The tooltip finding strategy.
     /// </value>
-    public TooltipFindingStrategy TooltipFindingStrategy { get; protected set; }
+    public FindingStrategy FindingStrategy { get; protected set; }
 
     /// <summary>
     /// Gets the tooltip.
@@ -331,10 +331,10 @@ public abstract class Chart<TDrawingContext> : IChart
             if (_isMobile) _isTooltipCanceled = false;
 #endif
 
-            var strategy = TooltipFindingStrategy;
+            var strategy = FindingStrategy;
 
-            if (strategy == TooltipFindingStrategy.Automatic)
-                strategy = VisibleSeries.GetTooltipFindingStrategy();
+            if (strategy == FindingStrategy.Automatic)
+                strategy = VisibleSeries.GetFindingStrategy();
 
             // fire the series event.
             foreach (var series in VisibleSeries)

--- a/src/LiveChartsCore/CoreAxis.cs
+++ b/src/LiveChartsCore/CoreAxis.cs
@@ -821,7 +821,7 @@ public abstract class CoreAxis<TDrawingContext, TTextGeometry, TLineGeometry>
         ChartPoint? closestPoint = null;
         foreach (var series in allSeries)
         {
-            var hitpoints = series.FindHitPoints(cartesianChart, pointerPosition, allSeries.GetTooltipFindingStrategy(), FindPointFor.PointerDownEvent);
+            var hitpoints = series.FindHitPoints(cartesianChart, pointerPosition, allSeries.GetFindingStrategy(), FindPointFor.PointerDownEvent);
             var hitpoint = hitpoints.FirstOrDefault();
             if (hitpoint == null) continue;
 

--- a/src/LiveChartsCore/CoreBoxSeries.cs
+++ b/src/LiveChartsCore/CoreBoxSeries.cs
@@ -226,7 +226,7 @@ public abstract class CoreBoxSeries<TModel, TVisual, TLabel, TMiniatureGeometry,
 
             _ = ha.SetDimensions(secondary - helper.actualUw * 0.5f, high, helper.actualUw, Math.Abs(low - high));
 
-            if (chart.TooltipFindingStrategy == TooltipFindingStrategy.ExactMatch)
+            if (chart.FindingStrategy == FindingStrategy.ExactMatch)
                 _ = ha
                     .SetDimensions(x, high, helper.uw, low)
                     .CenterXToolTip();
@@ -282,11 +282,11 @@ public abstract class CoreBoxSeries<TModel, TVisual, TLabel, TMiniatureGeometry,
             everFetched, cartesianChart.View, primaryScale, secondaryScale, SoftDeleteOrDisposePoint);
     }
 
-    /// <inheritdoc cref="Series{TModel, TVisual, TLabel, TDrawingContext}.FindPointsInPosition(IChart, LvcPoint, TooltipFindingStrategy, FindPointFor)"/>
+    /// <inheritdoc cref="Series{TModel, TVisual, TLabel, TDrawingContext}.FindPointsInPosition(IChart, LvcPoint, FindingStrategy, FindPointFor)"/>
     protected override IEnumerable<ChartPoint> FindPointsInPosition(
-        IChart chart, LvcPoint pointerPosition, TooltipFindingStrategy strategy, FindPointFor findPointFor)
+        IChart chart, LvcPoint pointerPosition, FindingStrategy strategy, FindPointFor findPointFor)
     {
-        return strategy == TooltipFindingStrategy.ExactMatch
+        return strategy == FindingStrategy.ExactMatch
             ? Fetch(chart)
                 .Where(point =>
                 {

--- a/src/LiveChartsCore/CoreColumnSeries.cs
+++ b/src/LiveChartsCore/CoreColumnSeries.cs
@@ -279,7 +279,7 @@ public abstract class CoreColumnSeries<TModel, TVisual, TLabel, TDrawingContext,
                 .SetDimensions(secondary - helper.actualUw * 0.5f, cy, helper.actualUw, b)
                 .CenterXToolTip();
 
-            if (chart.TooltipFindingStrategy == TooltipFindingStrategy.ExactMatch)
+            if (chart.FindingStrategy == FindingStrategy.ExactMatch)
                 _ = ha
                     .SetDimensions(x, cy, helper.uw, b)
                     .CenterXToolTip();

--- a/src/LiveChartsCore/CoreLineSeries.cs
+++ b/src/LiveChartsCore/CoreLineSeries.cs
@@ -499,13 +499,13 @@ public class CoreLineSeries<TModel, TVisual, TLabel, TDrawingContext, TPathGeome
         _geometrySvgChanged = false;
     }
 
-    /// <inheritdoc cref="Series{TModel, TVisual, TLabel, TDrawingContext}.FindPointsInPosition(IChart, LvcPoint, TooltipFindingStrategy, FindPointFor)"/>
+    /// <inheritdoc cref="Series{TModel, TVisual, TLabel, TDrawingContext}.FindPointsInPosition(IChart, LvcPoint, FindingStrategy, FindPointFor)"/>
     protected override IEnumerable<ChartPoint> FindPointsInPosition(
-        IChart chart, LvcPoint pointerPosition, TooltipFindingStrategy strategy, FindPointFor findPointFor)
+        IChart chart, LvcPoint pointerPosition, FindingStrategy strategy, FindPointFor findPointFor)
     {
         return strategy switch
         {
-            TooltipFindingStrategy.ExactMatch => Fetch(chart)
+            FindingStrategy.ExactMatch => Fetch(chart)
                 .Where(point =>
                 {
                     var v = (TVisual?)point.Context.Visual;
@@ -518,18 +518,18 @@ public class CoreLineSeries<TModel, TVisual, TLabel, TDrawingContext, TPathGeome
                         pointerPosition.X > x && pointerPosition.X < x + v.Width &&
                         pointerPosition.Y > y && pointerPosition.Y < y + v.Height;
                 }),
-            TooltipFindingStrategy.ExactMatchTakeClosest => Fetch(chart)
+            FindingStrategy.ExactMatchTakeClosest => Fetch(chart)
                 .Select(x => new { distance = x.DistanceTo(pointerPosition), point = x })
                 .OrderBy(x => x.distance)
                 .SelectFirst(x => x.point),
-            TooltipFindingStrategy.Automatic or
-            TooltipFindingStrategy.CompareAll or
-            TooltipFindingStrategy.CompareOnlyX or
-            TooltipFindingStrategy.CompareOnlyY or
-            TooltipFindingStrategy.CompareAllTakeClosest or
-            TooltipFindingStrategy.CompareOnlyXTakeClosest or
-            TooltipFindingStrategy.CompareOnlyYTakeClosest or
-            TooltipFindingStrategy.ExactMatchTakeClosest or
+            FindingStrategy.Automatic or
+            FindingStrategy.CompareAll or
+            FindingStrategy.CompareOnlyX or
+            FindingStrategy.CompareOnlyY or
+            FindingStrategy.CompareAllTakeClosest or
+            FindingStrategy.CompareOnlyXTakeClosest or
+            FindingStrategy.CompareOnlyYTakeClosest or
+            FindingStrategy.ExactMatchTakeClosest or
                 _ => base.FindPointsInPosition(chart, pointerPosition, strategy, findPointFor)
         };
     }

--- a/src/LiveChartsCore/CoreRowSeries.cs
+++ b/src/LiveChartsCore/CoreRowSeries.cs
@@ -286,7 +286,7 @@ public class CoreRowSeries<TModel, TVisual, TLabel, TDrawingContext, TErrorGeome
             _ = ha.SetDimensions(cx, secondary - helper.actualUw * 0.5f, b, helper.actualUw)
                 .CenterXToolTip().StartYToolTip();
 
-            if (chart.TooltipFindingStrategy == TooltipFindingStrategy.ExactMatch)
+            if (chart.FindingStrategy == FindingStrategy.ExactMatch)
                 _ = ha
                     .SetDimensions(cx, y, b, helper.uw)
                     .CenterXToolTip().StartYToolTip();

--- a/src/LiveChartsCore/CoreStepLineSeries.cs
+++ b/src/LiveChartsCore/CoreStepLineSeries.cs
@@ -428,13 +428,13 @@ public class CoreStepLineSeries<TModel, TVisual, TLabel, TDrawingContext, TPathG
         _geometrySvgChanged = false;
     }
 
-    /// <inheritdoc cref="Series{TModel, TVisual, TLabel, TDrawingContext}.FindPointsInPosition(IChart, LvcPoint, TooltipFindingStrategy, FindPointFor)"/>
+    /// <inheritdoc cref="Series{TModel, TVisual, TLabel, TDrawingContext}.FindPointsInPosition(IChart, LvcPoint, FindingStrategy, FindPointFor)"/>
     protected override IEnumerable<ChartPoint> FindPointsInPosition(
-        IChart chart, LvcPoint pointerPosition, TooltipFindingStrategy strategy, FindPointFor findPointFor)
+        IChart chart, LvcPoint pointerPosition, FindingStrategy strategy, FindPointFor findPointFor)
     {
         return strategy switch
         {
-            TooltipFindingStrategy.ExactMatch => Fetch(chart)
+            FindingStrategy.ExactMatch => Fetch(chart)
                 .Where(point =>
                 {
                     var v = (TVisual?)point.Context.Visual;
@@ -447,18 +447,18 @@ public class CoreStepLineSeries<TModel, TVisual, TLabel, TDrawingContext, TPathG
                         pointerPosition.X > x && pointerPosition.X < x + v.Width &&
                         pointerPosition.Y > y && pointerPosition.Y < y + v.Height;
                 }),
-            TooltipFindingStrategy.ExactMatchTakeClosest => Fetch(chart)
+            FindingStrategy.ExactMatchTakeClosest => Fetch(chart)
                 .Select(x => new { distance = x.DistanceTo(pointerPosition), point = x })
                 .OrderBy(x => x.distance)
                 .SelectFirst(x => x.point),
-            TooltipFindingStrategy.Automatic or
-            TooltipFindingStrategy.CompareAll or
-            TooltipFindingStrategy.CompareOnlyX or
-            TooltipFindingStrategy.CompareOnlyY or
-            TooltipFindingStrategy.CompareAllTakeClosest or
-            TooltipFindingStrategy.CompareOnlyXTakeClosest or
-            TooltipFindingStrategy.CompareOnlyYTakeClosest or
-            TooltipFindingStrategy.ExactMatchTakeClosest or
+            FindingStrategy.Automatic or
+            FindingStrategy.CompareAll or
+            FindingStrategy.CompareOnlyX or
+            FindingStrategy.CompareOnlyY or
+            FindingStrategy.CompareAllTakeClosest or
+            FindingStrategy.CompareOnlyXTakeClosest or
+            FindingStrategy.CompareOnlyYTakeClosest or
+            FindingStrategy.ExactMatchTakeClosest or
                 _ => base.FindPointsInPosition(chart, pointerPosition, strategy, findPointFor)
         };
     }

--- a/src/LiveChartsCore/ISeries.cs
+++ b/src/LiveChartsCore/ISeries.cs
@@ -166,14 +166,14 @@ public interface ISeries : IChartElement
 
     /// <summary>
     /// Gets the <see cref="ChartPoint"/> instances which contain the <paramref name="pointerPosition"/>, according 
-    /// to the chart's <see cref="TooltipFindingStrategy"/> property.
+    /// to the chart's <see cref="FindingStrategy"/> property.
     /// </summary>
     /// <param name="chart">the chart.</param>
     /// <param name="pointerPosition">the pointer position.</param>
     /// <param name="strategy">the strategy.</param>
     /// <param name="findPointFor">the trigger that fired the search.</param>
     /// <returns></returns>
-    IEnumerable<ChartPoint> FindHitPoints(IChart chart, LvcPoint pointerPosition, TooltipFindingStrategy strategy, FindPointFor findPointFor);
+    IEnumerable<ChartPoint> FindHitPoints(IChart chart, LvcPoint pointerPosition, FindingStrategy strategy, FindPointFor findPointFor);
 
     /// <summary>
     /// Called when the pointer enters a chart point.

--- a/src/LiveChartsCore/Kernel/Drawing/HoverArea.cs
+++ b/src/LiveChartsCore/Kernel/Drawing/HoverArea.cs
@@ -43,7 +43,7 @@ public abstract class HoverArea
     /// <param name="pointerLocation">The pointer location.</param>
     /// <param name="strategy">The strategy.</param>
     /// <returns></returns>
-    public abstract bool IsPointerOver(LvcPoint pointerLocation, TooltipFindingStrategy strategy);
+    public abstract bool IsPointerOver(LvcPoint pointerLocation, FindingStrategy strategy);
 
     /// <summary>
     /// Suggests the tooltip placement.

--- a/src/LiveChartsCore/Kernel/Drawing/RectangleHoverArea.cs
+++ b/src/LiveChartsCore/Kernel/Drawing/RectangleHoverArea.cs
@@ -190,8 +190,8 @@ public class RectangleHoverArea : HoverArea
         return Math.Sqrt(Math.Pow(point.X - cx, 2) + Math.Pow(point.Y - cy, 2));
     }
 
-    /// <inheritdoc cref="HoverArea.IsPointerOver(LvcPoint, TooltipFindingStrategy)"/>
-    public override bool IsPointerOver(LvcPoint pointerLocation, TooltipFindingStrategy strategy)
+    /// <inheritdoc cref="HoverArea.IsPointerOver(LvcPoint, FindingStrategy)"/>
+    public override bool IsPointerOver(LvcPoint pointerLocation, FindingStrategy strategy)
     {
         // at least one pixel to fire the tooltip.
         var w = Width < 1 ? 1 : Width;
@@ -202,11 +202,11 @@ public class RectangleHoverArea : HoverArea
 
         return strategy switch
         {
-            TooltipFindingStrategy.CompareOnlyX or TooltipFindingStrategy.CompareOnlyXTakeClosest => isInX,
-            TooltipFindingStrategy.CompareOnlyY or TooltipFindingStrategy.CompareOnlyYTakeClosest => isInY,
-            TooltipFindingStrategy.CompareAll or TooltipFindingStrategy.CompareAllTakeClosest => isInX && isInY,
-            TooltipFindingStrategy.ExactMatch => isInX && isInY,
-            TooltipFindingStrategy.Automatic => throw new Exception($"The strategy {strategy} is not supported."),
+            FindingStrategy.CompareOnlyX or FindingStrategy.CompareOnlyXTakeClosest => isInX,
+            FindingStrategy.CompareOnlyY or FindingStrategy.CompareOnlyYTakeClosest => isInY,
+            FindingStrategy.CompareAll or FindingStrategy.CompareAllTakeClosest => isInX && isInY,
+            FindingStrategy.ExactMatch => isInX && isInY,
+            FindingStrategy.Automatic => throw new Exception($"The strategy {strategy} is not supported."),
             _ => throw new NotImplementedException()
         };
     }

--- a/src/LiveChartsCore/Kernel/Drawing/SemicircleHoverArea.cs
+++ b/src/LiveChartsCore/Kernel/Drawing/SemicircleHoverArea.cs
@@ -104,8 +104,8 @@ public class SemicircleHoverArea : HoverArea
         return Math.Sqrt(Math.Pow(point.X - x, 2) + Math.Pow(point.Y - y, 2));
     }
 
-    /// <inheritdoc cref="HoverArea.IsPointerOver(LvcPoint, TooltipFindingStrategy)"/>
-    public override bool IsPointerOver(LvcPoint pointerLocation, TooltipFindingStrategy strategy)
+    /// <inheritdoc cref="HoverArea.IsPointerOver(LvcPoint, FindingStrategy)"/>
+    public override bool IsPointerOver(LvcPoint pointerLocation, FindingStrategy strategy)
     {
         var startAngle = GetActualStartAngle();
         var endAngle = GetActualEndAngle();

--- a/src/LiveChartsCore/Kernel/Extensions.cs
+++ b/src/LiveChartsCore/Kernel/Extensions.cs
@@ -505,11 +505,11 @@ public static class Extensions
     }
 
     /// <summary>
-    /// Calculates the tooltips finding strategy based on the series properties.
+    /// Calculates the finding strategy based on the series properties.
     /// </summary>
     /// <param name="seriesCollection">The series collection.</param>
     /// <returns></returns>
-    public static TooltipFindingStrategy GetTooltipFindingStrategy(this IEnumerable<ISeries> seriesCollection)
+    public static FindingStrategy GetFindingStrategy(this IEnumerable<ISeries> seriesCollection)
     {
         var areAllX = true;
         var areAllY = true;
@@ -521,10 +521,10 @@ public static class Extensions
         }
 
         return areAllX
-            ? TooltipFindingStrategy.CompareOnlyXTakeClosest
+            ? FindingStrategy.CompareOnlyXTakeClosest
             : (areAllY
-                ? TooltipFindingStrategy.CompareOnlyYTakeClosest
-                : TooltipFindingStrategy.CompareAllTakeClosest);
+                ? FindingStrategy.CompareOnlyYTakeClosest
+                : FindingStrategy.CompareAllTakeClosest);
     }
 
     /// <summary>

--- a/src/LiveChartsCore/Kernel/LiveChartsSettings.cs
+++ b/src/LiveChartsCore/Kernel/LiveChartsSettings.cs
@@ -132,12 +132,12 @@ public class LiveChartsSettings
     public double MaxTooltipsAndLegendsLabelsWidth { get; set; } = 170;
 
     /// <summary>
-    /// Gets or sets the default tooltip finding strategy.
+    /// Gets or sets the default finding strategy.
     /// </summary>
     /// <value>
-    /// The default tooltip finding strategy.
+    /// The default finding strategy.
     /// </value>
-    public TooltipFindingStrategy TooltipFindingStrategy { get; set; } = TooltipFindingStrategy.Automatic;
+    public FindingStrategy FindingStrategy { get; set; } = FindingStrategy.Automatic;
 
     /// <summary>
     /// Gets or sets the default polar initial rotation.

--- a/src/LiveChartsCore/Kernel/Sketches/ICartesianChartView.cs
+++ b/src/LiveChartsCore/Kernel/Sketches/ICartesianChartView.cs
@@ -91,12 +91,12 @@ public interface ICartesianChartView<TDrawingContext> : IChartView<TDrawingConte
     ZoomAndPanMode ZoomMode { get; set; }
 
     /// <summary>
-    /// Gets or sets the tool tip finding strategy.
+    /// Gets or sets the finding strategy.
     /// </summary>
     /// <value>
-    /// The tool tip finding strategy.
+    /// The finding strategy.
     /// </value>
-    TooltipFindingStrategy TooltipFindingStrategy { get; set; }
+    FindingStrategy FindingStrategy { get; set; }
 
     /// <summary>
     /// Gets or sets the zooming speed from 0 to 1, where 0 is the slowest and 1 the fastest.

--- a/src/LiveChartsCore/Kernel/Sketches/IChart.cs
+++ b/src/LiveChartsCore/Kernel/Sketches/IChart.cs
@@ -70,12 +70,12 @@ public interface IChart
     TooltipPosition TooltipPosition { get; }
 
     /// <summary>
-    /// Gets the toolTip finding strategy.
+    /// Gets the finding strategy.
     /// </summary>
     /// <value>
-    /// The toolTip finding strategy.
+    /// The finding strategy.
     /// </value>
-    TooltipFindingStrategy TooltipFindingStrategy { get; }
+    FindingStrategy FindingStrategy { get; }
 
     /// <summary>
     /// Updates the chart in the user interface.

--- a/src/LiveChartsCore/Kernel/Sketches/IChartView.cs
+++ b/src/LiveChartsCore/Kernel/Sketches/IChartView.cs
@@ -259,10 +259,10 @@ public interface IChartView<TDrawingContext> : IChartView
     /// Gets all the <see cref="ChartPoint"/> that contain the given point.
     /// </summary>
     /// <param name="point">The given point.</param>
-    /// <param name="strategy">The finding strategy, default is <see cref="TooltipFindingStrategy.Automatic"/>.</param>
+    /// <param name="strategy">The finding strategy, default is <see cref="FindingStrategy.Automatic"/>.</param>
     /// <param name="findPointFor">The find point for, default is <see cref="FindPointFor.HoverEvent"/>.</param>
     /// <returns>An enumerable of <see cref="ChartPoint"/>.</returns>
-    IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, TooltipFindingStrategy strategy = TooltipFindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent);
+    IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, FindingStrategy strategy = FindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent);
 
     /// <summary>
     /// Gets all the <see cref="VisualElement{TDrawingContext}"/> that contain the given point.

--- a/src/LiveChartsCore/Measure/FindingStrategy.cs
+++ b/src/LiveChartsCore/Measure/FindingStrategy.cs
@@ -20,16 +20,14 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System;
 using LiveChartsCore.Kernel.Drawing;
 
 namespace LiveChartsCore.Measure;
 
 /// <summary>
-/// Defines the tool tip finding strategy.
+/// Defines the strategy to find points in a chart.
 /// </summary>
-[Obsolete($"Renamed to {nameof(FindingStrategy)}")]
-public enum TooltipFindingStrategy
+public enum FindingStrategy
 {
     /// <summary>
     /// The automatic mode, it will be calculated automatically based on the series and the chart.
@@ -79,37 +77,4 @@ public enum TooltipFindingStrategy
     /// if overlapped then takes the closest to the pointer in each series.
     /// </summary>
     ExactMatchTakeClosest
-}
-
-internal static class ObsoleteMapper
-{
-    public static FindingStrategy AsNew(this TooltipFindingStrategy oldName)
-        => oldName switch
-        {
-            TooltipFindingStrategy.Automatic => FindingStrategy.Automatic,
-            TooltipFindingStrategy.CompareAll => FindingStrategy.CompareAll,
-            TooltipFindingStrategy.CompareOnlyX => FindingStrategy.CompareOnlyX,
-            TooltipFindingStrategy.CompareOnlyY => FindingStrategy.CompareOnlyY,
-            TooltipFindingStrategy.CompareAllTakeClosest => FindingStrategy.CompareAllTakeClosest,
-            TooltipFindingStrategy.CompareOnlyXTakeClosest => FindingStrategy.CompareOnlyXTakeClosest,
-            TooltipFindingStrategy.CompareOnlyYTakeClosest => FindingStrategy.CompareOnlyYTakeClosest,
-            TooltipFindingStrategy.ExactMatch => FindingStrategy.ExactMatch,
-            TooltipFindingStrategy.ExactMatchTakeClosest => FindingStrategy.ExactMatchTakeClosest,
-            _ => throw new NotImplementedException()
-        };
-
-    public static TooltipFindingStrategy AsOld(this FindingStrategy newName)
-        => newName switch
-        {
-            FindingStrategy.Automatic => TooltipFindingStrategy.Automatic,
-            FindingStrategy.CompareAll => TooltipFindingStrategy.CompareAll,
-            FindingStrategy.CompareOnlyX => TooltipFindingStrategy.CompareOnlyX,
-            FindingStrategy.CompareOnlyY => TooltipFindingStrategy.CompareOnlyY,
-            FindingStrategy.CompareAllTakeClosest => TooltipFindingStrategy.CompareAllTakeClosest,
-            FindingStrategy.CompareOnlyXTakeClosest => TooltipFindingStrategy.CompareOnlyXTakeClosest,
-            FindingStrategy.CompareOnlyYTakeClosest => TooltipFindingStrategy.CompareOnlyYTakeClosest,
-            FindingStrategy.ExactMatch => TooltipFindingStrategy.ExactMatch,
-            FindingStrategy.ExactMatchTakeClosest => TooltipFindingStrategy.ExactMatchTakeClosest,
-            _ => throw new NotImplementedException()
-        };
 }

--- a/src/LiveChartsCore/PieChart.cs
+++ b/src/LiveChartsCore/PieChart.cs
@@ -101,7 +101,7 @@ public class PieChart<TDrawingContext>(
         return view.Series
             .Where(series => (series is IPieSeries<TDrawingContext> pieSeries) && !pieSeries.IsFillSeries)
             .Where(series => series.IsHoverable)
-            .SelectMany(series => series.FindHitPoints(this, pointerPosition, TooltipFindingStrategy.CompareAll, FindPointFor.HoverEvent));
+            .SelectMany(series => series.FindHitPoints(this, pointerPosition, FindingStrategy.CompareAll, FindPointFor.HoverEvent));
     }
 
     /// <summary>

--- a/src/LiveChartsCore/PolarChart.cs
+++ b/src/LiveChartsCore/PolarChart.cs
@@ -121,7 +121,7 @@ public class PolarChart<TDrawingContext>(
     {
         return VisibleSeries
             .Where(series => series.IsHoverable)
-            .SelectMany(series => series.FindHitPoints(this, pointerPosition, TooltipFindingStrategy.CompareAll, FindPointFor.HoverEvent));
+            .SelectMany(series => series.FindHitPoints(this, pointerPosition, FindingStrategy.CompareAll, FindPointFor.HoverEvent));
     }
 
     /// <summary>

--- a/src/LiveChartsCore/Series.cs
+++ b/src/LiveChartsCore/Series.cs
@@ -313,9 +313,9 @@ public abstract class Series<TModel, TVisual, TLabel, TDrawingContext>
         ChartPointPointerDown?.Invoke(chart, new ChartPoint<TModel, TVisual, TLabel>(points.FindClosestTo<TModel, TVisual, TLabel>(pointer)!));
     }
 
-    ///<inheritdoc cref="ISeries.FindHitPoints(IChart, LvcPoint, TooltipFindingStrategy, FindPointFor)"/>
+    ///<inheritdoc cref="ISeries.FindHitPoints(IChart, LvcPoint, FindingStrategy, FindPointFor)"/>
     protected virtual IEnumerable<ChartPoint> FindPointsInPosition(
-        IChart chart, LvcPoint pointerPosition, TooltipFindingStrategy strategy, FindPointFor findPointFor)
+        IChart chart, LvcPoint pointerPosition, FindingStrategy strategy, FindPointFor findPointFor)
     {
         var query =
             Fetch(chart)
@@ -344,7 +344,7 @@ public abstract class Series<TModel, TVisual, TLabel, TDrawingContext>
     IEnumerable<ChartPoint> ISeries.FindHitPoints(
         IChart chart,
         LvcPoint pointerPosition,
-        TooltipFindingStrategy strategy,
+        FindingStrategy strategy,
         FindPointFor findPointFor) =>
             FindPointsInPosition(chart, pointerPosition, strategy, findPointFor);
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/CartesianChart.axaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/CartesianChart.axaml.cs
@@ -479,6 +479,7 @@ public class CartesianChart : UserControl, ICartesianChartView<SkiaSharpDrawingC
     }
 
     /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.FindingStrategy" />
+    [Obsolete($"Renamed to {nameof(FindingStrategy)}")]
     public TooltipFindingStrategy TooltipFindingStrategy
     {
         get => ((FindingStrategy)GetValue(FindingStrategyProperty)!).AsOld();

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/CartesianChart.axaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/CartesianChart.axaml.cs
@@ -40,7 +40,6 @@ using LiveChartsCore.Kernel.Sketches;
 using LiveChartsCore.Measure;
 using LiveChartsCore.Motion;
 using LiveChartsCore.SkiaSharpView.Drawing;
-using LiveChartsCore.SkiaSharpView.Painting;
 using LiveChartsCore.SkiaSharpView.SKCharts;
 using LiveChartsCore.VisualElements;
 
@@ -218,9 +217,9 @@ public class CartesianChart : UserControl, ICartesianChartView<SkiaSharpDrawingC
     /// <summary>
     /// The tool tip finding strategy property
     /// </summary>
-    public static readonly AvaloniaProperty<TooltipFindingStrategy> TooltipFindingStrategyProperty =
-        AvaloniaProperty.Register<CartesianChart, TooltipFindingStrategy>(
-            nameof(LegendPosition), LiveCharts.DefaultSettings.TooltipFindingStrategy, inherits: true);
+    public static readonly AvaloniaProperty<FindingStrategy> FindingStrategyProperty =
+        AvaloniaProperty.Register<CartesianChart, FindingStrategy>(
+            nameof(FindingStrategy), LiveCharts.DefaultSettings.FindingStrategy, inherits: true);
 
     /// <summary>
     /// The tooltip background paint property
@@ -472,11 +471,18 @@ public class CartesianChart : UserControl, ICartesianChartView<SkiaSharpDrawingC
     /// <inheritdoc cref="IChartView{TDrawingContext}.Tooltip" />
     public IChartTooltip<SkiaSharpDrawingContext>? Tooltip { get => tooltip; set => tooltip = value; }
 
-    /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.TooltipFindingStrategy" />
+    /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.FindingStrategy" />
+    public FindingStrategy FindingStrategy
+    {
+        get => (FindingStrategy)GetValue(FindingStrategyProperty)!;
+        set => SetValue(FindingStrategyProperty, value);
+    }
+
+    /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.FindingStrategy" />
     public TooltipFindingStrategy TooltipFindingStrategy
     {
-        get => (TooltipFindingStrategy)GetValue(TooltipFindingStrategyProperty)!;
-        set => SetValue(TooltipFindingStrategyProperty, value);
+        get => ((FindingStrategy)GetValue(FindingStrategyProperty)!).AsOld();
+        set => SetValue(FindingStrategyProperty, value.AsNew());
     }
 
     /// <inheritdoc cref="IChartView{TDrawingContext}.TooltipBackgroundPaint" />
@@ -623,13 +629,13 @@ public class CartesianChart : UserControl, ICartesianChartView<SkiaSharpDrawingC
         return new LvcPointD { X = xScaler.ToPixels(point.X), Y = yScaler.ToPixels(point.Y) };
     }
 
-    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, TooltipFindingStrategy, FindPointFor)"/>
-    public IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, TooltipFindingStrategy strategy = TooltipFindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
+    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, FindingStrategy, FindPointFor)"/>
+    public IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, FindingStrategy strategy = FindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
     {
         if (_core is not CartesianChart<SkiaSharpDrawingContext> cc) throw new Exception("core not found");
 
-        if (strategy == TooltipFindingStrategy.Automatic)
-            strategy = cc.Series.GetTooltipFindingStrategy();
+        if (strategy == FindingStrategy.Automatic)
+            strategy = cc.Series.GetFindingStrategy();
 
         return cc.Series.SelectMany(series => series.FindHitPoints(cc, point, strategy, findPointFor));
     }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/PieChart.axaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/PieChart.axaml.cs
@@ -547,13 +547,13 @@ public class PieChart : UserControl, IPieChartView<SkiaSharpDrawingContext>
 
     #endregion
 
-    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, TooltipFindingStrategy, FindPointFor)"/>
-    public IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, TooltipFindingStrategy strategy = TooltipFindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
+    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, FindingStrategy, FindPointFor)"/>
+    public IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, FindingStrategy strategy = FindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
     {
         if (_core is not CartesianChart<SkiaSharpDrawingContext> cc) throw new Exception("core not found");
 
-        if (strategy == TooltipFindingStrategy.Automatic)
-            strategy = cc.Series.GetTooltipFindingStrategy();
+        if (strategy == FindingStrategy.Automatic)
+            strategy = cc.Series.GetFindingStrategy();
 
         return cc.Series.SelectMany(series => series.FindHitPoints(cc, point, strategy, findPointFor));
     }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/PolarChart.axaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/PolarChart.axaml.cs
@@ -201,9 +201,9 @@ public class PolarChart : UserControl, IPolarChartView<SkiaSharpDrawingContext>
     /// <summary>
     /// The tool tip finding strategy property.
     /// </summary>
-    public static readonly AvaloniaProperty<TooltipFindingStrategy> TooltipFindingStrategyProperty =
-        AvaloniaProperty.Register<PolarChart, TooltipFindingStrategy>(
-            nameof(LegendPosition), LiveCharts.DefaultSettings.TooltipFindingStrategy, inherits: true);
+    public static readonly AvaloniaProperty<FindingStrategy> TooltipFindingStrategyProperty =
+        AvaloniaProperty.Register<PolarChart, FindingStrategy>(
+            nameof(LegendPosition), LiveCharts.DefaultSettings.FindingStrategy, inherits: true);
 
     /// <summary>
     /// The tooltip background paint property
@@ -596,13 +596,13 @@ public class PolarChart : UserControl, IPolarChartView<SkiaSharpDrawingContext>
         return new LvcPointD { X = (float)r.X, Y = (float)r.Y };
     }
 
-    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, TooltipFindingStrategy, FindPointFor)"/>
-    public IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, TooltipFindingStrategy strategy = TooltipFindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
+    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, FindingStrategy, FindPointFor)"/>
+    public IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, FindingStrategy strategy = FindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
     {
         if (_core is not PolarChart<SkiaSharpDrawingContext> cc) throw new Exception("core not found");
 
-        if (strategy == TooltipFindingStrategy.Automatic)
-            strategy = cc.Series.GetTooltipFindingStrategy();
+        if (strategy == FindingStrategy.Automatic)
+            strategy = cc.Series.GetFindingStrategy();
 
         return cc.Series.SelectMany(series => series.FindHitPoints(cc, point, strategy, findPointFor));
     }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/CartesianChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/CartesianChart.cs
@@ -33,8 +33,6 @@ using LiveChartsCore.Kernel;
 using LiveChartsCore.Kernel.Sketches;
 using LiveChartsCore.Measure;
 using LiveChartsCore.SkiaSharpView.Drawing;
-using LiveChartsCore.SkiaSharpView.Drawing.Geometries;
-using LiveChartsCore.SkiaSharpView.Painting;
 using LiveChartsCore.SkiaSharpView.SKCharts;
 using LiveChartsCore.VisualElements;
 
@@ -206,10 +204,10 @@ public class CartesianChart : Chart, ICartesianChartView<SkiaSharpDrawingContext
     /// <summary>
     /// The tool tip finding strategy property
     /// </summary>
-    public static readonly DependencyProperty TooltipFindingStrategyProperty =
+    public static readonly DependencyProperty FindingStrategyProperty =
         DependencyProperty.Register(
-            nameof(TooltipFindingStrategy), typeof(TooltipFindingStrategy), typeof(Chart),
-            new PropertyMetadata(LiveCharts.DefaultSettings.TooltipFindingStrategy, OnDependencyPropertyChanged));
+            nameof(FindingStrategy), typeof(FindingStrategy), typeof(Chart),
+            new PropertyMetadata(LiveCharts.DefaultSettings.FindingStrategy, OnDependencyPropertyChanged));
 
     #endregion
 
@@ -279,11 +277,18 @@ public class CartesianChart : Chart, ICartesianChartView<SkiaSharpDrawingContext
         set => SetValueOrCurrentValue(ZoomingSpeedProperty, value);
     }
 
-    /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.TooltipFindingStrategy" />
+    /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.FindingStrategy" />
     public TooltipFindingStrategy TooltipFindingStrategy
     {
-        get => (TooltipFindingStrategy)GetValue(TooltipFindingStrategyProperty);
-        set => SetValue(TooltipFindingStrategyProperty, value);
+        get => ((FindingStrategy)GetValue(FindingStrategyProperty)!).AsOld();
+        set => SetValue(FindingStrategyProperty, value.AsNew());
+    }
+
+    /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.FindingStrategy" />
+    public FindingStrategy FindingStrategy
+    {
+        get => (FindingStrategy)GetValue(FindingStrategyProperty);
+        set => SetValue(FindingStrategyProperty, value);
     }
 
     #endregion
@@ -310,13 +315,13 @@ public class CartesianChart : Chart, ICartesianChartView<SkiaSharpDrawingContext
         return new LvcPointD { X = xScaler.ToPixels(point.X), Y = yScaler.ToPixels(point.Y) };
     }
 
-    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, TooltipFindingStrategy, FindPointFor)"/>
-    public override IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, TooltipFindingStrategy strategy = TooltipFindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
+    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, FindingStrategy, FindPointFor)"/>
+    public override IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, FindingStrategy strategy = FindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
     {
         if (core is not CartesianChart<SkiaSharpDrawingContext> cc) throw new Exception("core not found");
 
-        if (strategy == TooltipFindingStrategy.Automatic)
-            strategy = cc.Series.GetTooltipFindingStrategy();
+        if (strategy == FindingStrategy.Automatic)
+            strategy = cc.Series.GetFindingStrategy();
 
         return cc.Series.SelectMany(series => series.FindHitPoints(cc, point, strategy, findPointFor));
     }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/CartesianChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/CartesianChart.cs
@@ -278,6 +278,7 @@ public class CartesianChart : Chart, ICartesianChartView<SkiaSharpDrawingContext
     }
 
     /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.FindingStrategy" />
+    [Obsolete($"Renamed to {nameof(FindingStrategy)}")]
     public TooltipFindingStrategy TooltipFindingStrategy
     {
         get => ((FindingStrategy)GetValue(FindingStrategyProperty)!).AsOld();

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/Chart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/Chart.cs
@@ -556,8 +556,8 @@ public abstract class Chart : UserControl, IChartView<SkiaSharpDrawingContext>
         core.UpdateFinished += OnCoreUpdateFinished;
     }
 
-    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, TooltipFindingStrategy, FindPointFor)"/>
-    public abstract IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, TooltipFindingStrategy strategy = TooltipFindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent);
+    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, FindingStrategy, FindPointFor)"/>
+    public abstract IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, FindingStrategy strategy = FindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent);
 
     /// <inheritdoc cref="IChartView{TDrawingContext}.GetVisualsAt(LvcPoint)"/>
     public abstract IEnumerable<VisualElement<SkiaSharpDrawingContext>> GetVisualsAt(LvcPoint point);

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/PieChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/PieChart.cs
@@ -161,13 +161,13 @@ public class PieChart : Chart, IPieChartView<SkiaSharpDrawingContext>
         set => SetValue(MinValueProperty, value);
     }
 
-    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, TooltipFindingStrategy, FindPointFor)"/>
-    public override IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, TooltipFindingStrategy strategy = TooltipFindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
+    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, FindingStrategy, FindPointFor)"/>
+    public override IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, FindingStrategy strategy = FindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
     {
         if (core is not PieChart<SkiaSharpDrawingContext> cc) throw new Exception("core not found");
 
-        if (strategy == TooltipFindingStrategy.Automatic)
-            strategy = cc.Series.GetTooltipFindingStrategy();
+        if (strategy == FindingStrategy.Automatic)
+            strategy = cc.Series.GetFindingStrategy();
 
         return cc.Series.SelectMany(series => series.FindHitPoints(cc, point, strategy, findPointFor));
     }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/PolarChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/PolarChart.cs
@@ -262,13 +262,13 @@ public class PolarChart : Chart, IPolarChartView<SkiaSharpDrawingContext>
         return new LvcPointD { X = (float)r.X, Y = (float)r.Y };
     }
 
-    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, TooltipFindingStrategy, FindPointFor)"/>
-    public override IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, TooltipFindingStrategy strategy = TooltipFindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
+    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, FindingStrategy, FindPointFor)"/>
+    public override IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, FindingStrategy strategy = FindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
     {
         if (core is not PolarChart<SkiaSharpDrawingContext> cc) throw new Exception("core not found");
 
-        if (strategy == TooltipFindingStrategy.Automatic)
-            strategy = cc.Series.GetTooltipFindingStrategy();
+        if (strategy == FindingStrategy.Automatic)
+            strategy = cc.Series.GetFindingStrategy();
 
         return cc.Series.SelectMany(series => series.FindHitPoints(cc, point, strategy, findPointFor));
     }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WinForms/CartesianChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WinForms/CartesianChart.cs
@@ -32,8 +32,6 @@ using LiveChartsCore.Kernel;
 using LiveChartsCore.Kernel.Sketches;
 using LiveChartsCore.Measure;
 using LiveChartsCore.SkiaSharpView.Drawing;
-using LiveChartsCore.SkiaSharpView.Drawing.Geometries;
-using LiveChartsCore.SkiaSharpView.Painting;
 using LiveChartsCore.VisualElements;
 
 namespace LiveChartsCore.SkiaSharpView.WinForms;
@@ -50,7 +48,7 @@ public class CartesianChart : Chart, ICartesianChartView<SkiaSharpDrawingContext
     private IEnumerable<ICartesianAxis> _yAxes = new List<Axis> { new() };
     private IEnumerable<Section<SkiaSharpDrawingContext>> _sections = new List<Section<SkiaSharpDrawingContext>>();
     private DrawMarginFrame<SkiaSharpDrawingContext>? _drawMarginFrame;
-    private TooltipFindingStrategy _tooltipFindingStrategy = LiveCharts.DefaultSettings.TooltipFindingStrategy;
+    private FindingStrategy _findingStrategy = LiveCharts.DefaultSettings.FindingStrategy;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CartesianChart"/> class.
@@ -168,9 +166,13 @@ public class CartesianChart : Chart, ICartesianChartView<SkiaSharpDrawingContext
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public double ZoomingSpeed { get; set; } = LiveCharts.DefaultSettings.ZoomSpeed;
 
-    /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.TooltipFindingStrategy" />
+    /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.FindingStrategy" />
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    public TooltipFindingStrategy TooltipFindingStrategy { get => _tooltipFindingStrategy; set { _tooltipFindingStrategy = value; OnPropertyChanged(); } }
+    public TooltipFindingStrategy TooltipFindingStrategy { get => FindingStrategy.AsOld(); set => FindingStrategy = value.AsNew(); }
+
+    /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.FindingStrategy" />
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public FindingStrategy FindingStrategy { get => _findingStrategy; set { _findingStrategy = value; OnPropertyChanged(); } }
 
     /// <summary>
     /// Initializes the core.
@@ -205,13 +207,13 @@ public class CartesianChart : Chart, ICartesianChartView<SkiaSharpDrawingContext
         return new LvcPointD { X = xScaler.ToPixels(point.X), Y = yScaler.ToPixels(point.Y) };
     }
 
-    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, TooltipFindingStrategy, FindPointFor)"/>
-    public override IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, TooltipFindingStrategy strategy = TooltipFindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
+    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, FindingStrategy, FindPointFor)"/>
+    public override IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, FindingStrategy strategy = FindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
     {
         if (core is not CartesianChart<SkiaSharpDrawingContext> cc) throw new Exception("core not found");
 
-        if (strategy == TooltipFindingStrategy.Automatic)
-            strategy = cc.Series.GetTooltipFindingStrategy();
+        if (strategy == FindingStrategy.Automatic)
+            strategy = cc.Series.GetFindingStrategy();
 
         return cc.Series.SelectMany(series => series.FindHitPoints(cc, point, strategy, findPointFor));
     }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WinForms/CartesianChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WinForms/CartesianChart.cs
@@ -168,6 +168,7 @@ public class CartesianChart : Chart, ICartesianChartView<SkiaSharpDrawingContext
 
     /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.FindingStrategy" />
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    [Obsolete($"Renamed to {nameof(FindingStrategy)}")]
     public TooltipFindingStrategy TooltipFindingStrategy { get => FindingStrategy.AsOld(); set => FindingStrategy = value.AsNew(); }
 
     /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.FindingStrategy" />

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WinForms/Chart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WinForms/Chart.cs
@@ -257,8 +257,8 @@ public abstract class Chart : UserControl, IChartView<SkiaSharpDrawingContext>
 
     #endregion
 
-    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, TooltipFindingStrategy, FindPointFor)"/>
-    public abstract IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, TooltipFindingStrategy strategy = TooltipFindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent);
+    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, FindingStrategy, FindPointFor)"/>
+    public abstract IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, FindingStrategy strategy = FindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent);
 
     /// <inheritdoc cref="IChartView{TDrawingContext}.GetVisualsAt(LvcPoint)"/>
     public abstract IEnumerable<VisualElement<SkiaSharpDrawingContext>> GetVisualsAt(LvcPoint point);

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WinForms/PieChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WinForms/PieChart.cs
@@ -104,13 +104,13 @@ public class PieChart : Chart, IPieChartView<SkiaSharpDrawingContext>
     /// <inheritdoc cref="IPieChartView{TDrawingContext}.MinValue" />
     public double MinValue { get => _minValue; set { _minValue = value; OnPropertyChanged(); } }
 
-    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, TooltipFindingStrategy, FindPointFor)"/>
-    public override IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, TooltipFindingStrategy strategy = TooltipFindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
+    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, FindingStrategy, FindPointFor)"/>
+    public override IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, FindingStrategy strategy = FindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
     {
         if (core is not PieChart<SkiaSharpDrawingContext> cc) throw new Exception("core not found");
 
-        if (strategy == TooltipFindingStrategy.Automatic)
-            strategy = cc.Series.GetTooltipFindingStrategy();
+        if (strategy == FindingStrategy.Automatic)
+            strategy = cc.Series.GetFindingStrategy();
 
         return cc.Series.SelectMany(series => series.FindHitPoints(cc, point, strategy, findPointFor));
     }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WinForms/PolarChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WinForms/PolarChart.cs
@@ -215,13 +215,13 @@ public class PolarChart : Chart, IPolarChartView<SkiaSharpDrawingContext>
         return new LvcPointD { X = (float)r.X, Y = (float)r.Y };
     }
 
-    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, TooltipFindingStrategy, FindPointFor)"/>
-    public override IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, TooltipFindingStrategy strategy = TooltipFindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
+    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, FindingStrategy, FindPointFor)"/>
+    public override IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, FindingStrategy strategy = FindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
     {
         if (core is not PolarChart<SkiaSharpDrawingContext> cc) throw new Exception("core not found");
 
-        if (strategy == TooltipFindingStrategy.Automatic)
-            strategy = cc.Series.GetTooltipFindingStrategy();
+        if (strategy == FindingStrategy.Automatic)
+            strategy = cc.Series.GetFindingStrategy();
 
         return cc.Series.SelectMany(series => series.FindHitPoints(cc, point, strategy, findPointFor));
     }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/CartesianChart.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/CartesianChart.xaml.cs
@@ -564,6 +564,7 @@ public partial class CartesianChart : ContentView, ICartesianChartView<SkiaSharp
     }
 
     /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.FindingStrategy" />
+    [Obsolete($"Renamed to {nameof(FindingStrategy)}")]
     public TooltipFindingStrategy TooltipFindingStrategy
     {
         get => ((FindingStrategy)GetValue(FindingStrategyProperty)!).AsOld();

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/CartesianChart.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/CartesianChart.xaml.cs
@@ -35,8 +35,6 @@ using LiveChartsCore.Kernel.Sketches;
 using LiveChartsCore.Measure;
 using LiveChartsCore.Motion;
 using LiveChartsCore.SkiaSharpView.Drawing;
-using LiveChartsCore.SkiaSharpView.Drawing.Geometries;
-using LiveChartsCore.SkiaSharpView.Painting;
 using LiveChartsCore.SkiaSharpView.SKCharts;
 using LiveChartsCore.VisualElements;
 using SkiaSharp.Views.Forms;
@@ -316,10 +314,10 @@ public partial class CartesianChart : ContentView, ICartesianChartView<SkiaSharp
     /// <summary>
     /// The tool tip finding strategy property.
     /// </summary>
-    public static readonly BindableProperty TooltipFindingStrategyProperty =
+    public static readonly BindableProperty FindingStrategyProperty =
         BindableProperty.Create(
-            nameof(TooltipFindingStrategy), typeof(TooltipFindingStrategy), typeof(CartesianChart),
-            LiveCharts.DefaultSettings.TooltipFindingStrategy);
+            nameof(FindingStrategy), typeof(FindingStrategy), typeof(CartesianChart),
+            LiveCharts.DefaultSettings.FindingStrategy);
 
     /// <summary>
     /// The tooltip background paint property.
@@ -565,11 +563,18 @@ public partial class CartesianChart : ContentView, ICartesianChartView<SkiaSharp
         set => SetValue(TooltipPositionProperty, value);
     }
 
-    /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.TooltipFindingStrategy" />
+    /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.FindingStrategy" />
     public TooltipFindingStrategy TooltipFindingStrategy
     {
-        get => (TooltipFindingStrategy)GetValue(TooltipFindingStrategyProperty);
-        set => SetValue(TooltipFindingStrategyProperty, value);
+        get => ((FindingStrategy)GetValue(FindingStrategyProperty)!).AsOld();
+        set => SetValue(FindingStrategyProperty, value.AsNew());
+    }
+
+    /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.FindingStrategy" />
+    public FindingStrategy FindingStrategy
+    {
+        get => (FindingStrategy)GetValue(FindingStrategyProperty);
+        set => SetValue(FindingStrategyProperty, value);
     }
 
     /// <inheritdoc cref="IChartView{TDrawingContext}.TooltipBackgroundPaint" />
@@ -679,13 +684,13 @@ public partial class CartesianChart : ContentView, ICartesianChartView<SkiaSharp
         return new LvcPointD { X = xScaler.ToPixels(point.X), Y = yScaler.ToPixels(point.Y) };
     }
 
-    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, TooltipFindingStrategy, FindPointFor)"/>
-    public IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, TooltipFindingStrategy strategy = TooltipFindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
+    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, FindingStrategy, FindPointFor)"/>
+    public IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, FindingStrategy strategy = FindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
     {
         if (core is not CartesianChart<SkiaSharpDrawingContext> cc) throw new Exception("core not found");
 
-        if (strategy == TooltipFindingStrategy.Automatic)
-            strategy = cc.Series.GetTooltipFindingStrategy();
+        if (strategy == FindingStrategy.Automatic)
+            strategy = cc.Series.GetFindingStrategy();
 
         return cc.Series.SelectMany(series => series.FindHitPoints(cc, point, strategy, findPointFor));
     }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/PieChart.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/PieChart.xaml.cs
@@ -577,13 +577,13 @@ public partial class PieChart : ContentView, IPieChartView<SkiaSharpDrawingConte
 
     #endregion
 
-    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, TooltipFindingStrategy, FindPointFor)"/>
-    public IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, TooltipFindingStrategy strategy = TooltipFindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
+    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, FindingStrategy, FindPointFor)"/>
+    public IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, FindingStrategy strategy = FindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
     {
         if (core is not PieChart<SkiaSharpDrawingContext> cc) throw new Exception("core not found");
 
-        if (strategy == TooltipFindingStrategy.Automatic)
-            strategy = cc.Series.GetTooltipFindingStrategy();
+        if (strategy == FindingStrategy.Automatic)
+            strategy = cc.Series.GetFindingStrategy();
 
         return cc.Series.SelectMany(series => series.FindHitPoints(cc, point, strategy, findPointFor));
     }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/PolarChart.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Xamarin.Forms/PolarChart.xaml.cs
@@ -290,8 +290,8 @@ public partial class PolarChart : ContentView, IPolarChartView<SkiaSharpDrawingC
     /// </summary>
     public static readonly BindableProperty TooltipFindingStrategyProperty =
         BindableProperty.Create(
-            nameof(TooltipFindingStrategy), typeof(TooltipFindingStrategy), typeof(PolarChart),
-            LiveCharts.DefaultSettings.TooltipFindingStrategy);
+            nameof(FindingStrategy), typeof(FindingStrategy), typeof(PolarChart),
+            LiveCharts.DefaultSettings.FindingStrategy);
 
     /// <summary>
     /// The tooltip background paint property.
@@ -648,13 +648,13 @@ public partial class PolarChart : ContentView, IPolarChartView<SkiaSharpDrawingC
         return new LvcPointD { X = (float)r.X, Y = (float)r.Y };
     }
 
-    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, TooltipFindingStrategy, FindPointFor)"/>
-    public IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, TooltipFindingStrategy strategy = TooltipFindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
+    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, FindingStrategy, FindPointFor)"/>
+    public IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, FindingStrategy strategy = FindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
     {
         if (core is not PolarChart<SkiaSharpDrawingContext> cc) throw new Exception("core not found");
 
-        if (strategy == TooltipFindingStrategy.Automatic)
-            strategy = cc.Series.GetTooltipFindingStrategy();
+        if (strategy == FindingStrategy.Automatic)
+            strategy = cc.Series.GetFindingStrategy();
 
         return cc.Series.SelectMany(series => series.FindHitPoints(cc, point, strategy, findPointFor));
     }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/SKCharts/SKCartesianChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/SKCharts/SKCartesianChart.cs
@@ -109,7 +109,10 @@ public class SKCartesianChart : InMemorySkiaSharpChart, ICartesianChartView<Skia
     /// <inheritdoc cref="IChartView{TDrawingContext}.AutoUpdateEnabled"/>
     public bool AutoUpdateEnabled { get; set; }
 
-    /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.TooltipFindingStrategy"/>
+    /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.FindingStrategy"/>
+    public FindingStrategy FindingStrategy { get; set; }
+
+    /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.FindingStrategy"/>
     public TooltipFindingStrategy TooltipFindingStrategy { get; set; }
 
     /// <inheritdoc cref="IChartView{TDrawingContext}.Legend"/>
@@ -205,11 +208,11 @@ public class SKCartesianChart : InMemorySkiaSharpChart, ICartesianChartView<Skia
         return new LvcPointD { X = xScaler.ToPixels(point.X), Y = yScaler.ToPixels(point.Y) };
     }
 
-    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, TooltipFindingStrategy, FindPointFor)"/>
-    public IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, TooltipFindingStrategy strategy = TooltipFindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
+    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, FindingStrategy, FindPointFor)"/>
+    public IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, FindingStrategy strategy = FindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
     {
-        if (strategy == TooltipFindingStrategy.Automatic)
-            strategy = Core.Series.GetTooltipFindingStrategy();
+        if (strategy == FindingStrategy.Automatic)
+            strategy = Core.Series.GetFindingStrategy();
 
         return Core.Series.SelectMany(series => series.FindHitPoints(Core, point, strategy, findPointFor));
     }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/SKCharts/SKPieChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/SKCharts/SKPieChart.cs
@@ -181,11 +181,11 @@ public class SKPieChart : InMemorySkiaSharpChart, IPieChartView<SkiaSharpDrawing
     /// <inheritdoc cref="IChartView{TDrawingContext}.VisualElementsPointerDown"/>
     public event VisualElementsHandler<SkiaSharpDrawingContext>? VisualElementsPointerDown;
 
-    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, TooltipFindingStrategy, FindPointFor)"/>
-    public IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, TooltipFindingStrategy strategy = TooltipFindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
+    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, FindingStrategy, FindPointFor)"/>
+    public IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, FindingStrategy strategy = FindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
     {
-        if (strategy == TooltipFindingStrategy.Automatic)
-            strategy = Core.Series.GetTooltipFindingStrategy();
+        if (strategy == FindingStrategy.Automatic)
+            strategy = Core.Series.GetFindingStrategy();
 
         return Core.Series.SelectMany(series => series.FindHitPoints(Core, point, strategy, findPointFor));
     }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/SKCharts/SKPolarChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/SKCharts/SKPolarChart.cs
@@ -208,11 +208,11 @@ public class SKPolarChart : InMemorySkiaSharpChart, IPolarChartView<SkiaSharpDra
         return new LvcPointD { X = (float)r.X, Y = (float)r.Y };
     }
 
-    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, TooltipFindingStrategy, FindPointFor)"/>
-    public IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, TooltipFindingStrategy strategy = TooltipFindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
+    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, FindingStrategy, FindPointFor)"/>
+    public IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, FindingStrategy strategy = FindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
     {
-        if (strategy == TooltipFindingStrategy.Automatic)
-            strategy = Core.Series.GetTooltipFindingStrategy();
+        if (strategy == FindingStrategy.Automatic)
+            strategy = Core.Series.GetFindingStrategy();
 
         return Core.Series.SelectMany(series => series.FindHitPoints(Core, point, strategy, findPointFor));
     }

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Blazor/CartesianChart.razor.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Blazor/CartesianChart.razor.cs
@@ -28,8 +28,6 @@ using LiveChartsCore.Kernel;
 using LiveChartsCore.Kernel.Sketches;
 using LiveChartsCore.Measure;
 using LiveChartsCore.SkiaSharpView.Drawing;
-using LiveChartsCore.SkiaSharpView.Drawing.Geometries;
-using LiveChartsCore.SkiaSharpView.Painting;
 using LiveChartsCore.VisualElements;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
@@ -49,7 +47,7 @@ public partial class CartesianChart : Chart, ICartesianChartView<SkiaSharpDrawin
     private IEnumerable<ICartesianAxis>? _yAxes;
     private IEnumerable<Section<SkiaSharpDrawingContext>> _sections = new List<Section<SkiaSharpDrawingContext>>();
     private DrawMarginFrame<SkiaSharpDrawingContext>? _drawMarginFrame;
-    private TooltipFindingStrategy _tooltipFindingStrategy = LiveCharts.DefaultSettings.TooltipFindingStrategy;
+    private FindingStrategy _findingStrategy = LiveCharts.DefaultSettings.FindingStrategy;
 
     /// <inheritdoc cref="Chart.OnInitialized"/>
     protected override void OnInitialized()
@@ -161,14 +159,22 @@ public partial class CartesianChart : Chart, ICartesianChartView<SkiaSharpDrawin
     [Parameter]
     public double ZoomingSpeed { get; set; } = LiveCharts.DefaultSettings.ZoomSpeed;
 
-    /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.TooltipFindingStrategy" />
+    /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.FindingStrategy" />
     [Parameter]
     public TooltipFindingStrategy TooltipFindingStrategy
     {
-        get => _tooltipFindingStrategy;
+        get => FindingStrategy.AsOld();
+        set => FindingStrategy = value.AsNew();
+    }
+
+    /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.FindingStrategy" />
+    [Parameter]
+    public FindingStrategy FindingStrategy
+    {
+        get => _findingStrategy;
         set
         {
-            _tooltipFindingStrategy = value;
+            _findingStrategy = value;
             OnPropertyChanged();
         }
     }
@@ -194,13 +200,13 @@ public partial class CartesianChart : Chart, ICartesianChartView<SkiaSharpDrawin
         return new LvcPointD { X = xScaler.ToPixels(point.X), Y = yScaler.ToPixels(point.Y) };
     }
 
-    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, TooltipFindingStrategy, FindPointFor)"/>
-    public override IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, TooltipFindingStrategy strategy = TooltipFindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
+    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, FindingStrategy, FindPointFor)"/>
+    public override IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, FindingStrategy strategy = FindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
     {
         if (core is not CartesianChart<SkiaSharpDrawingContext> cc) throw new Exception("core not found");
 
-        if (strategy == TooltipFindingStrategy.Automatic)
-            strategy = cc.Series.GetTooltipFindingStrategy();
+        if (strategy == FindingStrategy.Automatic)
+            strategy = cc.Series.GetFindingStrategy();
 
         return cc.Series.SelectMany(series => series.FindHitPoints(cc, point, strategy, findPointFor));
     }

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Blazor/CartesianChart.razor.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Blazor/CartesianChart.razor.cs
@@ -161,6 +161,7 @@ public partial class CartesianChart : Chart, ICartesianChartView<SkiaSharpDrawin
 
     /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.FindingStrategy" />
     [Parameter]
+    [Obsolete($"Renamed to {nameof(FindingStrategy)}")]
     public TooltipFindingStrategy TooltipFindingStrategy
     {
         get => FindingStrategy.AsOld();

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Blazor/Chart.razor.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Blazor/Chart.razor.cs
@@ -268,8 +268,8 @@ public partial class Chart : IBlazorChart, IDisposable, IChartView<SkiaSharpDraw
 
     #endregion
 
-    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, TooltipFindingStrategy, FindPointFor)"/>
-    public virtual IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, TooltipFindingStrategy strategy = TooltipFindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
+    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, FindingStrategy, FindPointFor)"/>
+    public virtual IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, FindingStrategy strategy = FindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
     {
         throw new NotImplementedException();
     }

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Blazor/PieChart.razor.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Blazor/PieChart.razor.cs
@@ -93,13 +93,13 @@ public partial class PieChart : Chart, IPieChartView<SkiaSharpDrawingContext>
     [Parameter]
     public double MinValue { get => _minValue; set { _minValue = value; OnPropertyChanged(); } }
 
-    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, TooltipFindingStrategy, FindPointFor)"/>
-    public override IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, TooltipFindingStrategy strategy = TooltipFindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
+    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, FindingStrategy, FindPointFor)"/>
+    public override IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, FindingStrategy strategy = FindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
     {
         if (core is not PieChart<SkiaSharpDrawingContext> cc) throw new Exception("core not found");
 
-        if (strategy == TooltipFindingStrategy.Automatic)
-            strategy = cc.Series.GetTooltipFindingStrategy();
+        if (strategy == FindingStrategy.Automatic)
+            strategy = cc.Series.GetFindingStrategy();
 
         return cc.Series.SelectMany(series => series.FindHitPoints(cc, point, strategy, findPointFor));
     }

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Blazor/PolarChart.razor.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Blazor/PolarChart.razor.cs
@@ -209,13 +209,13 @@ public partial class PolarChart : Chart, IPolarChartView<SkiaSharpDrawingContext
         return new LvcPointD { X = (float)r.X, Y = (float)r.Y };
     }
 
-    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, TooltipFindingStrategy, FindPointFor)"/>
-    public override IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, TooltipFindingStrategy strategy = TooltipFindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
+    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, FindingStrategy, FindPointFor)"/>
+    public override IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, FindingStrategy strategy = FindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
     {
         if (core is not PolarChart<SkiaSharpDrawingContext> cc) throw new Exception("core not found");
 
-        if (strategy == TooltipFindingStrategy.Automatic)
-            strategy = cc.Series.GetTooltipFindingStrategy();
+        if (strategy == FindingStrategy.Automatic)
+            strategy = cc.Series.GetFindingStrategy();
 
         return cc.Series.SelectMany(series => series.FindHitPoints(cc, point, strategy, findPointFor));
     }

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Eto/CartesianChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Eto/CartesianChart.cs
@@ -159,6 +159,7 @@ public class CartesianChart : Chart, ICartesianChartView<SkiaSharpDrawingContext
     public double ZoomingSpeed { get; set; } = LiveCharts.DefaultSettings.ZoomSpeed;
 
     /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.FindingStrategy" />
+    [Obsolete($"Renamed to {nameof(FindingStrategy)}")]
     public TooltipFindingStrategy TooltipFindingStrategy { get => FindingStrategy.AsOld(); set => FindingStrategy = value.AsNew(); }
 
     /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.FindingStrategy" />

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Eto/CartesianChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Eto/CartesianChart.cs
@@ -32,8 +32,6 @@ using LiveChartsCore.Kernel;
 using LiveChartsCore.Kernel.Sketches;
 using LiveChartsCore.Measure;
 using LiveChartsCore.SkiaSharpView.Drawing;
-using LiveChartsCore.SkiaSharpView.Drawing.Geometries;
-using LiveChartsCore.SkiaSharpView.Painting;
 using LiveChartsCore.VisualElements;
 
 namespace LiveChartsCore.SkiaSharpView.Eto;
@@ -50,7 +48,7 @@ public class CartesianChart : Chart, ICartesianChartView<SkiaSharpDrawingContext
     private IEnumerable<ICartesianAxis> _yAxes = new List<Axis> { new() };
     private IEnumerable<Section<SkiaSharpDrawingContext>> _sections = new List<Section<SkiaSharpDrawingContext>>();
     private DrawMarginFrame<SkiaSharpDrawingContext>? _drawMarginFrame;
-    private TooltipFindingStrategy _tooltipFindingStrategy = LiveCharts.DefaultSettings.TooltipFindingStrategy;
+    private FindingStrategy _findingStrategy = LiveCharts.DefaultSettings.FindingStrategy;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CartesianChart"/> class.
@@ -160,8 +158,11 @@ public class CartesianChart : Chart, ICartesianChartView<SkiaSharpDrawingContext
     /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.ZoomingSpeed" />
     public double ZoomingSpeed { get; set; } = LiveCharts.DefaultSettings.ZoomSpeed;
 
-    /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.TooltipFindingStrategy" />
-    public TooltipFindingStrategy TooltipFindingStrategy { get => _tooltipFindingStrategy; set { _tooltipFindingStrategy = value; OnPropertyChanged(); } }
+    /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.FindingStrategy" />
+    public TooltipFindingStrategy TooltipFindingStrategy { get => FindingStrategy.AsOld(); set => FindingStrategy = value.AsNew(); }
+
+    /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.FindingStrategy" />
+    public FindingStrategy FindingStrategy { get => _findingStrategy; set { _findingStrategy = value; OnPropertyChanged(); } }
 
     /// <summary>
     /// Initializes the core.
@@ -209,13 +210,13 @@ public class CartesianChart : Chart, ICartesianChartView<SkiaSharpDrawingContext
         return new LvcPointD { X = xScaler.ToPixels(point.X), Y = yScaler.ToPixels(point.Y) };
     }
 
-    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, TooltipFindingStrategy, FindPointFor)"/>
-    public override IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, TooltipFindingStrategy strategy = TooltipFindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
+    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, FindingStrategy, FindPointFor)"/>
+    public override IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, FindingStrategy strategy = FindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
     {
         if (core is not CartesianChart<SkiaSharpDrawingContext> cc) throw new Exception("core not found");
 
-        if (strategy == TooltipFindingStrategy.Automatic)
-            strategy = cc.Series.GetTooltipFindingStrategy();
+        if (strategy == FindingStrategy.Automatic)
+            strategy = cc.Series.GetFindingStrategy();
 
         return cc.Series.SelectMany(series => series.FindHitPoints(cc, point, strategy, findPointFor));
     }

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Eto/Chart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Eto/Chart.cs
@@ -254,8 +254,8 @@ public abstract class Chart : Panel, IChartView<SkiaSharpDrawingContext>
 
     #endregion
 
-    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, TooltipFindingStrategy, FindPointFor)"/>
-    public abstract IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, TooltipFindingStrategy strategy = TooltipFindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent);
+    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, FindingStrategy, FindPointFor)"/>
+    public abstract IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, FindingStrategy strategy = FindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent);
 
     /// <inheritdoc cref="IChartView{TDrawingContext}.GetVisualsAt(LvcPoint)"/>
     public abstract IEnumerable<VisualElement<SkiaSharpDrawingContext>> GetVisualsAt(LvcPoint point);

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Eto/PieChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Eto/PieChart.cs
@@ -98,13 +98,13 @@ public class PieChart : Chart, IPieChartView<SkiaSharpDrawingContext>
     /// <inheritdoc cref="IPieChartView{TDrawingContext}.MinValue" />
     public double MinValue { get => _minValue; set { _minValue = value; OnPropertyChanged(); } }
 
-    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, TooltipFindingStrategy, FindPointFor)"/>
-    public override IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, TooltipFindingStrategy strategy = TooltipFindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
+    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, FindingStrategy, FindPointFor)"/>
+    public override IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, FindingStrategy strategy = FindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
     {
         if (core is not PieChart<SkiaSharpDrawingContext> cc) throw new Exception("core not found");
 
-        if (strategy == TooltipFindingStrategy.Automatic)
-            strategy = cc.Series.GetTooltipFindingStrategy();
+        if (strategy == FindingStrategy.Automatic)
+            strategy = cc.Series.GetFindingStrategy();
 
         return cc.Series.SelectMany(series => series.FindHitPoints(cc, point, strategy, findPointFor));
     }

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Eto/PolarChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Eto/PolarChart.cs
@@ -218,13 +218,13 @@ public class PolarChart : Chart, IPolarChartView<SkiaSharpDrawingContext>
         return new LvcPointD { X = (float)r.X, Y = (float)r.Y };
     }
 
-    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, TooltipFindingStrategy, FindPointFor)"/>
-    public override IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, TooltipFindingStrategy strategy = TooltipFindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
+    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, FindingStrategy, FindPointFor)"/>
+    public override IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, FindingStrategy strategy = FindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
     {
         if (core is not PolarChart<SkiaSharpDrawingContext> cc) throw new Exception("core not found");
 
-        if (strategy == TooltipFindingStrategy.Automatic)
-            strategy = cc.Series.GetTooltipFindingStrategy();
+        if (strategy == FindingStrategy.Automatic)
+            strategy = cc.Series.GetFindingStrategy();
 
         return cc.Series.SelectMany(series => series.FindHitPoints(cc, point, strategy, findPointFor));
     }

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/CartesianChart.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/CartesianChart.xaml.cs
@@ -35,8 +35,6 @@ using LiveChartsCore.Kernel.Sketches;
 using LiveChartsCore.Measure;
 using LiveChartsCore.Motion;
 using LiveChartsCore.SkiaSharpView.Drawing;
-using LiveChartsCore.SkiaSharpView.Drawing.Geometries;
-using LiveChartsCore.SkiaSharpView.Painting;
 using LiveChartsCore.SkiaSharpView.SKCharts;
 using LiveChartsCore.VisualElements;
 using Microsoft.Maui.ApplicationModel;
@@ -307,10 +305,10 @@ public partial class CartesianChart : ContentView, ICartesianChartView<SkiaSharp
     /// <summary>
     /// The tool tip finding strategy property.
     /// </summary>
-    public static readonly BindableProperty TooltipFindingStrategyProperty =
+    public static readonly BindableProperty FindingStrategyProperty =
         BindableProperty.Create(
-            nameof(TooltipFindingStrategy), typeof(TooltipFindingStrategy), typeof(CartesianChart),
-            LiveCharts.DefaultSettings.TooltipFindingStrategy);
+            nameof(FindingStrategy), typeof(FindingStrategy), typeof(CartesianChart),
+            LiveCharts.DefaultSettings.FindingStrategy);
 
     /// <summary>
     /// The tooltip background property.
@@ -563,11 +561,18 @@ public partial class CartesianChart : ContentView, ICartesianChartView<SkiaSharp
         set => SetValue(TooltipPositionProperty, value);
     }
 
-    /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.TooltipFindingStrategy" />
+    /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.FindingStrategy" />
     public TooltipFindingStrategy TooltipFindingStrategy
     {
-        get => (TooltipFindingStrategy)GetValue(TooltipFindingStrategyProperty);
-        set => SetValue(TooltipFindingStrategyProperty, value);
+        get => ((FindingStrategy)GetValue(FindingStrategyProperty)!).AsOld();
+        set => SetValue(FindingStrategyProperty, value.AsNew());
+    }
+
+    /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.FindingStrategy" />
+    public FindingStrategy FindingStrategy
+    {
+        get => (FindingStrategy)GetValue(FindingStrategyProperty);
+        set => SetValue(FindingStrategyProperty, value);
     }
 
     /// <inheritdoc cref="IChartView{TDrawingContext}.TooltipBackgroundPaint" />
@@ -686,13 +691,13 @@ public partial class CartesianChart : ContentView, ICartesianChartView<SkiaSharp
         return new LvcPointD { X = xScaler.ToPixels(point.X), Y = yScaler.ToPixels(point.Y) };
     }
 
-    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, TooltipFindingStrategy, FindPointFor)"/>
-    public IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, TooltipFindingStrategy strategy = TooltipFindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
+    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, FindingStrategy, FindPointFor)"/>
+    public IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, FindingStrategy strategy = FindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
     {
         if (_core is not CartesianChart<SkiaSharpDrawingContext> cc) throw new Exception("core not found");
 
-        if (strategy == TooltipFindingStrategy.Automatic)
-            strategy = cc.Series.GetTooltipFindingStrategy();
+        if (strategy == FindingStrategy.Automatic)
+            strategy = cc.Series.GetFindingStrategy();
 
         return cc.Series.SelectMany(series => series.FindHitPoints(cc, point, strategy, FindPointFor.HoverEvent));
     }

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/CartesianChart.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/CartesianChart.xaml.cs
@@ -562,6 +562,7 @@ public partial class CartesianChart : ContentView, ICartesianChartView<SkiaSharp
     }
 
     /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.FindingStrategy" />
+    [Obsolete($"Renamed to {nameof(FindingStrategy)}")]
     public TooltipFindingStrategy TooltipFindingStrategy
     {
         get => ((FindingStrategy)GetValue(FindingStrategyProperty)!).AsOld();

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/PieChart.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/PieChart.xaml.cs
@@ -587,13 +587,13 @@ public partial class PieChart : ContentView, IPieChartView<SkiaSharpDrawingConte
 
     #endregion
 
-    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, TooltipFindingStrategy, FindPointFor)"/>
-    public IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, TooltipFindingStrategy strategy = TooltipFindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
+    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, FindingStrategy, FindPointFor)"/>
+    public IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, FindingStrategy strategy = FindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
     {
         if (_core is not PieChart<SkiaSharpDrawingContext> cc) throw new Exception("core not found");
 
-        if (strategy == TooltipFindingStrategy.Automatic)
-            strategy = cc.Series.GetTooltipFindingStrategy();
+        if (strategy == FindingStrategy.Automatic)
+            strategy = cc.Series.GetFindingStrategy();
 
         return cc.Series.SelectMany(series => series.FindHitPoints(cc, point, strategy, findPointFor));
     }

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/PolarChart.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/PolarChart.xaml.cs
@@ -284,8 +284,8 @@ public partial class PolarChart : ContentView, IPolarChartView<SkiaSharpDrawingC
     /// </summary>
     public static readonly BindableProperty TooltipFindingStrategyProperty =
         BindableProperty.Create(
-            nameof(TooltipFindingStrategy), typeof(TooltipFindingStrategy), typeof(PolarChart),
-            LiveCharts.DefaultSettings.TooltipFindingStrategy);
+            nameof(FindingStrategy), typeof(FindingStrategy), typeof(PolarChart),
+            LiveCharts.DefaultSettings.FindingStrategy);
 
     /// <summary>
     /// The tooltip background property.
@@ -661,13 +661,13 @@ public partial class PolarChart : ContentView, IPolarChartView<SkiaSharpDrawingC
         return new LvcPointD { X = (float)r.X, Y = (float)r.Y };
     }
 
-    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, TooltipFindingStrategy, FindPointFor)"/>
-    public IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, TooltipFindingStrategy strategy = TooltipFindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
+    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, FindingStrategy, FindPointFor)"/>
+    public IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, FindingStrategy strategy = FindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
     {
         if (_core is not PolarChart<SkiaSharpDrawingContext> cc) throw new Exception("core not found");
 
-        if (strategy == TooltipFindingStrategy.Automatic)
-            strategy = cc.Series.GetTooltipFindingStrategy();
+        if (strategy == FindingStrategy.Automatic)
+            strategy = cc.Series.GetFindingStrategy();
 
         return cc.Series.SelectMany(series => series.FindHitPoints(cc, point, strategy, findPointFor));
     }

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Uno.WinUI/CartesianChart.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Uno.WinUI/CartesianChart.xaml.cs
@@ -516,6 +516,7 @@ public sealed partial class CartesianChart : UserControl, ICartesianChartView<Sk
     }
 
     /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.FindingStrategy" />
+    [Obsolete($"Renamed to {nameof(FindingStrategy)}")]
     public TooltipFindingStrategy TooltipFindingStrategy
     {
         get => ((FindingStrategy)GetValue(FindingStrategyProperty)!).AsOld();

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Uno.WinUI/CartesianChart.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Uno.WinUI/CartesianChart.xaml.cs
@@ -39,7 +39,6 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using LiveChartsCore.SkiaSharpView.WinUI.Helpers;
-using LiveChartsCore.SkiaSharpView.Painting;
 using LiveChartsCore.VisualElements;
 using System.Linq;
 using LiveChartsCore.SkiaSharpView.SKCharts;
@@ -226,10 +225,10 @@ public sealed partial class CartesianChart : UserControl, ICartesianChartView<Sk
     /// <summary>
     /// The tool tip finding strategy property
     /// </summary>
-    public static readonly DependencyProperty TooltipFindingStrategyProperty =
+    public static readonly DependencyProperty FindingStrategyProperty =
         DependencyProperty.Register(
-            nameof(TooltipFindingStrategy), typeof(TooltipFindingStrategy), typeof(CartesianChart),
-            new PropertyMetadata(LiveCharts.DefaultSettings.TooltipFindingStrategy, OnDependencyPropertyChanged));
+            nameof(FindingStrategy), typeof(FindingStrategy), typeof(CartesianChart),
+            new PropertyMetadata(LiveCharts.DefaultSettings.FindingStrategy, OnDependencyPropertyChanged));
 
     /// <summary>
     /// The draw margin property
@@ -516,11 +515,18 @@ public sealed partial class CartesianChart : UserControl, ICartesianChartView<Sk
         set => SetValue(ZoomingSpeedProperty, value);
     }
 
-    /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.TooltipFindingStrategy" />
+    /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.FindingStrategy" />
     public TooltipFindingStrategy TooltipFindingStrategy
     {
-        get => (TooltipFindingStrategy)GetValue(TooltipFindingStrategyProperty);
-        set => SetValue(TooltipFindingStrategyProperty, value);
+        get => ((FindingStrategy)GetValue(FindingStrategyProperty)!).AsOld();
+        set => SetValue(FindingStrategyProperty, value.AsNew());
+    }
+
+    /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.FindingStrategy" />
+    public FindingStrategy FindingStrategy
+    {
+        get => (FindingStrategy)GetValue(FindingStrategyProperty);
+        set => SetValue(FindingStrategyProperty, value);
     }
 
     /// <inheritdoc cref="IChartView.AnimationsSpeed" />
@@ -709,13 +715,13 @@ public sealed partial class CartesianChart : UserControl, ICartesianChartView<Sk
         return new LvcPointD { X = xScaler.ToPixels(point.X), Y = yScaler.ToPixels(point.Y) };
     }
 
-    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, TooltipFindingStrategy, FindPointFor)"/>
-    public IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, TooltipFindingStrategy strategy = TooltipFindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
+    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, FindingStrategy, FindPointFor)"/>
+    public IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, FindingStrategy strategy = FindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
     {
         if (_core is not CartesianChart<SkiaSharpDrawingContext> cc) throw new Exception("core not found");
 
-        if (strategy == TooltipFindingStrategy.Automatic)
-            strategy = cc.Series.GetTooltipFindingStrategy();
+        if (strategy == FindingStrategy.Automatic)
+            strategy = cc.Series.GetFindingStrategy();
 
         return cc.Series.SelectMany(series => series.FindHitPoints(cc, point, strategy, findPointFor));
     }

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Uno.WinUI/PieChart.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Uno.WinUI/PieChart.xaml.cs
@@ -591,13 +591,13 @@ public sealed partial class PieChart : UserControl, IPieChartView<SkiaSharpDrawi
 
     #endregion
 
-    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, TooltipFindingStrategy, FindPointFor)"/>
-    public IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, TooltipFindingStrategy strategy = TooltipFindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
+    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, FindingStrategy, FindPointFor)"/>
+    public IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, FindingStrategy strategy = FindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
     {
         if (_core is not PieChart<SkiaSharpDrawingContext> cc) throw new Exception("core not found");
 
-        if (strategy == TooltipFindingStrategy.Automatic)
-            strategy = cc.Series.GetTooltipFindingStrategy();
+        if (strategy == FindingStrategy.Automatic)
+            strategy = cc.Series.GetFindingStrategy();
 
         return cc.Series.SelectMany(series => series.FindHitPoints(cc, point, strategy, findPointFor));
     }

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Uno.WinUI/PolarChart.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Uno.WinUI/PolarChart.xaml.cs
@@ -211,8 +211,8 @@ public sealed partial class PolarChart : UserControl, IPolarChartView<SkiaSharpD
     /// </summary>
     public static readonly DependencyProperty TooltipFindingStrategyProperty =
         DependencyProperty.Register(
-            nameof(TooltipFindingStrategy), typeof(TooltipFindingStrategy), typeof(PolarChart),
-            new PropertyMetadata(LiveCharts.DefaultSettings.TooltipFindingStrategy, OnDependencyPropertyChanged));
+            nameof(FindingStrategy), typeof(FindingStrategy), typeof(PolarChart),
+            new PropertyMetadata(LiveCharts.DefaultSettings.FindingStrategy, OnDependencyPropertyChanged));
 
     /// <summary>
     /// The animations speed property.
@@ -671,13 +671,13 @@ public sealed partial class PolarChart : UserControl, IPolarChartView<SkiaSharpD
         return new LvcPointD { X = (float)r.X, Y = (float)r.Y };
     }
 
-    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, TooltipFindingStrategy, FindPointFor)"/>
-    public IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, TooltipFindingStrategy strategy = TooltipFindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
+    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, FindingStrategy, FindPointFor)"/>
+    public IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, FindingStrategy strategy = FindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
     {
         if (_core is not PolarChart<SkiaSharpDrawingContext> cc) throw new Exception("core not found");
 
-        if (strategy == TooltipFindingStrategy.Automatic)
-            strategy = cc.Series.GetTooltipFindingStrategy();
+        if (strategy == FindingStrategy.Automatic)
+            strategy = cc.Series.GetFindingStrategy();
 
         return cc.Series.SelectMany(series => series.FindHitPoints(cc, point, strategy, findPointFor));
     }

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.WinUI/CartesianChart.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.WinUI/CartesianChart.xaml.cs
@@ -511,6 +511,7 @@ public sealed partial class CartesianChart : UserControl, ICartesianChartView<Sk
     }
 
     /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.FindingStrategy" />
+    [Obsolete($"Renamed to {nameof(FindingStrategy)}")]
     public TooltipFindingStrategy TooltipFindingStrategy
     {
         get => ((FindingStrategy)GetValue(FindingStrategyProperty)!).AsOld();

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.WinUI/CartesianChart.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.WinUI/CartesianChart.xaml.cs
@@ -34,7 +34,6 @@ using LiveChartsCore.Kernel.Sketches;
 using LiveChartsCore.Measure;
 using LiveChartsCore.Motion;
 using LiveChartsCore.SkiaSharpView.Drawing;
-using LiveChartsCore.SkiaSharpView.Painting;
 using LiveChartsCore.SkiaSharpView.SKCharts;
 using LiveChartsCore.VisualElements;
 using Microsoft.UI.Xaml;
@@ -221,10 +220,10 @@ public sealed partial class CartesianChart : UserControl, ICartesianChartView<Sk
     /// <summary>
     /// The tool tip finding strategy property
     /// </summary>
-    public static readonly DependencyProperty TooltipFindingStrategyProperty =
+    public static readonly DependencyProperty FindingStrategyProperty =
         DependencyProperty.Register(
-            nameof(TooltipFindingStrategy), typeof(TooltipFindingStrategy), typeof(CartesianChart),
-            new PropertyMetadata(LiveCharts.DefaultSettings.TooltipFindingStrategy, OnDependencyPropertyChanged));
+            nameof(FindingStrategy), typeof(FindingStrategy), typeof(CartesianChart),
+            new PropertyMetadata(LiveCharts.DefaultSettings.FindingStrategy, OnDependencyPropertyChanged));
 
     /// <summary>
     /// The draw margin property
@@ -511,11 +510,18 @@ public sealed partial class CartesianChart : UserControl, ICartesianChartView<Sk
         set => SetValue(ZoomingSpeedProperty, value);
     }
 
-    /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.TooltipFindingStrategy" />
+    /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.FindingStrategy" />
     public TooltipFindingStrategy TooltipFindingStrategy
     {
-        get => (TooltipFindingStrategy)GetValue(TooltipFindingStrategyProperty);
-        set => SetValue(TooltipFindingStrategyProperty, value);
+        get => ((FindingStrategy)GetValue(FindingStrategyProperty)!).AsOld();
+        set => SetValue(FindingStrategyProperty, value.AsNew());
+    }
+
+    /// <inheritdoc cref="ICartesianChartView{TDrawingContext}.FindingStrategy" />
+    public FindingStrategy FindingStrategy
+    {
+        get => (FindingStrategy)GetValue(FindingStrategyProperty);
+        set => SetValue(FindingStrategyProperty, value);
     }
 
     /// <inheritdoc cref="IChartView.AnimationsSpeed" />
@@ -698,13 +704,13 @@ public sealed partial class CartesianChart : UserControl, ICartesianChartView<Sk
         return new LvcPointD { X = xScaler.ToPixels(point.X), Y = yScaler.ToPixels(point.Y) };
     }
 
-    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, TooltipFindingStrategy, FindPointFor)"/>
-    public IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, TooltipFindingStrategy strategy = TooltipFindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
+    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, FindingStrategy, FindPointFor)"/>
+    public IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, FindingStrategy strategy = FindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
     {
         if (_core is not CartesianChart<SkiaSharpDrawingContext> cc) throw new Exception("core not found");
 
-        if (strategy == TooltipFindingStrategy.Automatic)
-            strategy = cc.Series.GetTooltipFindingStrategy();
+        if (strategy == FindingStrategy.Automatic)
+            strategy = cc.Series.GetFindingStrategy();
 
         return cc.Series.SelectMany(series => series.FindHitPoints(cc, point, strategy, findPointFor));
     }

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.WinUI/PieChart.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.WinUI/PieChart.xaml.cs
@@ -601,13 +601,13 @@ public sealed partial class PieChart : UserControl, IPieChartView<SkiaSharpDrawi
 
     #endregion
 
-    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, TooltipFindingStrategy, FindPointFor)"/>
-    public IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, TooltipFindingStrategy strategy = TooltipFindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
+    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, FindingStrategy, FindPointFor)"/>
+    public IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, FindingStrategy strategy = FindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
     {
         if (_core is not PieChart<SkiaSharpDrawingContext> cc) throw new Exception("core not found");
 
-        if (strategy == TooltipFindingStrategy.Automatic)
-            strategy = cc.Series.GetTooltipFindingStrategy();
+        if (strategy == FindingStrategy.Automatic)
+            strategy = cc.Series.GetFindingStrategy();
 
         return cc.Series.SelectMany(series => series.FindHitPoints(cc, point, strategy, findPointFor));
     }

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.WinUI/PolarChart.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.WinUI/PolarChart.xaml.cs
@@ -663,13 +663,13 @@ public sealed partial class PolarChart : UserControl, IPolarChartView<SkiaSharpD
         return new LvcPointD { X = (float)r.X, Y = (float)r.Y };
     }
 
-    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, TooltipFindingStrategy, FindPointFor)"/>
-    public IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, TooltipFindingStrategy strategy = TooltipFindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
+    /// <inheritdoc cref="IChartView{TDrawingContext}.GetPointsAt(LvcPoint, FindingStrategy, FindPointFor)"/>
+    public IEnumerable<ChartPoint> GetPointsAt(LvcPoint point, FindingStrategy strategy = FindingStrategy.Automatic, FindPointFor findPointFor = FindPointFor.HoverEvent)
     {
         if (_core is not PolarChart<SkiaSharpDrawingContext> cc) throw new Exception("core not found");
 
-        if (strategy == TooltipFindingStrategy.Automatic)
-            strategy = cc.Series.GetTooltipFindingStrategy();
+        if (strategy == FindingStrategy.Automatic)
+            strategy = cc.Series.GetFindingStrategy();
 
         return cc.Series.SelectMany(series => series.FindHitPoints(cc, point, strategy, findPointFor));
     }

--- a/tests/LiveChartsCore.UnitTesting/OtherTests/DataProviderTest.cs
+++ b/tests/LiveChartsCore.UnitTesting/OtherTests/DataProviderTest.cs
@@ -299,7 +299,7 @@ public class DataProviderTest
         {
             Width = 100,
             Height = 100,
-            TooltipFindingStrategy = Measure.TooltipFindingStrategy.ExactMatch,
+            FindingStrategy = Measure.FindingStrategy.ExactMatch,
             Series = [sutSeries]
         };
 

--- a/tests/LiveChartsCore.UnitTesting/OtherTests/EventsTests.cs
+++ b/tests/LiveChartsCore.UnitTesting/OtherTests/EventsTests.cs
@@ -62,7 +62,7 @@ public class EventsTests
 
         // Test points.
         // Charts use the Series.FindHitPoints method to check if the mouse is over a point.
-        var strategy = chart.Series.GetTooltipFindingStrategy();
+        var strategy = chart.Series.GetFindingStrategy();
         var s = chart.Series
             .SelectMany(x => x.FindHitPoints(chart.Core, new LvcPoint(251, 251), strategy, FindPointFor.HoverEvent))
             .ToArray();


### PR DESCRIPTION
Fixes name inconsistency, renames `TooltipFindingStrategy` to `FindingStrategy`.

Becuase this strategy is not only used on tooltips, but also on PointerDown, Hover and Hover lost events.

There are no braking changes here, TooltipFindingStrategy is still valid, but marked as obsolete.