### PR TITLE
Improve WinUI AOT compatibility

### DIFF
--- a/src/LiveChartsCore/Geo/DrawnMap.cs
+++ b/src/LiveChartsCore/Geo/DrawnMap.cs
@@ -23,10 +23,17 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using LiveChartsCore.Painting;
 
 namespace LiveChartsCore.Geo;
+
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+[JsonSerializable(typeof(GeoJsonFile))]
+internal partial class GeoJsonFileSourceGenerationContext : JsonSerializerContext
+{
+}
 
 /// <summary>
 /// Defines a geographic map for LiveCharts controls.
@@ -130,10 +137,7 @@ public class DrawnMap : IDisposable
 
         var geoJson = System.Text.Json.JsonSerializer.Deserialize<GeoJsonFile>(
             streamReader.ReadToEnd(),
-            new System.Text.Json.JsonSerializerOptions
-            {
-                PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase
-            }) ?? throw new Exception("Map not found");
+            GeoJsonFileSourceGenerationContext.Default.GeoJsonFile) ?? throw new Exception("Map not found");
 
         layer.AddFile(geoJson);
         return layer;

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.WinUI/LiveChartsCore.SkiaSharpView.WinUI.csproj
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.WinUI/LiveChartsCore.SkiaSharpView.WinUI.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <LangVersion>$(GlobalLangVersion)</LangVersion>
     <Nullable>enable</Nullable>
@@ -13,6 +13,7 @@
     <EnableMsixTooling>true</EnableMsixTooling>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <UseWinUI>true</UseWinUI>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
     <RootNamespace>LiveChartsCore.SkiaSharpView.WinUI</RootNamespace>
     <Version>$(LiveChartsVersion)</Version>
@@ -49,8 +50,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.4.230913002" />
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.1" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.240923002" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
     <PackageReference Include="SkiaSharp.Views.WinUI" Version="$(SkiaSharpVersion)" />
     <PackageReference Include="SkiaSharp.HarfBuzz" Version="$(SkiaSharpVersion)" />
   </ItemGroup>

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.WinUI/MotionCanvas.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.WinUI/MotionCanvas.cs
@@ -35,7 +35,7 @@ namespace LiveChartsCore.SkiaSharpView.WinUI;
 /// </summary>
 /// <seealso cref="UserControl" />
 /// <seealso cref="Microsoft.UI.Xaml.Markup.IComponentConnector" />
-public class MotionCanvas : UserControl
+public partial class MotionCanvas : UserControl
 {
     private readonly SKXamlCanvas? _skiaElement;
     private bool _isDrawingLoopRunning;


### PR DESCRIPTION
This patch improves compatibility with AOT compiled WinUI apps. Fixes https://github.com/beto-rodriguez/LiveCharts2/issues/1889#issue-3122398282:

- AllowUnsafeBlocks is required by the cswinrt source generator
- MotionCanvas needs to be declared partial to generate the necessary code
- Some of the dependencies have been upgraded to AOT compatible versions, matching the winui sample project
- Json source generation is required for the DrawnMap class