### PR TITLE
Memory leak repair

### DIFF
--- a/src/LiveChartsCore/Chart.cs
+++ b/src/LiveChartsCore/Chart.cs
@@ -494,6 +494,16 @@ public abstract class Chart
     protected bool SizeChanged() => _previousSize.Width != ControlSize.Width || _previousSize.Height != ControlSize.Height;
 
     /// <summary>
+    /// Is it being rendered
+    /// </summary>
+    public bool _isRendering = false;
+
+    /// <summary>
+    /// Indicates if it is the first render
+    /// </summary>
+    public bool _isFirstRender = true;
+
+    /// <summary>
     /// Called when the updated the throttler is unlocked.
     /// </summary>
     /// <returns></returns>
@@ -505,7 +515,14 @@ public abstract class Chart
             {
                 lock (Canvas.Sync)
                 {
-                    Measure();
+                    //1.The first rendering must be released (Chart will be added to the subscription list),
+                    //otherwise the subsequent UpdateThrottlerUnlocked cannot be triggered (you need to click on the chart to join the subscription again).
+                    //2.Allow traffic only when MotionCanvas is being rendered, so as to avoid the infinite accumulation of elements in the chart when it is not rendered.
+                    if (_isFirstRender || _isRendering)
+                    {
+                        _isFirstRender = false;
+                        Measure();
+                    }
                 }
             });
         });

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/MotionCanvas.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/MotionCanvas.cs
@@ -66,9 +66,9 @@ public class MotionCanvas : UserControl
     {
         if (_isDeatached) return;
 
-        var chartView = this.Parent as Kernel.Sketches.IChartView;
-        var chart = chartView.CoreChart as LiveChartsCore.Chart;
-        chart._isRendering = true;
+        var chart = (Parent as Kernel.Sketches.IChartView)?.CoreChart;
+        if (chart is not null)
+            chart._isRendering = true;
 
         context.Custom(new ChartFrameOperation(
             CanvasCore, new Rect(0, 0, Bounds.Width, Bounds.Height)));
@@ -76,7 +76,8 @@ public class MotionCanvas : UserControl
         if (CanvasCore.IsValid) return;
         _ = Dispatcher.UIThread.InvokeAsync(InvalidateVisual, DispatcherPriority.Background);
 
-        chart._isRendering = false;
+        if (chart is not null)
+            chart._isRendering = false;
     }
 
     private void OnCanvasCoreInvalidated(CoreMotionCanvas sender) =>

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/MotionCanvas.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/MotionCanvas.cs
@@ -66,11 +66,17 @@ public class MotionCanvas : UserControl
     {
         if (_isDeatached) return;
 
+        var chartView = this.Parent as Kernel.Sketches.IChartView;
+        var chart = chartView.CoreChart as LiveChartsCore.Chart;
+        chart._isRendering = true;
+
         context.Custom(new ChartFrameOperation(
             CanvasCore, new Rect(0, 0, Bounds.Width, Bounds.Height)));
 
         if (CanvasCore.IsValid) return;
         _ = Dispatcher.UIThread.InvokeAsync(InvalidateVisual, DispatcherPriority.Background);
+
+        chart._isRendering = false;
     }
 
     private void OnCanvasCoreInvalidated(CoreMotionCanvas sender) =>


### PR DESCRIPTION
### Purpose
Fix memory leaks in specific scenarios

### Changes
- Added conditional checks in:
  - Chart.UpdateThrottlerUnlocked()
  - MotionCanvas.Render()

### Testing
When the CartesianChart is loaded and continuously adds DateTimePoints:
1. When CartesianChart is visible, memory fluctuates normally
2. When CartesianChart is invisible, elements such as CircleGeometry and FloatMotionProperty continue to accumulate, leading to a continuous increase in memory usage
In industrial scenarios where long-term operation and continuous data refreshing are required, the impact on memory may have unforeseeable consequences
![20250808113132](https://github.com/user-attachments/assets/e5d2c602-67c6-466f-bfd5-304109d9937d)
<img width="665" height="635" alt="20250808113102" src="https://github.com/user-attachments/assets/c1680f2f-437b-41fd-931f-20518165e2e3" />
<img width="845" height="465" alt="20250808112919" src="https://github.com/user-attachments/assets/50499636-000e-4e55-98d9-5021ede71d7c" />


### Evidence
1. In practical applications, the program memory grows abnormally large, and a large number of Livechartscore-related objects are found in the dump
2. In demo:
   - I added counters to CircleGeometry and FloatMotionProperty types for easy observation of issues.
   - Created multiple CartesianCharts with high-frequency DateTimePoint additions to amplify the issue
   - Demo provides two leakage scenarios. I only tested CartesianChart with DateTimePoint and TimeSpanPoint, and other types may also have such problems.

### Notes
1. This might not be the optimal solution
2. This is my first attempt to submit PR to an open source project, hoping to be helpful to the LiveCharts2 project.
3. It took a lot of effort to locate this problem, look forward to getting a response.