### PR TITLE
Fix 1589

### DIFF
--- a/src/LiveChartsCore/CoreAxis.cs
+++ b/src/LiveChartsCore/CoreAxis.cs
@@ -817,14 +817,16 @@ public abstract class CoreAxis<TTextGeometry, TLineGeometry>
         IEnumerable<ICartesianSeries> allSeries)
     {
         ChartPoint? closestPoint = null;
+        var strategy = allSeries.GetFindingStrategy();
+
         foreach (var series in allSeries)
         {
-            var hitpoints = series.FindHitPoints(cartesianChart, pointerPosition, allSeries.GetFindingStrategy(), FindPointFor.PointerDownEvent);
+            var hitpoints = series.FindHitPoints(cartesianChart, pointerPosition, strategy, FindPointFor.PointerDownEvent);
             var hitpoint = hitpoints.FirstOrDefault();
             if (hitpoint == null) continue;
 
             if (closestPoint is null ||
-                hitpoint.DistanceTo(pointerPosition) < closestPoint.DistanceTo(pointerPosition))
+                hitpoint.DistanceTo(pointerPosition, strategy) < closestPoint.DistanceTo(pointerPosition, strategy))
             {
                 closestPoint = hitpoint;
             }

--- a/src/LiveChartsCore/CoreLineSeries.cs
+++ b/src/LiveChartsCore/CoreLineSeries.cs
@@ -531,7 +531,7 @@ public abstract class CoreLineSeries<TModel, TVisual, TLabel, TPathGeometry, TEr
                         pointerPosition.Y > y && pointerPosition.Y < y + v.Height;
                 }),
             FindingStrategy.ExactMatchTakeClosest => Fetch(chart)
-                .Select(x => new { distance = x.DistanceTo(pointerPosition), point = x })
+                .Select(x => new { distance = x.DistanceTo(pointerPosition, strategy), point = x })
                 .OrderBy(x => x.distance)
                 .SelectFirst(x => x.point),
             FindingStrategy.Automatic or

--- a/src/LiveChartsCore/CoreStepLineSeries.cs
+++ b/src/LiveChartsCore/CoreStepLineSeries.cs
@@ -460,7 +460,7 @@ public abstract class CoreStepLineSeries<TModel, TVisual, TLabel, TPathGeometry,
                         pointerPosition.Y > y && pointerPosition.Y < y + v.Height;
                 }),
             FindingStrategy.ExactMatchTakeClosest => Fetch(chart)
-                .Select(x => new { distance = x.DistanceTo(pointerPosition), point = x })
+                .Select(x => new { distance = x.DistanceTo(pointerPosition, strategy), point = x })
                 .OrderBy(x => x.distance)
                 .SelectFirst(x => x.point),
             FindingStrategy.Automatic or

--- a/src/LiveChartsCore/Kernel/ChartPoint.cs
+++ b/src/LiveChartsCore/Kernel/ChartPoint.cs
@@ -22,6 +22,7 @@
 
 using LiveChartsCore.Drawing;
 using LiveChartsCore.Kernel.Sketches;
+using LiveChartsCore.Measure;
 
 namespace LiveChartsCore.Kernel;
 
@@ -109,11 +110,10 @@ public class ChartPoint
     /// Gets the distance to a given point.
     /// </summary>
     /// <param name="point">The point to calculate the distance to.</param>
+    /// <param name="strategy">The strategy to use to calculate the distance.</param>
     /// <returns>The distance in pixels.</returns>
-    public double DistanceTo(LvcPoint point)
-    {
-        return Context.HoverArea?.DistanceTo(point) ?? double.NaN;
-    }
+    public double DistanceTo(LvcPoint point, FindingStrategy strategy) =>
+        Context.HoverArea?.DistanceTo(point, strategy) ?? double.NaN;
 
     private void SetCoordinate(
         double primary = double.NaN, double secondary = double.NaN, double tertiary = double.NaN,

--- a/src/LiveChartsCore/Kernel/Drawing/HoverArea.cs
+++ b/src/LiveChartsCore/Kernel/Drawing/HoverArea.cs
@@ -34,8 +34,9 @@ public abstract class HoverArea
     /// Gets the distance to a given point.
     /// </summary>
     /// <param name="point">The point to calculate the distance to.</param>
+    /// <param name="strategy">The strategy.</param>
     /// <returns>The distance in pixels.</returns>
-    public abstract double DistanceTo(LvcPoint point);
+    public abstract double DistanceTo(LvcPoint point, FindingStrategy strategy);
 
     /// <summary>
     /// Determines whether the pointer is over the area.

--- a/src/LiveChartsCore/Kernel/Drawing/RectangleHoverArea.cs
+++ b/src/LiveChartsCore/Kernel/Drawing/RectangleHoverArea.cs
@@ -181,13 +181,25 @@ public class RectangleHoverArea : HoverArea
         return this;
     }
 
-    /// <inheritdoc cref="HoverArea.DistanceTo(LvcPoint)"/>
-    public override double DistanceTo(LvcPoint point)
+    /// <inheritdoc cref="HoverArea.DistanceTo(LvcPoint, FindingStrategy)"/>
+    public override double DistanceTo(LvcPoint point, FindingStrategy strategy)
     {
-        var cx = X + Width * 0.5;
-        var cy = Y + Height * 0.5;
+        var midX = X + Width * 0.5;
+        var midY = Y + Height * 0.5;
 
-        return Math.Sqrt(Math.Pow(point.X - cx, 2) + Math.Pow(point.Y - cy, 2));
+        return strategy switch
+        {
+            FindingStrategy.CompareOnlyX or FindingStrategy.CompareOnlyXTakeClosest
+                => Math.Abs(point.X - midX),
+            FindingStrategy.CompareOnlyY or FindingStrategy.CompareOnlyYTakeClosest
+                => Math.Abs(point.Y - midY),
+            FindingStrategy.CompareAll or FindingStrategy.CompareAllTakeClosest or
+            FindingStrategy.ExactMatch or FindingStrategy.ExactMatchTakeClosest
+                => Math.Sqrt(Math.Pow(point.X - midX, 2) + Math.Pow(point.Y - midY, 2)),
+            FindingStrategy.Automatic
+                => throw new Exception($"The strategy {strategy} is not supported."),
+            _ => throw new NotImplementedException()
+        };
     }
 
     /// <inheritdoc cref="HoverArea.IsPointerOver(LvcPoint, FindingStrategy)"/>
@@ -202,11 +214,15 @@ public class RectangleHoverArea : HoverArea
 
         return strategy switch
         {
-            FindingStrategy.CompareOnlyX or FindingStrategy.CompareOnlyXTakeClosest => isInX,
-            FindingStrategy.CompareOnlyY or FindingStrategy.CompareOnlyYTakeClosest => isInY,
-            FindingStrategy.CompareAll or FindingStrategy.CompareAllTakeClosest => isInX && isInY,
-            FindingStrategy.ExactMatch => isInX && isInY,
-            FindingStrategy.Automatic => throw new Exception($"The strategy {strategy} is not supported."),
+            FindingStrategy.CompareOnlyX or FindingStrategy.CompareOnlyXTakeClosest
+                => isInX,
+            FindingStrategy.CompareOnlyY or FindingStrategy.CompareOnlyYTakeClosest
+                => isInY,
+            FindingStrategy.CompareAll or FindingStrategy.CompareAllTakeClosest or
+            FindingStrategy.ExactMatch or FindingStrategy.ExactMatchTakeClosest
+                => isInX && isInY,
+            FindingStrategy.Automatic
+                => throw new Exception($"The strategy {strategy} is not supported."),
             _ => throw new NotImplementedException()
         };
     }

--- a/src/LiveChartsCore/Kernel/Drawing/SemicircleHoverArea.cs
+++ b/src/LiveChartsCore/Kernel/Drawing/SemicircleHoverArea.cs
@@ -90,8 +90,8 @@ public class SemicircleHoverArea : HoverArea
         return this;
     }
 
-    /// <inheritdoc cref="HoverArea.DistanceTo(LvcPoint)"/>
-    public override double DistanceTo(LvcPoint point)
+    /// <inheritdoc cref="HoverArea.DistanceTo(LvcPoint, FindingStrategy)"/>
+    public override double DistanceTo(LvcPoint point, FindingStrategy strategy)
     {
         var a = (StartAngle + EndAngle) * 0.5;
         var r = Radius * 0.5f;

--- a/src/LiveChartsCore/Kernel/Extensions.cs
+++ b/src/LiveChartsCore/Kernel/Extensions.cs
@@ -486,7 +486,7 @@ public static class Extensions
         return points
             .Select(p => new
             {
-                distance = p.DistanceTo(fp),
+                distance = p.DistanceTo(fp, FindingStrategy.CompareAll),
                 point = p
             })
             .OrderBy(p => p.distance)

--- a/src/LiveChartsCore/Series.cs
+++ b/src/LiveChartsCore/Series.cs
@@ -346,7 +346,7 @@ public abstract class Series<TModel, TVisual, TLabel>
         {
             // if select closest...
             query = query
-                .Select(x => new { distance = x.DistanceTo(pointerPosition), point = x })
+                .Select(x => new { distance = x.DistanceTo(pointerPosition, strategy), point = x })
                 .OrderBy(x => x.distance)
                 .SelectFirst(x => x.point);
         }


### PR DESCRIPTION
fixes #1589 

The ClosestTo FindingStrategies were always considering both X and Y to calculate the distance to a point, this is wrong because some FindingStrategies  ignore X or Y depending on the case, this PR helps the `HoverArea`.`DistanceTo` function to consider the actual coordinates described on the strategy.