### PR TITLE
Fix stack calculation for positive and negative values

### DIFF
--- a/src/LiveChartsCore/Kernel/Stacker.cs
+++ b/src/LiveChartsCore/Kernel/Stacker.cs
@@ -125,16 +125,22 @@ public class Stacker
         if (value >= 0)
         {
             currentStack.End += value;
+            currentStack.NegativeEnd += value;
             var positiveTotal = _totals[index].Positive + value;
             _totals[index].Positive = positiveTotal;
+            var negativeTotal = _totals[index].Negative + value;
+            _totals[index].Negative = negativeTotal;
 
             return positiveTotal;
         }
         else
         {
+            currentStack.End += value;
             currentStack.NegativeEnd += value;
             var negativeTotal = _totals[index].Negative + value;
             _totals[index].Negative = negativeTotal;
+            var positiveTotal = _totals[index].Positive + value;
+            _totals[index].Positive = positiveTotal;
 
             return negativeTotal;
         }


### PR DESCRIPTION
Fix: The Negative+Positive values are not calculated correctly for the stacked graphics 
[issue 2073](https://github.com/Live-Charts/LiveCharts2/issues/2073)