### PR TITLE
Fixes #1971 - Android Fix: Add a null check for _customScaleListener in DisposeController to prevent crash

### DIFF
--- a/src/_Shared.Native/Platforms/Android/PointerController.cs
+++ b/src/_Shared.Native/Platforms/Android/PointerController.cs
@@ -68,7 +68,7 @@ internal partial class PointerController : INativePointerController
         _scaleDetector?.Dispose();
         _scaleDetector = null;
 
-        _customScaleListener.Dispose();
+        _customScaleListener?.Dispose();
         _customScaleListener = null!;
     }
 


### PR DESCRIPTION
Add a null check for _customScaleListener in DisposeController in [src/_Shared.Native/Platforms/Android/PointerController.cs](https://github.com/Domik234/LiveCharts2/blob/53739c43090aa44b005876a9a2c882b0d8ef320c/src/_Shared.Native/Platforms/Android/PointerController.cs#L71) to prevent crashes when navigating away without touching the chart. Only dispose _customScaleListener if it is not null.

Fixes: https://github.com/beto-rodriguez/LiveCharts2/issues/1971