### PR TITLE
Fix 1885

### DIFF
--- a/samples/AvaloniaSample/General/ChartToImage/View.axaml.cs
+++ b/samples/AvaloniaSample/General/ChartToImage/View.axaml.cs
@@ -21,14 +21,14 @@ public partial class View : UserControl
     {
         // you can take any chart in the UI, and build an image from it // mark
         var chartControl = this.FindControl<CartesianChart>("cartesianChart");
-        var skChart = new SKCartesianChart(chartControl) { Width = 900, Height = 600, };
+        var skChart = new SKCartesianChart(chartControl);
         skChart.SaveImage("CartesianImageFromControl.png");
     }
 
     private void CreateImageFromPieControl()
     {
         var chartControl = this.FindControl<PieChart>("pieChart");
-        var skChart = new SKPieChart(chartControl) { Width = 900, Height = 600, };
+        var skChart = new SKPieChart(chartControl);
         skChart.SaveImage("PieImageFromControl.png");
     }
 

--- a/samples/BlazorSample/Pages/General/ChartToImage.razor
+++ b/samples/BlazorSample/Pages/General/ChartToImage.razor
@@ -51,14 +51,14 @@
     private void CreateImageFromCartesianControl()
     {
         var chartControl = _cartesianChart;
-        var skChart = new SKCartesianChart(chartControl) { Width = 900, Height = 600 };
+        var skChart = new SKCartesianChart(chartControl);
         skChart.SaveImage("CartesianImageFromControl.png");
     }
 
     private void CreateImageFromPieControl()
     {
         var chartControl = _pieChart;
-        var skChart = new SKPieChart(chartControl) { Width = 900, Height = 600 };
+        var skChart = new SKPieChart(chartControl);
         skChart.SaveImage("PieImageFromControl.png");
     }
 }

--- a/samples/EtoFormsSample/General/ChartToImage/View.cs
+++ b/samples/EtoFormsSample/General/ChartToImage/View.cs
@@ -50,14 +50,14 @@ public class View : Panel
     private void CreateImageFromCartesianControl()
     {
         var chartControl = _cartesian;
-        var skChart = new SKCartesianChart(chartControl) { Width = 900, Height = 600 };
+        var skChart = new SKCartesianChart(chartControl);
         skChart.SaveImage("CartesianImageFromControl.png");
     }
 
     private void CreateImageFromPieControl()
     {
         var chartControl = _pie;
-        var skChart = new SKPieChart(chartControl) { Width = 900, Height = 600 };
+        var skChart = new SKPieChart(chartControl);
         skChart.SaveImage("PieImageFromControl.png");
     }
 }

--- a/samples/MauiSample/General/ChartToImage/View.xaml.cs
+++ b/samples/MauiSample/General/ChartToImage/View.xaml.cs
@@ -22,14 +22,14 @@ public partial class View : ContentPage
     {
         // you can take any chart in the UI, and build an image from it // mark
         var chartControl = (CartesianChart)FindByName("cartesianChart");
-        var skChart = new SKCartesianChart(chartControl) { Width = 900, Height = 600, };
+        var skChart = new SKCartesianChart(chartControl);
         skChart.SaveImage(Path.Combine(_folderPath, "CartesianImageFromControl.png"));
     }
 
     private void CreateImageFromPieControl()
     {
         var chartControl = (PieChart)FindByName("pieChart");
-        var skChart = new SKPieChart(chartControl) { Width = 900, Height = 600, };
+        var skChart = new SKPieChart(chartControl);
         skChart.SaveImage(Path.Combine(_folderPath, "PieImageFromControl.png"));
     }
 }

--- a/samples/WPFSample/General/ChartToImage/View.xaml.cs
+++ b/samples/WPFSample/General/ChartToImage/View.xaml.cs
@@ -28,14 +28,14 @@ public partial class View : UserControl
     {
         // you can take any chart in the UI, and build an image from it // mark
         var chartControl = (CartesianChart)FindName("cartesianChart");
-        var skChart = new SKCartesianChart(chartControl) { Width = 900, Height = 600, };
+        var skChart = new SKCartesianChart(chartControl);
         skChart.SaveImage("CartesianImageFromControl.png");
     }
 
     private void CreateImageFromPieControl()
     {
         var chartControl = (PieChart)FindName("pieChart");
-        var skChart = new SKPieChart(chartControl) { Width = 900, Height = 600, };
+        var skChart = new SKPieChart(chartControl);
         skChart.SaveImage("PieImageFromControl.png");
     }
 }

--- a/samples/WinFormsSample/General/ChartToImage/View.cs
+++ b/samples/WinFormsSample/General/ChartToImage/View.cs
@@ -53,14 +53,14 @@ public partial class View : UserControl
     private void CreateImageFromCartesianControl()
     {
         var chartControl = _cartesian;
-        var skChart = new SKCartesianChart(chartControl) { Width = 900, Height = 600 };
+        var skChart = new SKCartesianChart(chartControl);
         skChart.SaveImage("CartesianImageFromControl.png");
     }
 
     private void CreateImageFromPieControl()
     {
         var chartControl = _pie;
-        var skChart = new SKPieChart(chartControl) { Width = 900, Height = 600 };
+        var skChart = new SKPieChart(chartControl);
         skChart.SaveImage("PieImageFromControl.png");
     }
 }

--- a/samples/WinUISample/WinUISample/Samples/General/ChartToImage/View.xaml.cs
+++ b/samples/WinUISample/WinUISample/Samples/General/ChartToImage/View.xaml.cs
@@ -24,14 +24,14 @@ public sealed partial class View : UserControl
     {
         // you can take any chart in the UI, and build an image from it // mark
         var chartControl = cartesianChart;
-        var skChart = new SKCartesianChart(chartControl) { Width = 900, Height = 600, };
+        var skChart = new SKCartesianChart(chartControl);
         skChart.SaveImage("CartesianImageFromControl.png");
     }
 
     private void CreateImageFromPieControl()
     {
         var chartControl = pieChart;
-        var skChart = new SKPieChart(chartControl) { Width = 900, Height = 600, };
+        var skChart = new SKPieChart(chartControl);
         skChart.SaveImage("PieImageFromControl.png");
     }
 }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/SKCharts/InMemorySkiaSharpChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/SKCharts/InMemorySkiaSharpChart.cs
@@ -34,12 +34,15 @@ namespace LiveChartsCore.SkiaSharpView.SKCharts;
 /// </summary>
 public abstract class InMemorySkiaSharpChart
 {
+    private readonly IChartView? _chartView;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="InMemorySkiaSharpChart"/> class.
     /// </summary>
-    public InMemorySkiaSharpChart()
+    public InMemorySkiaSharpChart(IChartView? chartView = null)
     {
         LiveCharts.Configure(config => config.UseDefaults());
+        _chartView = chartView;
     }
 
     /// <inheritdoc cref="IChartView.CoreCanvas"/>
@@ -136,6 +139,20 @@ public abstract class InMemorySkiaSharpChart
     {
         if (CoreChart is null || CoreChart is not Chart skiaChart)
             throw new Exception("Something is missing :(");
+
+        if (_chartView is not null)
+        {
+            _chartView.CoreCanvas.DrawFrame(
+                new SkiaSharpDrawingContext(
+                    CoreCanvas,
+                    new SKImageInfo(Width, Height),
+                    surface!,
+                    canvas,
+                    Background,
+                    clearCanvasOnBeginDraw));
+
+            return;
+        }
 
         skiaChart.Canvas.DisableAnimations = true;
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/SKCharts/InMemorySkiaSharpChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/SKCharts/InMemorySkiaSharpChart.cs
@@ -67,7 +67,11 @@ public abstract class InMemorySkiaSharpChart
     /// <value>
     /// The height.
     /// </value>
-    public int Height { get; set; } = 600;
+    public int Height
+    {
+        get => _chartView is null ? field : (int)_chartView.ControlSize.Height;
+        set { field = value; WarnSize(); }
+    } = 600;
 
     /// <summary>
     /// Gets or sets the width.
@@ -75,7 +79,11 @@ public abstract class InMemorySkiaSharpChart
     /// <value>
     /// The width.
     /// </value>
-    public int Width { get; set; } = 900;
+    public int Width
+    {
+        get => _chartView is null ? field : (int)_chartView.ControlSize.Width;
+        set { field = value; WarnSize(); }
+    } = 900;
 
     /// <summary>
     /// Gets the current <see cref="SKSurface"/>.
@@ -123,10 +131,8 @@ public abstract class InMemorySkiaSharpChart
     /// </summary>
     /// <param name="canvas">The canvas</param>
     /// <param name="clearCanvasOnBeginDraw">Indicates whether the canvas should be cleared when the draw starts, default is false.</param>
-    public virtual void SaveImage(SKCanvas canvas, bool clearCanvasOnBeginDraw = false)
-    {
+    public virtual void SaveImage(SKCanvas canvas, bool clearCanvasOnBeginDraw = false) =>
         DrawOnCanvas(canvas, null, clearCanvasOnBeginDraw);
-    }
 
     /// <summary>
     /// Draws the chart to the specified canvas.
@@ -172,5 +178,16 @@ public abstract class InMemorySkiaSharpChart
                 clearCanvasOnBeginDraw));
 
         if (!ExplicitDisposing) skiaChart.Unload();
+    }
+
+    private void WarnSize()
+    {
+#if DEBUG
+        if (_chartView is null) return;
+        throw new InvalidOperationException(
+           $"The chart image dimensions are ignored when built from an {nameof(IChartView)} instance. " +
+           $"If you need the chart in a specific size, please use the parameterless contructor and build " +
+           $"the chart from there, or resize the chart in UI first to the desired size.");
+#endif
     }
 }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/SKCharts/SKCartesianChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/SKCharts/SKCartesianChart.cs
@@ -41,12 +41,13 @@ namespace LiveChartsCore.SkiaSharpView.SKCharts;
 public class SKCartesianChart : InMemorySkiaSharpChart, ICartesianChartView
 {
     private LvcColor _backColor;
-    private bool _matchAxesScreenDataRatio;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SKCartesianChart"/> class.
     /// </summary>
-    public SKCartesianChart()
+    /// <param name="chartView">The chart view source to build the image from.</param>
+    public SKCartesianChart(ICartesianChartView? chartView = null)
+        : base(chartView)
     {
         LiveCharts.Configure(config => config.UseDefaults());
 
@@ -56,23 +57,6 @@ public class SKCartesianChart : InMemorySkiaSharpChart, ICartesianChartView
         Core.UpdateFinished += OnCoreUpdateFinished;
 
         CoreChart = Core;
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="SKCartesianChart"/> class.
-    /// </summary>
-    /// <param name="view">The view.</param>
-    public SKCartesianChart(ICartesianChartView view) : this()
-    {
-        XAxes = view.XAxes;
-        YAxes = view.YAxes;
-        Series = view.Series;
-        Sections = view.Sections;
-        DrawMarginFrame = view.DrawMarginFrame;
-        LegendPosition = view.LegendPosition;
-        Title = view.Title;
-        DrawMargin = view.DrawMargin;
-        VisualElements = view.VisualElements;
     }
 
     bool IChartView.DesignerMode => false;
@@ -203,10 +187,10 @@ public class SKCartesianChart : InMemorySkiaSharpChart, ICartesianChartView
     /// <inheritdoc cref="ICartesianChartView.MatchAxesScreenDataRatio" />
     public bool MatchAxesScreenDataRatio
     {
-        get => _matchAxesScreenDataRatio;
+        get;
         set
         {
-            _matchAxesScreenDataRatio = value;
+            field = value;
 
             if (value) SharedAxes.MatchAxesScreenDataRatio(this);
             else SharedAxes.DisposeMatchAxesScreenDataRatio(this);

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/SKCharts/SKPieChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/SKCharts/SKPieChart.cs
@@ -45,7 +45,9 @@ public class SKPieChart : InMemorySkiaSharpChart, IPieChartView
     /// <summary>
     /// Initializes a new instance of the <see cref="SKPieChart"/> class.
     /// </summary>
-    public SKPieChart()
+    /// <param name="chartView">The chart view source to build the image from.</param>
+    public SKPieChart(IPieChartView? chartView = null)
+        : base(chartView)
     {
         LiveCharts.Configure(config => config.UseDefaults());
 
@@ -55,23 +57,6 @@ public class SKPieChart : InMemorySkiaSharpChart, IPieChartView
         Core.UpdateFinished += OnCoreUpdateFinished;
 
         CoreChart = Core;
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="SKPieChart"/> class.
-    /// </summary>
-    /// <param name="view">The view.</param>
-    public SKPieChart(IPieChartView view) : this()
-    {
-        Series = view.Series;
-        InitialRotation = view.InitialRotation;
-        MaxAngle = view.MaxAngle;
-        MaxValue = view.MaxValue;
-        MinValue = view.MinValue;
-        LegendPosition = view.LegendPosition;
-        Title = view.Title;
-        DrawMargin = view.DrawMargin;
-        VisualElements = view.VisualElements;
     }
 
     bool IChartView.DesignerMode => false;

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/SKCharts/SKPolarChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/SKCharts/SKPolarChart.cs
@@ -45,7 +45,9 @@ public class SKPolarChart : InMemorySkiaSharpChart, IPolarChartView
     /// <summary>
     /// Initializes a new instance of the <see cref="SKPolarChart"/> class.
     /// </summary>
-    public SKPolarChart()
+    /// <param name="chartView">The chart view source to build the image from.</param>
+    public SKPolarChart(IChartView chartView)
+        : base(chartView)
     {
         LiveCharts.Configure(config => config.UseDefaults());
 
@@ -55,25 +57,6 @@ public class SKPolarChart : InMemorySkiaSharpChart, IPolarChartView
         Core.UpdateFinished += OnCoreUpdateFinished;
 
         CoreChart = Core;
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="SKPolarChart"/> class.
-    /// </summary>
-    /// <param name="view">The view.</param>
-    public SKPolarChart(IPolarChartView view) : this()
-    {
-        AngleAxes = view.AngleAxes;
-        RadiusAxes = view.RadiusAxes;
-        Series = view.Series;
-        FitToBounds = view.FitToBounds;
-        TotalAngle = view.TotalAngle;
-        InnerRadius = view.InnerRadius;
-        InitialRotation = view.InitialRotation;
-        LegendPosition = view.LegendPosition;
-        Title = view.Title;
-        DrawMargin = view.DrawMargin;
-        VisualElements = view.VisualElements;
     }
 
     bool IChartView.DesignerMode => false;


### PR DESCRIPTION
- fixes #1885 

This PR changes the way images are built from `IChartView` instances.

*Previously*:
We copied the Series, Axes, VisualElements, Title and Sections properties to the `SKChart` instance, but this method has a problem, some elemenets are not designed to be consumed by multiple views (for example the view in the UI, and the view that generates the image) thus we get errors like #1885 or #1333.

*Now*
We use the canvas in the `IChartView` to generate the image, we write this canvas into an image file. This is much simpler, but the only problem is that this canvas has already a size, so the generated image has the same size as the chart in the UI. When we need a different size, we can do it but using the parameterless constructor.