### PR TITLE
Add zoom, pan, tooltips, and click events for GeoMap

### DIFF
--- a/samples/AvaloniaSample/Maps/World/View.axaml
+++ b/samples/AvaloniaSample/Maps/World/View.axaml
@@ -30,6 +30,23 @@
                            ValueChanged="OnTextSizeChanged"/>
 
             <Button Content="Toggle Brazil" Command="{Binding ToggleBrazilCommand}"/>
+            <Button Content="Clear Series" x:Name="ClearSeriesBtn"/>
+            <Button Content="Reset Zoom" x:Name="ResetZoomBtn"/>
+
+            <TextBlock Text="Border:" VerticalAlignment="Center"/>
+            <NumericUpDown x:Name="BorderWidthUpDown" Value="1" Minimum="0" Maximum="10"
+                           Increment="0.5" Width="110" VerticalAlignment="Center"
+                           ValueChanged="OnBorderWidthChanged"/>
+            <ComboBox x:Name="BorderColorCombo" SelectedIndex="0" VerticalAlignment="Center">
+                <ComboBoxItem Content="White" Tag="White"/>
+                <ComboBoxItem Content="Black" Tag="Black"/>
+                <ComboBoxItem Content="Gray" Tag="Gray"/>
+                <ComboBoxItem Content="Red" Tag="Red"/>
+                <ComboBoxItem Content="None" Tag="None"/>
+            </ComboBox>
+
+            <TextBlock x:Name="ClickedLandText" Text="Click a country..." VerticalAlignment="Center"
+                       Margin="12,0,0,0" Foreground="Gray"/>
         </StackPanel>
 
         <lvc:GeoMap

--- a/samples/AvaloniaSample/Maps/World/View.axaml
+++ b/samples/AvaloniaSample/Maps/World/View.axaml
@@ -6,13 +6,37 @@
              x:Class="AvaloniaSample.Maps.World.View"
              xmlns:lvc="using:LiveChartsCore.SkiaSharpView.Avalonia"
              xmlns:vms="using:ViewModelsSamples.Maps.World"
+             xmlns:m="using:LiveChartsCore.Measure"
              x:DataType="vms:ViewModel">
     <UserControl.DataContext>
         <vms:ViewModel/>
     </UserControl.DataContext>
-    <lvc:GeoMap
-        x:Name="geoMap"
-        Series="{Binding Series}"
-        MapProjection="Mercator">
-    </lvc:GeoMap>
+    <Grid RowDefinitions="Auto,*">
+
+        <!-- Tooltip settings panel -->
+        <StackPanel Grid.Row="0" Orientation="Horizontal" Spacing="12" Margin="8">
+            <TextBlock Text="Tooltip:" VerticalAlignment="Center"/>
+
+            <ComboBox x:Name="TooltipPositionCombo" SelectedIndex="1" VerticalAlignment="Center">
+                <ComboBoxItem Content="Hidden" Tag="{x:Static m:TooltipPosition.Hidden}"/>
+                <ComboBoxItem Content="Auto" Tag="{x:Static m:TooltipPosition.Auto}"/>
+                <ComboBoxItem Content="Top (wedge below)" Tag="{x:Static m:TooltipPosition.Top}"/>
+                <ComboBoxItem Content="Bottom (wedge above)" Tag="{x:Static m:TooltipPosition.Bottom}"/>
+            </ComboBox>
+
+            <TextBlock Text="Text size:" VerticalAlignment="Center"/>
+            <NumericUpDown x:Name="TextSizeUpDown" Value="14" Minimum="8" Maximum="32"
+                           Increment="1" Width="130" VerticalAlignment="Center"
+                           ValueChanged="OnTextSizeChanged"/>
+
+            <Button Content="Toggle Brazil" Command="{Binding ToggleBrazilCommand}"/>
+        </StackPanel>
+
+        <lvc:GeoMap
+            Grid.Row="1"
+            x:Name="geoMap"
+            Series="{Binding Series}"
+            MapProjection="Mercator">
+        </lvc:GeoMap>
+    </Grid>
 </UserControl>

--- a/samples/AvaloniaSample/Maps/World/View.axaml.cs
+++ b/samples/AvaloniaSample/Maps/World/View.axaml.cs
@@ -1,5 +1,6 @@
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
+using LiveChartsCore.Measure;
 using LiveChartsCore.SkiaSharpView.Avalonia;
 
 namespace AvaloniaSample.Maps.World;
@@ -14,6 +15,22 @@ public partial class View : UserControl
     private void InitializeComponent()
     {
         AvaloniaXamlLoader.Load(this);
+
+        var geoMap = this.Find<GeoMap>("geoMap")!;
+        var combo = this.Find<ComboBox>("TooltipPositionCombo")!;
+
+        combo.SelectionChanged += (_, _) =>
+        {
+            if (combo.SelectedItem is ComboBoxItem item && item.Tag is TooltipPosition pos)
+                geoMap.TooltipPosition = pos;
+        };
+    }
+
+    private void OnTextSizeChanged(object? sender, NumericUpDownValueChangedEventArgs e)
+    {
+        var geoMap = this.Find<GeoMap>("geoMap");
+        if (geoMap is not null && e.NewValue.HasValue)
+            geoMap.TooltipTextSize = (double)e.NewValue.Value;
     }
 
 #if UI_TESTING

--- a/samples/AvaloniaSample/Maps/World/View.axaml.cs
+++ b/samples/AvaloniaSample/Maps/World/View.axaml.cs
@@ -1,7 +1,10 @@
+using System.Linq;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 using LiveChartsCore.Measure;
+using LiveChartsCore.SkiaSharpView;
 using LiveChartsCore.SkiaSharpView.Avalonia;
+using LiveChartsCore.SkiaSharpView.Drawing.Geometries;
 using LiveChartsCore.SkiaSharpView.Painting;
 using SkiaSharp;
 
@@ -31,7 +34,25 @@ public partial class View : UserControl
         resetBtn.Click += (_, _) => geoMap.CoreChart.ResetViewport();
 
         var clearBtn = this.Find<Button>("ClearSeriesBtn")!;
-        clearBtn.Click += (_, _) => geoMap.Series = [];
+        HeatLand[]? savedLands = null;
+        clearBtn.Click += (_, _) =>
+        {
+            var series = geoMap.Series?.Cast<HeatLandSeries>().FirstOrDefault();
+            if (series is null) return;
+
+            if (savedLands is null)
+            {
+                savedLands = series.Lands?.Cast<HeatLand>().ToArray();
+                series.Lands = [];
+                clearBtn.Content = "Restore Series";
+            }
+            else
+            {
+                series.Lands = savedLands;
+                savedLands = null;
+                clearBtn.Content = "Clear Series";
+            }
+        };
 
         var borderColorCombo = this.Find<ComboBox>("BorderColorCombo")!;
         borderColorCombo.SelectionChanged += (_, _) =>
@@ -62,7 +83,10 @@ public partial class View : UserControl
     {
         var geoMap = this.Find<GeoMap>("geoMap");
         if (geoMap?.Stroke is not null && e.NewValue.HasValue)
+        {
             geoMap.Stroke.StrokeThickness = (float)e.NewValue.Value;
+            geoMap.CoreChart.Update();
+        }
     }
 
     private void OnTextSizeChanged(object? sender, NumericUpDownValueChangedEventArgs e)

--- a/samples/AvaloniaSample/Maps/World/View.axaml.cs
+++ b/samples/AvaloniaSample/Maps/World/View.axaml.cs
@@ -2,6 +2,8 @@ using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 using LiveChartsCore.Measure;
 using LiveChartsCore.SkiaSharpView.Avalonia;
+using LiveChartsCore.SkiaSharpView.Painting;
+using SkiaSharp;
 
 namespace AvaloniaSample.Maps.World;
 
@@ -18,12 +20,49 @@ public partial class View : UserControl
 
         var geoMap = this.Find<GeoMap>("geoMap")!;
         var combo = this.Find<ComboBox>("TooltipPositionCombo")!;
+        var resetBtn = this.Find<Button>("ResetZoomBtn")!;
 
         combo.SelectionChanged += (_, _) =>
         {
             if (combo.SelectedItem is ComboBoxItem item && item.Tag is TooltipPosition pos)
                 geoMap.TooltipPosition = pos;
         };
+
+        resetBtn.Click += (_, _) => geoMap.CoreChart.ResetViewport();
+
+        var clearBtn = this.Find<Button>("ClearSeriesBtn")!;
+        clearBtn.Click += (_, _) => geoMap.Series = [];
+
+        var borderColorCombo = this.Find<ComboBox>("BorderColorCombo")!;
+        borderColorCombo.SelectionChanged += (_, _) =>
+        {
+            if (borderColorCombo.SelectedItem is ComboBoxItem item && item.Tag is string color)
+            {
+                geoMap.Stroke = color switch
+                {
+                    "White" => new SolidColorPaint(SKColors.White) { StrokeThickness = (float)(geoMap.Stroke?.StrokeThickness ?? 1) },
+                    "Black" => new SolidColorPaint(SKColors.Black) { StrokeThickness = (float)(geoMap.Stroke?.StrokeThickness ?? 1) },
+                    "Gray" => new SolidColorPaint(SKColors.Gray) { StrokeThickness = (float)(geoMap.Stroke?.StrokeThickness ?? 1) },
+                    "Red" => new SolidColorPaint(SKColors.Red) { StrokeThickness = (float)(geoMap.Stroke?.StrokeThickness ?? 1) },
+                    "None" => null,
+                    _ => geoMap.Stroke
+                };
+            }
+        };
+
+        var clickedText = this.Find<TextBlock>("ClickedLandText")!;
+        geoMap.CoreChart.LandClicked += args =>
+        {
+            Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+                clickedText.Text = $"Clicked: {args.Land.Name} ({args.Land.ShortName}) = {args.Value}");
+        };
+    }
+
+    private void OnBorderWidthChanged(object? sender, NumericUpDownValueChangedEventArgs e)
+    {
+        var geoMap = this.Find<GeoMap>("geoMap");
+        if (geoMap?.Stroke is not null && e.NewValue.HasValue)
+            geoMap.Stroke.StrokeThickness = (float)e.NewValue.Value;
     }
 
     private void OnTextSizeChanged(object? sender, NumericUpDownValueChangedEventArgs e)

--- a/src/LiveChartsCore/CoreHeatLandSeries.cs
+++ b/src/LiveChartsCore/CoreHeatLandSeries.cs
@@ -196,18 +196,11 @@ public abstract class CoreHeatLandSeries<TModel> : IGeoSeries, INotifyPropertyCh
     {
         foreach (var mapLand in toRemove)
         {
-            // THIS SEEEMS UNECESARY,
-            // I KEEP THIS CODE AS COMMENT BECAUSE IN GENERAL
-            // HEATMAPS REQUIRE A DEEPER REVIEW.
-
-            //var shapesQuery = mapLand.Data
-            //    .Select(x => x.Shape)
-            //    .Where(x => x is not null);
-
-            //foreach (var pathShape in shapesQuery)
-            //{
-            //    pathShape!.Fill = null;
-            //}
+            foreach (var data in mapLand.Data)
+            {
+                if (data.Shape is not null)
+                    data.Shape.Fill = null;
+            }
 
             _ = _everUsed.Remove(mapLand);
         }

--- a/src/LiveChartsCore/CoreHeatLandSeries.cs
+++ b/src/LiveChartsCore/CoreHeatLandSeries.cs
@@ -146,6 +146,25 @@ public abstract class CoreHeatLandSeries<TModel> : IGeoSeries, INotifyPropertyCh
         ClearHeat(toRemove);
     }
 
+    /// <inheritdoc cref="IGeoSeries.TryGetValue(string, out double)"/>
+    public bool TryGetValue(string landShortName, out double value)
+    {
+        if (Lands is not null)
+        {
+            foreach (var land in Lands)
+            {
+                if (string.Equals(land.Name, landShortName, StringComparison.OrdinalIgnoreCase))
+                {
+                    value = land.Value;
+                    return true;
+                }
+            }
+        }
+
+        value = 0;
+        return false;
+    }
+
     /// <inheritdoc cref="IGeoSeries.Delete(MapContext)"/>
     public void Delete(MapContext context)
     {

--- a/src/LiveChartsCore/Drawing/BaseVectorGeometry.cs
+++ b/src/LiveChartsCore/Drawing/BaseVectorGeometry.cs
@@ -195,6 +195,14 @@ public abstract partial class BaseVectorGeometry : Animatable, IDrawnElement
         base.CompleteTransition(properties);
     }
 
+    /// <summary>
+    /// Determines whether the specified point is inside this vector geometry.
+    /// </summary>
+    /// <param name="x">The x coordinate.</param>
+    /// <param name="y">The y coordinate.</param>
+    /// <returns><c>true</c> if the point is inside the geometry; otherwise, <c>false</c>.</returns>
+    public virtual bool ContainsPoint(float x, float y) => false;
+
     /// <inheritdoc cref="IDrawnElement.Measure()" />
     public LvcSize Measure() => new();
 

--- a/src/LiveChartsCore/Geo/GeoTooltipPoint.cs
+++ b/src/LiveChartsCore/Geo/GeoTooltipPoint.cs
@@ -1,4 +1,4 @@
-﻿// The MIT License(MIT)
+// The MIT License(MIT)
 //
 // Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
 //
@@ -20,41 +20,32 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using LiveChartsCore;
-using LiveChartsCore.Geo;
-using LiveChartsCore.Kernel.Observers;
-using LiveChartsCore.SkiaSharpView.SKCharts;
+using LiveChartsCore.Drawing;
 
-namespace LiveChartsGeneratedCode;
+namespace LiveChartsCore.Geo;
 
-// ==============================================================
-// this file contains the shared code between all UI frameworks
-// ==============================================================
-
-/// <inheritdoc cref="IGeoMapView" />
-#if SKIA_IMAGE_LVC
-public partial class SourceGenSKMapChart : IGeoMapView
-#else
-public partial class SourceGenMapChart : IGeoMapView
-#endif
+/// <summary>
+/// Represents a hovered land on a geo map, used for tooltip display.
+/// </summary>
+public class GeoTooltipPoint
 {
-    private CollectionDeepObserver _seriesObserver = null!;
+    /// <summary>
+    /// Gets or sets the land definition.
+    /// </summary>
+    public LandDefinition Land { get; set; } = null!;
 
     /// <summary>
-    /// Gets the core chart.
+    /// Gets or sets the heat value of the land.
     /// </summary>
-    public GeoMapChart CoreChart { get; private set; } = null!;
+    public double Value { get; set; }
 
-    /// <inheritdoc cref="IGeoMapView.AutoUpdateEnabled" />
-    public bool AutoUpdateEnabled { get; set; } = true;
+    /// <summary>
+    /// Gets or sets the heat color of the land.
+    /// </summary>
+    public LvcColor Color { get; set; }
 
-    private void InitializeChartControl()
-    {
-        CoreChart = new GeoMapChart(this);
-        _seriesObserver = new CollectionDeepObserver(() => CoreChart?.Update());
-
-        ActiveMap = Maps.GetWorldMap();
-        SyncContext = new object();
-        Tooltip = new SKDefaultGeoTooltip();
-    }
+    /// <summary>
+    /// Gets or sets the visual center of the land in screen coordinates.
+    /// </summary>
+    public LvcPoint LandCenter { get; set; }
 }

--- a/src/LiveChartsCore/Geo/GeoTooltipPoint.cs
+++ b/src/LiveChartsCore/Geo/GeoTooltipPoint.cs
@@ -40,6 +40,11 @@ public class GeoTooltipPoint
     public double Value { get; set; }
 
     /// <summary>
+    /// Gets or sets whether the land has a heat value assigned.
+    /// </summary>
+    public bool HasValue { get; set; }
+
+    /// <summary>
     /// Gets or sets the heat color of the land.
     /// </summary>
     public LvcColor Color { get; set; }

--- a/src/LiveChartsCore/Geo/IGeoMapTooltip.cs
+++ b/src/LiveChartsCore/Geo/IGeoMapTooltip.cs
@@ -1,4 +1,4 @@
-﻿// The MIT License(MIT)
+// The MIT License(MIT)
 //
 // Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
 //
@@ -20,41 +20,23 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using LiveChartsCore;
-using LiveChartsCore.Geo;
-using LiveChartsCore.Kernel.Observers;
-using LiveChartsCore.SkiaSharpView.SKCharts;
+namespace LiveChartsCore.Geo;
 
-namespace LiveChartsGeneratedCode;
-
-// ==============================================================
-// this file contains the shared code between all UI frameworks
-// ==============================================================
-
-/// <inheritdoc cref="IGeoMapView" />
-#if SKIA_IMAGE_LVC
-public partial class SourceGenSKMapChart : IGeoMapView
-#else
-public partial class SourceGenMapChart : IGeoMapView
-#endif
+/// <summary>
+/// Defines a tooltip for geo map charts.
+/// </summary>
+public interface IGeoMapTooltip
 {
-    private CollectionDeepObserver _seriesObserver = null!;
+    /// <summary>
+    /// Shows the tooltip for the specified land.
+    /// </summary>
+    /// <param name="point">The hovered land data.</param>
+    /// <param name="chart">The geo map chart.</param>
+    void Show(GeoTooltipPoint point, GeoMapChart chart);
 
     /// <summary>
-    /// Gets the core chart.
+    /// Hides the tooltip.
     /// </summary>
-    public GeoMapChart CoreChart { get; private set; } = null!;
-
-    /// <inheritdoc cref="IGeoMapView.AutoUpdateEnabled" />
-    public bool AutoUpdateEnabled { get; set; } = true;
-
-    private void InitializeChartControl()
-    {
-        CoreChart = new GeoMapChart(this);
-        _seriesObserver = new CollectionDeepObserver(() => CoreChart?.Update());
-
-        ActiveMap = Maps.GetWorldMap();
-        SyncContext = new object();
-        Tooltip = new SKDefaultGeoTooltip();
-    }
+    /// <param name="chart">The geo map chart.</param>
+    void Hide(GeoMapChart chart);
 }

--- a/src/LiveChartsCore/Geo/IGeoMapView.cs
+++ b/src/LiveChartsCore/Geo/IGeoMapView.cs
@@ -21,6 +21,7 @@
 // SOFTWARE.
 
 using LiveChartsCore.Kernel.Sketches;
+using LiveChartsCore.Measure;
 using LiveChartsCore.Painting;
 
 namespace LiveChartsCore.Geo;
@@ -86,4 +87,34 @@ public interface IGeoMapView : IDrawnView
     /// Gets or sets the series.
     /// </summary>
     IEnumerable<IGeoSeries> Series { get; set; }
+
+    /// <summary>
+    /// Gets whether the UI is in dark mode.
+    /// </summary>
+    bool IsDarkMode { get; }
+
+    /// <summary>
+    /// Gets or sets the tooltip.
+    /// </summary>
+    IGeoMapTooltip? Tooltip { get; set; }
+
+    /// <summary>
+    /// Gets or sets the tooltip position.
+    /// </summary>
+    TooltipPosition TooltipPosition { get; set; }
+
+    /// <summary>
+    /// Gets or sets the tooltip text paint.
+    /// </summary>
+    Paint? TooltipTextPaint { get; set; }
+
+    /// <summary>
+    /// Gets or sets the tooltip background paint.
+    /// </summary>
+    Paint? TooltipBackgroundPaint { get; set; }
+
+    /// <summary>
+    /// Gets or sets the tooltip text size.
+    /// </summary>
+    double TooltipTextSize { get; set; }
 }

--- a/src/LiveChartsCore/Geo/IGeoMapView.cs
+++ b/src/LiveChartsCore/Geo/IGeoMapView.cs
@@ -117,4 +117,19 @@ public interface IGeoMapView : IDrawnView
     /// Gets or sets the tooltip text size.
     /// </summary>
     double TooltipTextSize { get; set; }
+
+    /// <summary>
+    /// Gets or sets the zooming speed, a value between 0.1 and 0.95.
+    /// </summary>
+    double ZoomingSpeed { get; set; }
+
+    /// <summary>
+    /// Gets or sets the minimum zoom level. Defaults to 1.
+    /// </summary>
+    double MinZoomLevel { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum zoom level. Defaults to 100.
+    /// </summary>
+    double MaxZoomLevel { get; set; }
 }

--- a/src/LiveChartsCore/Geo/IGeoSeries.cs
+++ b/src/LiveChartsCore/Geo/IGeoSeries.cs
@@ -43,4 +43,12 @@ public interface IGeoSeries
     /// </summary>
     /// <param name="context">The map context.</param>
     void Delete(MapContext context);
+
+    /// <summary>
+    /// Gets the value for the specified land, if any.
+    /// </summary>
+    /// <param name="landShortName">The short name (ISO code) of the land.</param>
+    /// <param name="value">The value, if found.</param>
+    /// <returns><c>true</c> if the land has a value; otherwise, <c>false</c>.</returns>
+    bool TryGetValue(string landShortName, out double value);
 }

--- a/src/LiveChartsCore/Geo/IMapFactory.cs
+++ b/src/LiveChartsCore/Geo/IMapFactory.cs
@@ -22,6 +22,7 @@
 
 using System;
 using LiveChartsCore.Drawing;
+using LiveChartsCore.Measure;
 
 namespace LiveChartsCore.Geo;
 
@@ -49,4 +50,20 @@ public interface IMapFactory : IDisposable
     /// <param name="sender">The sender.</param>
     /// <param name="delta">The delta.</param>
     void Pan(GeoMapChart sender, LvcPoint delta);
+
+    /// <summary>
+    /// Zooms the map.
+    /// </summary>
+    /// <param name="sender">The sender.</param>
+    /// <param name="pivot">The pivot point in control coordinates.</param>
+    /// <param name="direction">The zoom direction.</param>
+    void Zoom(GeoMapChart sender, LvcPoint pivot, ZoomDirection direction);
+
+    /// <summary>
+    /// Sets the viewport directly to the given zoom and pan values.
+    /// </summary>
+    /// <param name="sender">The sender.</param>
+    /// <param name="zoom">The zoom level.</param>
+    /// <param name="panOffset">The pan offset.</param>
+    void SetViewport(GeoMapChart sender, float zoom, LvcPoint panOffset);
 }

--- a/src/LiveChartsCore/Geo/LandClickedEventArgs.cs
+++ b/src/LiveChartsCore/Geo/LandClickedEventArgs.cs
@@ -1,0 +1,46 @@
+// The MIT License(MIT)
+//
+// Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using LiveChartsCore.Drawing;
+
+namespace LiveChartsCore.Geo;
+
+/// <summary>
+/// Provides data for the <see cref="GeoMapChart.LandClicked"/> event.
+/// </summary>
+public class LandClickedEventArgs
+{
+    /// <summary>
+    /// Gets the land definition that was clicked.
+    /// </summary>
+    public LandDefinition Land { get; set; } = null!;
+
+    /// <summary>
+    /// Gets the heat value of the land, or 0 if no value is assigned.
+    /// </summary>
+    public double Value { get; set; }
+
+    /// <summary>
+    /// Gets the pointer position in control coordinates where the click occurred.
+    /// </summary>
+    public LvcPoint Position { get; set; }
+}

--- a/src/LiveChartsCore/Geo/LandData.cs
+++ b/src/LiveChartsCore/Geo/LandData.cs
@@ -86,4 +86,9 @@ public class LandData
     /// Gets or sets the shape.
     /// </summary>
     public BaseVectorGeometry? Shape { get; set; }
+
+    /// <summary>
+    /// Gets or sets the parent land definition.
+    /// </summary>
+    public LandDefinition? Land { get; set; }
 }

--- a/src/LiveChartsCore/GeoMapChart.cs
+++ b/src/LiveChartsCore/GeoMapChart.cs
@@ -59,6 +59,7 @@ public class GeoMapChart
     private float _zoomLevel = 1f;
     private LvcPoint _panOffset = new(0, 0);
     private bool _isBouncing = false;
+    private System.Threading.Timer? _bounceTimer;
     private bool _isPointerDown = false;
     private LvcPoint _pointerDownPosition = new(-10, -10);
     private bool _pointerDownIsClick = false;
@@ -101,21 +102,21 @@ public class GeoMapChart
     public IGeoMapView View { get; private set; }
 
     /// <summary>
-    /// Gets or sets the current zoom level.
+    /// Gets the current zoom level.
     /// </summary>
     public float ZoomLevel
     {
         get => _zoomLevel;
-        set => _zoomLevel = value;
+        internal set => _zoomLevel = value;
     }
 
     /// <summary>
-    /// Gets or sets the current pan offset.
+    /// Gets the current pan offset.
     /// </summary>
     public LvcPoint PanOffset
     {
         get => _panOffset;
-        set => _panOffset = value;
+        internal set => _panOffset = value;
     }
 
     /// <summary>
@@ -181,6 +182,10 @@ public class GeoMapChart
     {
         if (View.Stroke is not null) View.CoreCanvas.RemovePaintTask(View.Stroke);
         if (View.Fill is not null) View.CoreCanvas.RemovePaintTask(View.Fill);
+
+        _bounceTimer?.Dispose();
+        _bounceTimer = null;
+        _isBouncing = false;
 
         _everMeasuredSeries.Clear();
         _heatPaint = null!;
@@ -318,10 +323,11 @@ public class GeoMapChart
             View.TooltipPosition != TooltipPosition.Hidden)
         {
             var value = 0d;
+            var hasValue = false;
             foreach (var series in View.Series?.Cast<IGeoSeries>() ?? [])
             {
                 if (series.TryGetValue(_hoveredLand.ShortName, out value))
-                    break;
+                { hasValue = true; break; }
             }
 
             // Compute screen-space center from the first data shape
@@ -354,6 +360,7 @@ public class GeoMapChart
                 {
                     Land = _hoveredLand,
                     Value = value,
+                    HasValue = hasValue,
                     LandCenter = center
                 },
                 this);
@@ -382,8 +389,8 @@ public class GeoMapChart
     /// Finds the land definition at the specified pointer position, if any.
     /// </summary>
     /// <param name="pointerPosition">The pointer position in control coordinates.</param>
-    /// <returns>A tuple of the land definition, heat value, and screen-space center, or null.</returns>
-    public (LandDefinition Land, double Value, LvcPoint Center)? FindLandAt(LvcPoint pointerPosition)
+    /// <returns>A tuple of the land definition, heat value, whether a value exists, and screen-space center, or null.</returns>
+    public (LandDefinition Land, double Value, bool HasValue, LvcPoint Center)? FindLandAt(LvcPoint pointerPosition)
     {
         if (_activeMap is null) return null;
 
@@ -400,10 +407,11 @@ public class GeoMapChart
 
                     // Look up the heat value from the series
                     var value = 0d;
+                    var hasValue = false;
                     foreach (var series in View.Series?.Cast<IGeoSeries>() ?? [])
                     {
                         if (series.TryGetValue(landDefinition.ShortName, out value))
-                            break;
+                        { hasValue = true; break; }
                     }
 
                     // Compute screen-space center from the shape's segments (base coordinates)
@@ -427,7 +435,7 @@ public class GeoMapChart
                     var ty = ctrlCy * (1 - _zoomLevel) + _panOffset.Y;
                     var center = new LvcPoint(baseCx * _zoomLevel + tx, baseCy * _zoomLevel + ty);
 
-                    return (landDefinition, value, center);
+                    return (landDefinition, value, hasValue, center);
                 }
             }
         }
@@ -459,7 +467,7 @@ public class GeoMapChart
                         return;
                     }
 
-                    var (land, value, center) = result.Value;
+                    var (land, value, hasValue, center) = result.Value;
 
                     if (land == _hoveredLand) return;
                     _hoveredLand = land;
@@ -470,6 +478,7 @@ public class GeoMapChart
                         {
                             Land = land,
                             Value = value,
+                            HasValue = hasValue,
                             LandCenter = center
                         },
                         this);
@@ -639,9 +648,17 @@ public class GeoMapChart
         var startPanY = _panOffset.Y;
         var startZoom = _zoomLevel;
 
-        System.Threading.Timer? timer = null;
-        timer = new System.Threading.Timer(_ =>
+        _bounceTimer?.Dispose();
+        _bounceTimer = new System.Threading.Timer(_ =>
         {
+            if (_isUnloaded)
+            {
+                _isBouncing = false;
+                _bounceTimer?.Dispose();
+                _bounceTimer = null;
+                return;
+            }
+
             step++;
             var t = (float)step / steps;
             // ease-out cubic
@@ -653,13 +670,15 @@ public class GeoMapChart
 
             View.InvokeOnUIThread(() =>
             {
+                if (_isUnloaded) return;
                 _mapFactory.SetViewport(this, newZoom, new LvcPoint(newPanX, newPanY));
             });
 
             if (step >= steps)
             {
                 _isBouncing = false;
-                timer?.Dispose();
+                _bounceTimer?.Dispose();
+                _bounceTimer = null;
             }
         }, null, intervalMs, intervalMs);
     }

--- a/src/LiveChartsCore/GeoMapChart.cs
+++ b/src/LiveChartsCore/GeoMapChart.cs
@@ -27,7 +27,9 @@ using System.Threading.Tasks;
 using LiveChartsCore.Drawing;
 using LiveChartsCore.Geo;
 using LiveChartsCore.Kernel;
+using LiveChartsCore.Measure;
 using LiveChartsCore.Painting;
+using LiveChartsCore.Themes;
 
 namespace LiveChartsCore;
 
@@ -39,16 +41,21 @@ public class GeoMapChart
     private readonly HashSet<IGeoSeries> _everMeasuredSeries = [];
     private readonly ActionThrottler _updateThrottler;
     private readonly ActionThrottler _panningThrottler;
+    private readonly ActionThrottler _tooltipThrottler;
     private bool _isHeatInCanvas = false;
     private Paint _heatPaint;
     private Paint? _previousStroke;
     private Paint? _previousFill;
     private LvcPoint _pointerPanningPosition = new(-10, -10);
     private LvcPoint _pointerPreviousPanningPosition = new(-10, -10);
+    private LvcPoint _pointerPosition = new(-10, -10);
     private bool _isPanning = false;
+    private bool _isPointerIn = false;
     private IMapFactory _mapFactory;
     private DrawnMap? _activeMap;
     private bool _isUnloaded = false;
+    private bool _isToolTipOpen = false;
+    private LandDefinition? _hoveredLand;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="GeoMapChart"/> class.
@@ -69,6 +76,7 @@ public class GeoMapChart
         PointerLeft += Chart_PointerLeft;
 
         _panningThrottler = new ActionThrottler(PanningThrottlerUnlocked, TimeSpan.FromMilliseconds(30));
+        _tooltipThrottler = new ActionThrottler(TooltipThrottlerUnlocked, TimeSpan.FromMilliseconds(50));
     }
 
     internal event Action<LvcPoint> PointerDown;
@@ -80,6 +88,16 @@ public class GeoMapChart
     /// Gets the chart view.
     /// </summary>
     public IGeoMapView View { get; private set; }
+
+    /// <summary>
+    /// Gets the active theme, ensuring it is set up for the current dark/light mode.
+    /// </summary>
+    public Theme GetTheme()
+    {
+        var theme = LiveCharts.DefaultSettings.GetTheme();
+        theme.Setup(View.IsDarkMode);
+        return theme;
+    }
 
     /// <inheritdoc cref="IMapFactory.ViewTo(GeoMapChart, object)"/>
     public virtual void ViewTo(object? command) => _mapFactory.ViewTo(this, command);
@@ -245,6 +263,45 @@ public class GeoMapChart
             _ = _everMeasuredSeries.Remove(series);
         }
 
+        // Refresh tooltip if a land is currently hovered (data may have changed)
+        if (_hoveredLand is not null && View.Tooltip is not null &&
+            View.TooltipPosition != TooltipPosition.Hidden)
+        {
+            var value = 0d;
+            foreach (var series in View.Series?.Cast<IGeoSeries>() ?? [])
+            {
+                if (series.TryGetValue(_hoveredLand.ShortName, out value))
+                    break;
+            }
+
+            // Compute screen-space center from the first data shape
+            var center = _pointerPosition;
+            foreach (var data in _hoveredLand.Data)
+            {
+                if (data.Shape is null) continue;
+                float minX = float.MaxValue, minY = float.MaxValue;
+                float maxX = float.MinValue, maxY = float.MinValue;
+                foreach (var seg in data.Shape.Commands)
+                {
+                    if (seg.Xi < minX) minX = seg.Xi;
+                    if (seg.Yi < minY) minY = seg.Yi;
+                    if (seg.Xi > maxX) maxX = seg.Xi;
+                    if (seg.Yi > maxY) maxY = seg.Yi;
+                }
+                center = new LvcPoint((minX + maxX) / 2f, (minY + maxY) / 2f);
+                break;
+            }
+
+            View.Tooltip.Show(
+                new GeoTooltipPoint
+                {
+                    Land = _hoveredLand,
+                    Value = value,
+                    LandCenter = center
+                },
+                this);
+        }
+
         View.CoreCanvas.Invalidate();
     }
 
@@ -264,22 +321,142 @@ public class GeoMapChart
             }));
     }
 
+    /// <summary>
+    /// Finds the land definition at the specified pointer position, if any.
+    /// </summary>
+    /// <param name="pointerPosition">The pointer position in control coordinates.</param>
+    /// <returns>A tuple of the land definition, heat value, and screen-space center, or null.</returns>
+    public (LandDefinition Land, double Value, LvcPoint Center)? FindLandAt(LvcPoint pointerPosition)
+    {
+        if (_activeMap is null) return null;
+
+        foreach (var layer in _activeMap.Layers.Values)
+        {
+            if (!layer.IsVisible) continue;
+
+            foreach (var landDefinition in layer.Lands.Values)
+            {
+                foreach (var landData in landDefinition.Data)
+                {
+                    if (landData.Shape is null) continue;
+                    if (!landData.Shape.ContainsPoint(pointerPosition.X, pointerPosition.Y)) continue;
+
+                    // Look up the heat value from the series
+                    var value = 0d;
+                    foreach (var series in View.Series?.Cast<IGeoSeries>() ?? [])
+                    {
+                        if (series.TryGetValue(landDefinition.ShortName, out value))
+                            break;
+                    }
+
+                    // Compute screen-space center from the shape's segments
+                    var commands = landData.Shape.Commands;
+                    float minX = float.MaxValue, minY = float.MaxValue;
+                    float maxX = float.MinValue, maxY = float.MinValue;
+                    foreach (var seg in commands)
+                    {
+                        if (seg.Xi < minX) minX = seg.Xi;
+                        if (seg.Yi < minY) minY = seg.Yi;
+                        if (seg.Xi > maxX) maxX = seg.Xi;
+                        if (seg.Yi > maxY) maxY = seg.Yi;
+                    }
+                    var center = new LvcPoint((minX + maxX) / 2f, (minY + maxY) / 2f);
+
+                    return (landDefinition, value, center);
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private Task TooltipThrottlerUnlocked()
+    {
+        return Task.Run(() =>
+            View.InvokeOnUIThread(() =>
+            {
+                lock (View.CoreCanvas.Sync)
+                {
+                    if (_isUnloaded || _isPanning || !_isPointerIn) return;
+                    if (View.Tooltip is null || View.TooltipPosition == TooltipPosition.Hidden) return;
+
+                    var result = FindLandAt(_pointerPosition);
+
+                    if (result is null)
+                    {
+                        if (_isToolTipOpen)
+                        {
+                            _hoveredLand = null;
+                            _isToolTipOpen = false;
+                            View.Tooltip.Hide(this);
+                            View.CoreCanvas.Invalidate();
+                        }
+                        return;
+                    }
+
+                    var (land, value, center) = result.Value;
+
+                    if (land == _hoveredLand) return;
+                    _hoveredLand = land;
+                    _isToolTipOpen = true;
+
+                    View.Tooltip.Show(
+                        new GeoTooltipPoint
+                        {
+                            Land = land,
+                            Value = value,
+                            LandCenter = center
+                        },
+                        this);
+                    View.CoreCanvas.Invalidate();
+                }
+            }));
+    }
+
     private void Chart_PointerDown(LvcPoint pointerPosition)
     {
         _isPanning = true;
         _pointerPreviousPanningPosition = pointerPosition;
+
+        // Hide tooltip while panning
+        if (_isToolTipOpen)
+        {
+            _hoveredLand = null;
+            _isToolTipOpen = false;
+            View.Tooltip?.Hide(this);
+        }
     }
 
     private void Chart_PointerMove(LvcPoint pointerPosition)
     {
-        if (!_isPanning) return;
-        _pointerPanningPosition = pointerPosition;
-        _panningThrottler.Call();
+        _pointerPosition = pointerPosition;
+        _isPointerIn = true;
+
+        if (_isPanning)
+        {
+            _pointerPanningPosition = pointerPosition;
+            _panningThrottler.Call();
+        }
+        else
+        {
+            _tooltipThrottler.Call();
+        }
     }
 
     private void Chart_PointerLeft()
     {
-        // ...?
+        _isPointerIn = false;
+
+        if (_isToolTipOpen)
+        {
+            _hoveredLand = null;
+            _isToolTipOpen = false;
+            View.InvokeOnUIThread(() =>
+            {
+                View.Tooltip?.Hide(this);
+                View.CoreCanvas.Invalidate();
+            });
+        }
     }
 
     private void Chart_PointerUp(LvcPoint pointerPosition)

--- a/src/LiveChartsCore/GeoMapChart.cs
+++ b/src/LiveChartsCore/GeoMapChart.cs
@@ -56,6 +56,12 @@ public class GeoMapChart
     private bool _isUnloaded = false;
     private bool _isToolTipOpen = false;
     private LandDefinition? _hoveredLand;
+    private float _zoomLevel = 1f;
+    private LvcPoint _panOffset = new(0, 0);
+    private bool _isBouncing = false;
+    private bool _isPointerDown = false;
+    private LvcPoint _pointerDownPosition = new(-10, -10);
+    private bool _pointerDownIsClick = false;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="GeoMapChart"/> class.
@@ -85,9 +91,32 @@ public class GeoMapChart
     internal event Action PointerLeft;
 
     /// <summary>
+    /// Occurs when a land (country) is clicked.
+    /// </summary>
+    public event Action<LandClickedEventArgs>? LandClicked;
+
+    /// <summary>
     /// Gets the chart view.
     /// </summary>
     public IGeoMapView View { get; private set; }
+
+    /// <summary>
+    /// Gets or sets the current zoom level.
+    /// </summary>
+    public float ZoomLevel
+    {
+        get => _zoomLevel;
+        set => _zoomLevel = value;
+    }
+
+    /// <summary>
+    /// Gets or sets the current pan offset.
+    /// </summary>
+    public LvcPoint PanOffset
+    {
+        get => _panOffset;
+        set => _panOffset = value;
+    }
 
     /// <summary>
     /// Gets the active theme, ensuring it is set up for the current dark/light mode.
@@ -104,6 +133,27 @@ public class GeoMapChart
 
     /// <inheritdoc cref="IMapFactory.Pan(GeoMapChart, LvcPoint)"/>
     public virtual void Pan(LvcPoint delta) => _mapFactory.Pan(this, delta);
+
+    /// <inheritdoc cref="IMapFactory.Zoom(GeoMapChart, LvcPoint, ZoomDirection)"/>
+    public virtual void Zoom(LvcPoint pivot, ZoomDirection direction) =>
+        _mapFactory.Zoom(this, pivot, direction);
+
+    /// <summary>
+    /// Resets the viewport to the default zoom and pan.
+    /// </summary>
+    public void ResetViewport()
+    {
+        _isBouncing = false;
+        _mapFactory.SetViewport(this, 1f, new LvcPoint(0, 0));
+    }
+
+    /// <summary>
+    /// Invokes a pointer wheel event.
+    /// </summary>
+    /// <param name="point">The pointer position.</param>
+    /// <param name="direction">The zoom direction.</param>
+    protected internal void InvokePointerWheel(LvcPoint point, ZoomDirection direction) =>
+        Zoom(point, direction);
 
     /// <summary>
     /// Queues a measure request to update the chart.
@@ -288,7 +338,14 @@ public class GeoMapChart
                     if (seg.Xi > maxX) maxX = seg.Xi;
                     if (seg.Yi > maxY) maxY = seg.Yi;
                 }
-                center = new LvcPoint((minX + maxX) / 2f, (minY + maxY) / 2f);
+                // Transform base center to screen space
+                var baseCx = (minX + maxX) / 2f;
+                var baseCy = (minY + maxY) / 2f;
+                var ctrlCx = View.ControlSize.Width * 0.5f;
+                var ctrlCy = View.ControlSize.Height * 0.5f;
+                var tx = ctrlCx * (1 - _zoomLevel) + _panOffset.X;
+                var ty = ctrlCy * (1 - _zoomLevel) + _panOffset.Y;
+                center = new LvcPoint(baseCx * _zoomLevel + tx, baseCy * _zoomLevel + ty);
                 break;
             }
 
@@ -349,7 +406,7 @@ public class GeoMapChart
                             break;
                     }
 
-                    // Compute screen-space center from the shape's segments
+                    // Compute screen-space center from the shape's segments (base coordinates)
                     var commands = landData.Shape.Commands;
                     float minX = float.MaxValue, minY = float.MaxValue;
                     float maxX = float.MinValue, maxY = float.MinValue;
@@ -360,7 +417,15 @@ public class GeoMapChart
                         if (seg.Xi > maxX) maxX = seg.Xi;
                         if (seg.Yi > maxY) maxY = seg.Yi;
                     }
-                    var center = new LvcPoint((minX + maxX) / 2f, (minY + maxY) / 2f);
+
+                    // Transform base center to screen space
+                    var baseCx = (minX + maxX) / 2f;
+                    var baseCy = (minY + maxY) / 2f;
+                    var ctrlCx = View.ControlSize.Width * 0.5f;
+                    var ctrlCy = View.ControlSize.Height * 0.5f;
+                    var tx = ctrlCx * (1 - _zoomLevel) + _panOffset.X;
+                    var ty = ctrlCy * (1 - _zoomLevel) + _panOffset.Y;
+                    var center = new LvcPoint(baseCx * _zoomLevel + tx, baseCy * _zoomLevel + ty);
 
                     return (landDefinition, value, center);
                 }
@@ -415,16 +480,10 @@ public class GeoMapChart
 
     private void Chart_PointerDown(LvcPoint pointerPosition)
     {
-        _isPanning = true;
         _pointerPreviousPanningPosition = pointerPosition;
-
-        // Hide tooltip while panning
-        if (_isToolTipOpen)
-        {
-            _hoveredLand = null;
-            _isToolTipOpen = false;
-            View.Tooltip?.Hide(this);
-        }
+        _pointerDownPosition = pointerPosition;
+        _pointerDownIsClick = true;
+        _isPointerDown = true;
     }
 
     private void Chart_PointerMove(LvcPoint pointerPosition)
@@ -432,12 +491,31 @@ public class GeoMapChart
         _pointerPosition = pointerPosition;
         _isPointerIn = true;
 
+        if (_isPointerDown && !_isPanning)
+        {
+            var dx = pointerPosition.X - _pointerDownPosition.X;
+            var dy = pointerPosition.Y - _pointerDownPosition.Y;
+            if (dx * dx + dy * dy > 25) // 5px drag threshold
+            {
+                _isPanning = true;
+                _pointerDownIsClick = false;
+
+                // Hide tooltip while panning
+                if (_isToolTipOpen)
+                {
+                    _hoveredLand = null;
+                    _isToolTipOpen = false;
+                    View.Tooltip?.Hide(this);
+                }
+            }
+        }
+
         if (_isPanning)
         {
             _pointerPanningPosition = pointerPosition;
             _panningThrottler.Call();
         }
-        else
+        else if (!_isPointerDown)
         {
             _tooltipThrottler.Call();
         }
@@ -461,8 +539,128 @@ public class GeoMapChart
 
     private void Chart_PointerUp(LvcPoint pointerPosition)
     {
-        if (!_isPanning) return;
-        _isPanning = false;
-        _panningThrottler.Call();
+        var wasClick = _pointerDownIsClick;
+        _pointerDownIsClick = false;
+        _isPointerDown = false;
+
+        if (_isPanning)
+        {
+            _isPanning = false;
+            _panningThrottler.Call();
+            BounceBack();
+        }
+
+        if (wasClick && LandClicked is not null)
+        {
+            var result = FindLandAt(pointerPosition);
+            if (result is not null)
+            {
+                LandClicked.Invoke(new LandClickedEventArgs
+                {
+                    Land = result.Value.Land,
+                    Value = result.Value.Value,
+                    Position = pointerPosition
+                });
+            }
+        }
+    }
+
+    private void BounceBack()
+    {
+        if (_isBouncing) return;
+
+        var controlW = View.ControlSize.Width;
+        var controlH = View.ControlSize.Height;
+        if (controlW <= 0 || controlH <= 0) return;
+
+        var cx = controlW * 0.5f;
+        var cy = controlH * 0.5f;
+        var zoom = _zoomLevel;
+        var minZoom = (float)View.MinZoomLevel;
+        var targetZoom = zoom < minZoom ? minZoom : zoom;
+
+        // Map occupies [0,0]..[controlW,controlH] in base coordinates.
+        // After transform: screenX = baseX * zoom + tx, where tx = cx*(1-zoom) + panX
+        // Map left edge on screen = tx, map right edge on screen = controlW * zoom + tx
+        //
+        // Constraint: the map must fully cover the viewport (no background visible).
+        // When zoomed in (map bigger than viewport):
+        //   left edge <= 0  AND  right edge >= controlW
+        //   tx <= 0  AND  tx >= controlW - mapScreenW  (i.e. controlW*(1-zoom))
+        // When at 1x (map == viewport): tx must be 0, ty must be 0 → panX=0, panY=0
+
+        var mapScreenW = controlW * targetZoom;
+        var mapScreenH = controlH * targetZoom;
+
+        // Compute current tx/ty at the target zoom using current pan
+        var targetPanX = _panOffset.X;
+        var targetPanY = _panOffset.Y;
+
+        // If zoom is bouncing, reset pan to keep centered
+        if (targetZoom != zoom)
+        {
+            // Scale current pan proportionally to new zoom
+            targetPanX = _panOffset.X * targetZoom / zoom;
+            targetPanY = _panOffset.Y * targetZoom / zoom;
+        }
+
+        var tx = cx * (1 - targetZoom) + targetPanX;
+        var ty = cy * (1 - targetZoom) + targetPanY;
+
+        // Clamp: map left edge must be <= 0 (can't show background on left)
+        if (tx > 0) tx = 0;
+        // Clamp: map right edge must be >= controlW (can't show background on right)
+        if (tx + mapScreenW < controlW) tx = controlW - mapScreenW;
+
+        // Clamp vertical
+        if (ty > 0) ty = 0;
+        if (ty + mapScreenH < controlH) ty = controlH - mapScreenH;
+
+        targetPanX = tx - cx * (1 - targetZoom);
+        targetPanY = ty - cy * (1 - targetZoom);
+
+        var panDiffX = Math.Abs(targetPanX - _panOffset.X);
+        var panDiffY = Math.Abs(targetPanY - _panOffset.Y);
+        var zoomDiff = Math.Abs(targetZoom - zoom);
+
+        if (panDiffX < 0.5f && panDiffY < 0.5f && zoomDiff < 0.001f) return;
+
+        _isBouncing = true;
+        AnimateBounce(targetPanX, targetPanY, targetZoom);
+    }
+
+    private void AnimateBounce(float targetPanX, float targetPanY, float targetZoom)
+    {
+        const int steps = 8;
+        const int intervalMs = 16;
+        var step = 0;
+
+        var startPanX = _panOffset.X;
+        var startPanY = _panOffset.Y;
+        var startZoom = _zoomLevel;
+
+        System.Threading.Timer? timer = null;
+        timer = new System.Threading.Timer(_ =>
+        {
+            step++;
+            var t = (float)step / steps;
+            // ease-out cubic
+            t = 1 - (1 - t) * (1 - t) * (1 - t);
+
+            var newPanX = startPanX + (targetPanX - startPanX) * t;
+            var newPanY = startPanY + (targetPanY - startPanY) * t;
+            var newZoom = startZoom + (targetZoom - startZoom) * t;
+
+            View.InvokeOnUIThread(() =>
+            {
+                _mapFactory.SetViewport(this, newZoom, new LvcPoint(newPanX, newPanY));
+            });
+
+            if (step >= steps)
+            {
+                _isBouncing = false;
+                timer?.Dispose();
+            }
+        }, null, intervalMs, intervalMs);
     }
 }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/SourceGenMapChart.avalonia.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/SourceGenMapChart.avalonia.cs
@@ -23,7 +23,9 @@
 using System;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.Rendering;
+using Avalonia.Styling;
 using Avalonia.Threading;
 using LiveChartsCore.Drawing;
 using LiveChartsCore.Geo;
@@ -48,6 +50,11 @@ public partial class SourceGenMapChart : UserControl, IGeoMapView, ICustomHitTes
         Content = new MotionCanvas();
         InitializeChartControl();
 
+        PointerPressed += OnPointerPressed;
+        PointerMoved += OnPointerMoved;
+        PointerReleased += OnPointerReleased;
+        PointerExited += OnPointerExited;
+
         SizeChanged += (s, e) =>
             CoreChart.Update();
 
@@ -60,6 +67,7 @@ public partial class SourceGenMapChart : UserControl, IGeoMapView, ICustomHitTes
     public CoreMotionCanvas CoreCanvas => MotionCanvas.CanvasCore;
 
     bool IGeoMapView.DesignerMode => Design.IsDesignMode;
+    bool IGeoMapView.IsDarkMode => Application.Current?.ActualThemeVariant == ThemeVariant.Dark;
     LvcSize IDrawnView.ControlSize => new() { Width = (float)MotionCanvas.Bounds.Width, Height = (float)MotionCanvas.Bounds.Height };
 
     private void GeoMap_DetachedFromVisualTree(object? sender, VisualTreeAttachmentEventArgs e)
@@ -73,4 +81,27 @@ public partial class SourceGenMapChart : UserControl, IGeoMapView, ICustomHitTes
 
     bool ICustomHitTest.HitTest(Point point) =>
         new Rect(Bounds.Size).Contains(point);
+
+    private void OnPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        var p = e.GetPosition(this);
+        CoreChart?.InvokePointerDown(new LvcPoint((float)p.X, (float)p.Y));
+    }
+
+    private void OnPointerMoved(object? sender, PointerEventArgs e)
+    {
+        var p = e.GetPosition(this);
+        CoreChart?.InvokePointerMove(new LvcPoint((float)p.X, (float)p.Y));
+    }
+
+    private void OnPointerReleased(object? sender, PointerReleasedEventArgs e)
+    {
+        var p = e.GetPosition(this);
+        CoreChart?.InvokePointerUp(new LvcPoint((float)p.X, (float)p.Y));
+    }
+
+    private void OnPointerExited(object? sender, PointerEventArgs e)
+    {
+        CoreChart?.InvokePointerLeft();
+    }
 }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/SourceGenMapChart.avalonia.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/SourceGenMapChart.avalonia.cs
@@ -30,6 +30,7 @@ using Avalonia.Threading;
 using LiveChartsCore.Drawing;
 using LiveChartsCore.Geo;
 using LiveChartsCore.Kernel.Sketches;
+using LiveChartsCore.Measure;
 using LiveChartsCore.Motion;
 using LiveChartsCore.SkiaSharpView.Avalonia;
 
@@ -54,6 +55,7 @@ public partial class SourceGenMapChart : UserControl, IGeoMapView, ICustomHitTes
         PointerMoved += OnPointerMoved;
         PointerReleased += OnPointerReleased;
         PointerExited += OnPointerExited;
+        PointerWheelChanged += OnPointerWheelChanged;
 
         SizeChanged += (s, e) =>
             CoreChart.Update();
@@ -103,5 +105,15 @@ public partial class SourceGenMapChart : UserControl, IGeoMapView, ICustomHitTes
     private void OnPointerExited(object? sender, PointerEventArgs e)
     {
         CoreChart?.InvokePointerLeft();
+    }
+
+    private void OnPointerWheelChanged(object? sender, PointerWheelEventArgs e)
+    {
+        e.Handled = true;
+
+        var p = e.GetPosition(this);
+        CoreChart?.InvokePointerWheel(
+            new LvcPoint((float)p.X, (float)p.Y),
+            e.Delta.Y > 0 ? ZoomDirection.ZoomIn : ZoomDirection.ZoomOut);
     }
 }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/SourceGenMapChart.wpf.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/SourceGenMapChart.wpf.cs
@@ -61,6 +61,7 @@ public abstract partial class SourceGenMapChart : UserControl, IGeoMapView
     public CoreMotionCanvas CoreCanvas => MotionCanvas.CanvasCore;
 
     bool IGeoMapView.DesignerMode => DesignerProperties.GetIsInDesignMode(this);
+    bool IGeoMapView.IsDarkMode => false;
     LvcSize IDrawnView.ControlSize => new() { Width = (float)ActualWidth, Height = (float)ActualHeight };
 
     private void OnUnloaded(object sender, RoutedEventArgs e) =>

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/SourceGenMapChart.wpf.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/SourceGenMapChart.wpf.cs
@@ -24,9 +24,11 @@ using System;
 using System.ComponentModel;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
 using LiveChartsCore.Drawing;
 using LiveChartsCore.Geo;
 using LiveChartsCore.Kernel.Sketches;
+using LiveChartsCore.Measure;
 using LiveChartsCore.Motion;
 using LiveChartsCore.SkiaSharpView.WPF;
 
@@ -52,6 +54,12 @@ public abstract partial class SourceGenMapChart : UserControl, IGeoMapView
 
         InitializeChartControl();
 
+        MouseWheel += OnMouseWheel;
+        MouseDown += OnMouseDown;
+        MouseMove += OnMouseMove;
+        MouseUp += OnMouseUp;
+        MouseLeave += OnMouseLeave;
+
         Unloaded += OnUnloaded;
     }
 
@@ -69,4 +77,35 @@ public abstract partial class SourceGenMapChart : UserControl, IGeoMapView
 
     void IGeoMapView.InvokeOnUIThread(Action action) =>
         Dispatcher.Invoke(action);
+
+    private void OnMouseWheel(object? sender, MouseWheelEventArgs e)
+    {
+        var p = e.GetPosition(this);
+        CoreChart?.InvokePointerWheel(
+            new LvcPoint((float)p.X, (float)p.Y),
+            e.Delta > 0 ? ZoomDirection.ZoomIn : ZoomDirection.ZoomOut);
+    }
+
+    private void OnMouseDown(object? sender, MouseButtonEventArgs e)
+    {
+        var p = e.GetPosition(this);
+        CoreChart?.InvokePointerDown(new LvcPoint((float)p.X, (float)p.Y));
+    }
+
+    private void OnMouseMove(object? sender, MouseEventArgs e)
+    {
+        var p = e.GetPosition(this);
+        CoreChart?.InvokePointerMove(new LvcPoint((float)p.X, (float)p.Y));
+    }
+
+    private void OnMouseUp(object? sender, MouseButtonEventArgs e)
+    {
+        var p = e.GetPosition(this);
+        CoreChart?.InvokePointerUp(new LvcPoint((float)p.X, (float)p.Y));
+    }
+
+    private void OnMouseLeave(object? sender, MouseEventArgs e)
+    {
+        CoreChart?.InvokePointerLeft();
+    }
 }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WinForms/SourceGenMapChart.winforms.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WinForms/SourceGenMapChart.winforms.cs
@@ -68,6 +68,7 @@ public abstract partial class SourceGenMapChart : UserControl, IGeoMapView
 
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     bool IGeoMapView.DesignerMode => false;
+    bool IGeoMapView.IsDarkMode => false;
 
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     LvcSize IDrawnView.ControlSize => new() { Width = Width, Height = Height };

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WinForms/SourceGenMapChart.winforms.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WinForms/SourceGenMapChart.winforms.cs
@@ -27,6 +27,7 @@ using System.Windows.Forms;
 using LiveChartsCore.Drawing;
 using LiveChartsCore.Geo;
 using LiveChartsCore.Kernel.Sketches;
+using LiveChartsCore.Measure;
 using LiveChartsCore.Motion;
 using LiveChartsCore.SkiaSharpView.WinForms;
 
@@ -60,6 +61,13 @@ public abstract partial class SourceGenMapChart : UserControl, IGeoMapView
 
         motionCanvas.Resize += (s, e) =>
             CoreChart.Update();
+
+        var drawnControl = GetDrawnControl();
+        drawnControl.MouseWheel += OnMouseWheel;
+        drawnControl.MouseDown += OnMouseDown;
+        drawnControl.MouseMove += OnMouseMove;
+        drawnControl.MouseUp += OnMouseUp;
+        drawnControl.MouseLeave += OnMouseLeave;
     }
 
     /// <inheritdoc cref="IDrawnView.CoreCanvas"/>"/>
@@ -94,5 +102,36 @@ public abstract partial class SourceGenMapChart : UserControl, IGeoMapView
     {
         base.OnHandleDestroyed(e);
         CoreChart?.Unload();
+    }
+
+    private void OnMouseWheel(object? sender, MouseEventArgs e)
+    {
+        var p = e.Location;
+        CoreChart?.InvokePointerWheel(
+            new LvcPoint(p.X, p.Y),
+            e.Delta > 0 ? ZoomDirection.ZoomIn : ZoomDirection.ZoomOut);
+    }
+
+    private void OnMouseDown(object? sender, MouseEventArgs e)
+    {
+        var p = e.Location;
+        CoreChart?.InvokePointerDown(new LvcPoint(p.X, p.Y));
+    }
+
+    private void OnMouseMove(object? sender, MouseEventArgs e)
+    {
+        var p = e.Location;
+        CoreChart?.InvokePointerMove(new LvcPoint(p.X, p.Y));
+    }
+
+    private void OnMouseUp(object? sender, MouseEventArgs e)
+    {
+        var p = e.Location;
+        CoreChart?.InvokePointerUp(new LvcPoint(p.X, p.Y));
+    }
+
+    private void OnMouseLeave(object? sender, EventArgs e)
+    {
+        CoreChart?.InvokePointerLeft();
     }
 }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/Geometries/LandAreaGeometry.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/Geometries/LandAreaGeometry.cs
@@ -1,4 +1,4 @@
-﻿// The MIT License(MIT)
+// The MIT License(MIT)
 //
 // Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
 //
@@ -20,16 +20,149 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using LiveChartsCore.Drawing;
 using LiveChartsCore.Drawing.Segments;
 using SkiaSharp;
 
 namespace LiveChartsCore.SkiaSharpView.Drawing.Geometries;
 
 /// <summary>
-/// Defines an area drawin using bezier segments.
+/// Holds shared viewport transform state for all land geometries.
+/// A single instance is shared across all geometries — update once, affects all draws.
 /// </summary>
-public class LandAreaGeometry : VectorGeometry
+public class MapViewportTransform
 {
+    /// <summary>
+    /// Gets or sets the zoom level.
+    /// </summary>
+    public float Zoom { get; set; } = 1f;
+
+    /// <summary>
+    /// Gets or sets the pan X offset.
+    /// </summary>
+    public float PanX { get; set; }
+
+    /// <summary>
+    /// Gets or sets the pan Y offset.
+    /// </summary>
+    public float PanY { get; set; }
+
+    /// <summary>
+    /// Gets or sets the center X of the control.
+    /// </summary>
+    public float CenterX { get; set; }
+
+    /// <summary>
+    /// Gets or sets the center Y of the control.
+    /// </summary>
+    public float CenterY { get; set; }
+
+    /// <summary>
+    /// Gets whether this transform is non-identity.
+    /// </summary>
+    public bool IsActive => Zoom != 1f || PanX != 0 || PanY != 0;
+
+    /// <summary>
+    /// Builds the SKMatrix for the current viewport transform.
+    /// </summary>
+    public SKMatrix GetMatrix()
+    {
+        var tx = CenterX * (1 - Zoom) + PanX;
+        var ty = CenterY * (1 - Zoom) + PanY;
+        return new SKMatrix(Zoom, 0, tx, 0, Zoom, ty, 0, 0, 1);
+    }
+
+    /// <summary>
+    /// Inverse-transforms a screen point to base (unzoomed) coordinates.
+    /// </summary>
+    public (float x, float y) InverseTransform(float screenX, float screenY)
+    {
+        var tx = CenterX * (1 - Zoom) + PanX;
+        var ty = CenterY * (1 - Zoom) + PanY;
+        return ((screenX - tx) / Zoom, (screenY - ty) / Zoom);
+    }
+}
+
+/// <summary>
+/// Defines a land area geometry with cached path rendering for smooth zoom/pan.
+/// Re-implements the draw interface to bypass per-frame path rebuilding.
+/// Uses canvas matrix transform (GPU-accelerated) — zero allocations during zoom/pan.
+/// </summary>
+public class LandAreaGeometry : VectorGeometry, IDrawnElement<SkiaSharpDrawingContext>
+{
+    private SKPath? _basePath;
+    private bool _pathDirty = true;
+
+    /// <summary>
+    /// Gets or sets the shared viewport transform applied during rendering.
+    /// </summary>
+    public MapViewportTransform? ViewportTransform { get; set; }
+
+    /// <summary>
+    /// Marks the cached path as dirty, forcing a rebuild on the next draw.
+    /// Call this after modifying the Commands collection.
+    /// </summary>
+    public void MarkPathDirty()
+    {
+        _pathDirty = true;
+    }
+
+    /// <summary>
+    /// Sets a pre-built base path directly, bypassing the Commands-based path building.
+    /// Used for combined geometries where multiple sub-paths need proper MoveTo calls.
+    /// </summary>
+    /// <param name="path">The pre-built SKPath. Ownership is transferred to this geometry.</param>
+    public void SetBasePath(SKPath path)
+    {
+        _basePath?.Dispose();
+        _basePath = path;
+        _pathDirty = false;
+    }
+
+    /// <summary>
+    /// Draws the land area using a cached base path with GPU canvas matrix transform.
+    /// Zero allocations during zoom/pan — just Save/Concat/DrawPath/Restore.
+    /// </summary>
+    void IDrawnElement<SkiaSharpDrawingContext>.Draw(SkiaSharpDrawingContext context)
+    {
+        if (_basePath is null && Commands.Count == 0) return;
+
+        // Rebuild base path only when geometry data changes (map load, resize)
+        if (_pathDirty || _basePath is null)
+        {
+            _basePath?.Dispose();
+            _basePath = new SKPath();
+
+            var isFirst = true;
+            foreach (var segment in Commands)
+            {
+                if (isFirst)
+                {
+                    _basePath.MoveTo(segment.Xi, segment.Yi);
+                    isFirst = false;
+                }
+                _basePath.LineTo(segment.Xi, segment.Yi);
+            }
+
+            _pathDirty = false;
+        }
+
+        // Apply viewport transform via canvas matrix (GPU) and draw cached path
+        var vt = ViewportTransform;
+        if (vt is not null && vt.IsActive)
+        {
+            var state = context.Canvas.Save();
+            var matrix = vt.GetMatrix();
+            context.Canvas.Concat(ref matrix);
+            context.Canvas.DrawPath(_basePath, context.ActiveSkiaPaint);
+            context.Canvas.RestoreToCount(state);
+        }
+        else
+        {
+            context.Canvas.DrawPath(_basePath, context.ActiveSkiaPaint);
+        }
+    }
+
     /// <inheritdoc cref="VectorGeometry.OnDrawSegment(SkiaSharpDrawingContext, SKPath, Segment)"/>
     protected override void OnDrawSegment(SkiaSharpDrawingContext context, SKPath path, Segment segment) =>
         path.LineTo(segment.Xi, segment.Yi);
@@ -43,10 +176,21 @@ public class LandAreaGeometry : VectorGeometry
     { }
 
     /// <summary>
-    /// Determines whether the specified point is inside this land polygon using SKPath hit-testing.
+    /// Determines whether the specified point is inside this land polygon.
     /// </summary>
     public override bool ContainsPoint(float x, float y)
     {
+        var vt = ViewportTransform;
+        if (vt is not null && vt.IsActive)
+            (x, y) = vt.InverseTransform(x, y);
+
+        if (_basePath is not null && !_pathDirty)
+        {
+            using var closedPath = new SKPath(_basePath);
+            closedPath.Close();
+            return closedPath.Contains(x, y);
+        }
+
         if (Commands.Count == 0) return false;
 
         using var path = new SKPath();
@@ -59,7 +203,6 @@ public class LandAreaGeometry : VectorGeometry
                 path.MoveTo(segment.Xi, segment.Yi);
                 isFirst = false;
             }
-
             path.LineTo(segment.Xi, segment.Yi);
         }
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/Geometries/LandAreaGeometry.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/Geometries/LandAreaGeometry.cs
@@ -41,4 +41,29 @@ public class LandAreaGeometry : VectorGeometry
     /// <inheritdoc cref="VectorGeometry.OnClose(SkiaSharpDrawingContext, SKPath, Segment)"/>
     protected override void OnClose(SkiaSharpDrawingContext context, SKPath path, Segment segment)
     { }
+
+    /// <summary>
+    /// Determines whether the specified point is inside this land polygon using SKPath hit-testing.
+    /// </summary>
+    public override bool ContainsPoint(float x, float y)
+    {
+        if (Commands.Count == 0) return false;
+
+        using var path = new SKPath();
+        var isFirst = true;
+
+        foreach (var segment in Commands)
+        {
+            if (isFirst)
+            {
+                path.MoveTo(segment.Xi, segment.Yi);
+                isFirst = false;
+            }
+
+            path.LineTo(segment.Xi, segment.Yi);
+        }
+
+        path.Close();
+        return path.Contains(x, y);
+    }
 }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/Geometries/LandAreaGeometry.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/Geometries/LandAreaGeometry.cs
@@ -185,11 +185,7 @@ public class LandAreaGeometry : VectorGeometry, IDrawnElement<SkiaSharpDrawingCo
             (x, y) = vt.InverseTransform(x, y);
 
         if (_basePath is not null && !_pathDirty)
-        {
-            using var closedPath = new SKPath(_basePath);
-            closedPath.Close();
-            return closedPath.Contains(x, y);
-        }
+            return _basePath.Contains(x, y);
 
         if (Commands.Count == 0) return false;
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/MapFactory.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/MapFactory.cs
@@ -82,6 +82,8 @@ public class MapFactory : IMapFactory
             {
                 foreach (var landData in landDefinition.Data)
                 {
+                    landData.Land = landDefinition;
+
                     LandAreaGeometry shape;
 
                     if (landData.Shape is null)

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/MapFactory.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/MapFactory.cs
@@ -20,13 +20,12 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using LiveChartsCore.Drawing;
 using LiveChartsCore.Drawing.Segments;
 using LiveChartsCore.Geo;
-using LiveChartsCore.Kernel;
+using LiveChartsCore.Measure;
 using LiveChartsCore.Painting;
 using LiveChartsCore.SkiaSharpView.Drawing.Geometries;
 
@@ -40,12 +39,21 @@ public class MapFactory : IMapFactory
     private readonly HashSet<LandAreaGeometry> _usedPathShapes = [];
     private readonly HashSet<Paint> _usedPaints = [];
     private readonly HashSet<string> _usedLayers = [];
+    private readonly MapViewportTransform _viewportTransform = new();
     private IGeoMapView? _mapView;
 
     /// <inheritdoc cref="IMapFactory.GenerateLands(MapContext)"/>
     public void GenerateLands(MapContext context)
     {
         var projector = context.Projector;
+
+        // Sync viewport transform with current chart state
+        _viewportTransform.Zoom = context.CoreMap.ZoomLevel;
+        _viewportTransform.PanX = context.CoreMap.PanOffset.X;
+        _viewportTransform.PanY = context.CoreMap.PanOffset.Y;
+        _viewportTransform.CenterX = context.View.ControlSize.Width * 0.5f;
+        _viewportTransform.CenterY = context.View.ControlSize.Height * 0.5f;
+
 
         var toRemoveLayers = new HashSet<string>(_usedLayers);
         var toRemovePathShapes = new HashSet<LandAreaGeometry>(_usedPathShapes);
@@ -89,7 +97,6 @@ public class MapFactory : IMapFactory
                     if (landData.Shape is null)
                     {
                         landData.Shape = shape = new LandAreaGeometry();
-                        shape.Animate(EasingFunctions.ExponentialOut, TimeSpan.FromMilliseconds(800));
                     }
                     else
                     {
@@ -98,6 +105,8 @@ public class MapFactory : IMapFactory
 
                     _ = _usedPathShapes.Add(shape);
                     _ = toRemovePathShapes.Remove(shape);
+
+                    shape.ViewportTransform = _viewportTransform;
 
                     stroke?.AddGeometryToPaintTask(context.View.CoreCanvas, shape);
                     fill?.AddGeometryToPaintTask(context.View.CoreCanvas, shape);
@@ -128,6 +137,8 @@ public class MapFactory : IMapFactory
                             Yj = y,
                         });
                     }
+
+                    shape.MarkPathDirty();
                 }
             }
 
@@ -159,7 +170,76 @@ public class MapFactory : IMapFactory
     public void ViewTo(GeoMapChart sender, object? command) { }
 
     /// <inheritdoc cref="IMapFactory.Pan(GeoMapChart, LvcPoint)"/>
-    public void Pan(GeoMapChart sender, LvcPoint delta) { }
+    public void Pan(GeoMapChart sender, LvcPoint delta)
+    {
+        _viewportTransform.PanX += delta.X;
+        _viewportTransform.PanY += delta.Y;
+
+
+        sender.PanOffset = new LvcPoint(_viewportTransform.PanX, _viewportTransform.PanY);
+        sender.View.CoreCanvas.Invalidate();
+    }
+
+    /// <inheritdoc cref="IMapFactory.Zoom(GeoMapChart, LvcPoint, ZoomDirection)"/>
+    public void Zoom(GeoMapChart sender, LvcPoint pivot, ZoomDirection direction)
+    {
+        _viewportTransform.CenterX = sender.View.ControlSize.Width * 0.5f;
+        _viewportTransform.CenterY = sender.View.ControlSize.Height * 0.5f;
+
+        var speed = sender.View.ZoomingSpeed;
+        speed = speed < 0.1 ? 0.1 : (speed > 0.95 ? 0.95 : speed);
+        speed = 1 - speed;
+
+        var oldZoom = _viewportTransform.Zoom;
+        var newZoom = direction == ZoomDirection.ZoomIn
+            ? (float)(oldZoom / speed)
+            : (float)(oldZoom * speed);
+
+        var minZoom = (float)sender.View.MinZoomLevel;
+        var maxZoom = (float)sender.View.MaxZoomLevel;
+
+        // Allow slight overshoot past min for bounce-back feel
+        if (newZoom < minZoom * 0.8f) newZoom = minZoom * 0.8f;
+        if (newZoom > maxZoom) newZoom = maxZoom;
+
+        // Adjust pan so the pivot point stays in place.
+        // screen = base * zoom + (center*(1-zoom) + pan)
+        // Solve: pivotScreen stays same => newPan = oldPan + (pivot - oldPan - center) * (1 - newZoom/oldZoom)
+        // Simpler: pan_new = pivot - (pivot - tx_old) * newZoom / oldZoom  where tx = center*(1-zoom)+pan
+        var cx = _viewportTransform.CenterX;
+        var cy = _viewportTransform.CenterY;
+        var txOld = cx * (1 - oldZoom) + _viewportTransform.PanX;
+        var tyOld = cy * (1 - oldZoom) + _viewportTransform.PanY;
+
+        var txNew = pivot.X - (pivot.X - txOld) * newZoom / oldZoom;
+        var tyNew = pivot.Y - (pivot.Y - tyOld) * newZoom / oldZoom;
+
+        var newPanX = txNew - cx * (1 - newZoom);
+        var newPanY = tyNew - cy * (1 - newZoom);
+
+        _viewportTransform.Zoom = newZoom;
+        _viewportTransform.PanX = newPanX;
+        _viewportTransform.PanY = newPanY;
+
+
+        sender.ZoomLevel = newZoom;
+        sender.PanOffset = new LvcPoint(newPanX, newPanY);
+        sender.View.CoreCanvas.Invalidate();
+    }
+
+    /// <inheritdoc cref="IMapFactory.SetViewport(GeoMapChart, float, LvcPoint)"/>
+    public void SetViewport(GeoMapChart sender, float zoom, LvcPoint panOffset)
+    {
+        _viewportTransform.Zoom = zoom;
+        _viewportTransform.PanX = panOffset.X;
+        _viewportTransform.PanY = panOffset.Y;
+        _viewportTransform.CenterX = sender.View.ControlSize.Width * 0.5f;
+        _viewportTransform.CenterY = sender.View.ControlSize.Height * 0.5f;
+
+        sender.ZoomLevel = zoom;
+        sender.PanOffset = panOffset;
+        sender.View.CoreCanvas.Invalidate();
+    }
 
     /// <summary>
     /// Disposes the map factory.
@@ -185,7 +265,7 @@ public class MapFactory : IMapFactory
                         if (shape is null) continue;
 
                         stroke?.RemoveGeometryFromPaintTask(_mapView.CoreCanvas, shape);
-                        fill?.AddGeometryToPaintTask(_mapView.CoreCanvas, shape);
+                        fill?.RemoveGeometryFromPaintTask(_mapView.CoreCanvas, shape);
 
                         landData.Shape = null;
                     }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/SKCharts/LiveChartsGeneratedCode/SourceGenSKMapChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/SKCharts/LiveChartsGeneratedCode/SourceGenSKMapChart.cs
@@ -55,6 +55,9 @@ public partial class SourceGenSKMapChart : InMemorySkiaSharpChart, IGeoMapView
     /// <inheritdoc cref="IGeoMapView.DesignerMode" />
     bool IGeoMapView.DesignerMode => false;
 
+    /// <inheritdoc cref="IGeoMapView.IsDarkMode" />
+    bool IGeoMapView.IsDarkMode => false;
+
     /// <inheritdoc cref="IDrawnView.CoreCanvas"/>
     LvcSize IDrawnView.ControlSize => new() { Width = Width, Height = Height };
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/SKCharts/SKDefaultGeoTooltip.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/SKCharts/SKDefaultGeoTooltip.cs
@@ -1,0 +1,254 @@
+// The MIT License(MIT)
+//
+// Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
+using System.Globalization;
+using LiveChartsCore.Drawing;
+using LiveChartsCore.Drawing.Layouts;
+using LiveChartsCore.Geo;
+using LiveChartsCore.Kernel;
+using LiveChartsCore.Measure;
+using LiveChartsCore.Motion;
+using LiveChartsCore.Painting;
+using LiveChartsCore.SkiaSharpView.Drawing;
+using LiveChartsCore.SkiaSharpView.Drawing.Geometries;
+using LiveChartsCore.SkiaSharpView.Drawing.Layouts;
+using LiveChartsCore.SkiaSharpView.Painting;
+using LiveChartsCore.SkiaSharpView.Painting.ImageFilters;
+using LiveChartsCore.Themes;
+using SkiaSharp;
+
+namespace LiveChartsCore.SkiaSharpView.SKCharts;
+
+/// <summary>
+/// Defines the default geo map tooltip.
+/// </summary>
+public class SKDefaultGeoTooltip : Container<PopUpGeometry>, IGeoMapTooltip
+{
+    private bool _isInitialized;
+    private bool _isOpen;
+    private object? _themeId;
+    private DrawnTask? _drawnTask;
+    private const int Py = 4;
+    private const int Px = 8;
+
+    /// <summary>
+    /// Gets or sets the easing function.
+    /// </summary>
+    public Func<float, float> Easing { get; set; } = EasingFunctions.EaseOut;
+
+    /// <summary>
+    /// Gets or sets the animation speed.
+    /// </summary>
+    public TimeSpan AnimationsSpeed { get; set; } = TimeSpan.FromMilliseconds(150);
+
+    /// <summary>
+    /// Gets or sets the wedge size.
+    /// </summary>
+    public int Wedge { get; set; } = 10;
+
+    /// <inheritdoc cref="IGeoMapTooltip.Show(GeoTooltipPoint, GeoMapChart)"/>
+    public virtual void Show(GeoTooltipPoint point, GeoMapChart chart)
+    {
+        var theme = chart.GetTheme();
+        var currentThemeId = theme.ThemeId;
+
+        if (!_isInitialized || _themeId != currentThemeId || chart.View.TooltipBackgroundPaint is not null)
+        {
+            Initialize(chart, theme);
+            _isInitialized = true;
+            _themeId = currentThemeId;
+        }
+
+        if (_drawnTask is null || _drawnTask.IsEmpty)
+        {
+            _drawnTask = chart.View.CoreCanvas.AddGeometry(this);
+            _drawnTask.ZIndex = 10100;
+        }
+
+        Opacity = 1;
+        ScaleTransform = new LvcPoint(1, 1);
+        _isOpen = true;
+
+        // Determine placement from view setting, or auto-detect
+        var preferredPlacement = chart.View.TooltipPosition switch
+        {
+            TooltipPosition.Bottom => PopUpPlacement.Bottom,
+            TooltipPosition.Top => PopUpPlacement.Top,
+            _ => PopUpPlacement.Top // Auto: default to top, flip if needed
+        };
+
+        var placement = preferredPlacement;
+        var layout = GetLayout(point, chart, theme, placement);
+        Content = (IDrawnElement<SkiaSharpDrawingContext>)layout;
+        var size = Measure();
+
+        float x, y;
+
+        if (placement == PopUpPlacement.Bottom)
+        {
+            x = point.LandCenter.X - size.Width / 2f;
+            y = point.LandCenter.Y;
+        }
+        else
+        {
+            x = point.LandCenter.X - size.Width / 2f;
+            y = point.LandCenter.Y - size.Height;
+        }
+
+        // Auto-flip if out of bounds (only when not explicitly set)
+        if (chart.View.TooltipPosition is TooltipPosition.Auto or TooltipPosition.Hidden)
+        {
+            if (placement == PopUpPlacement.Top && y < 0)
+            {
+                placement = PopUpPlacement.Bottom;
+                layout = GetLayout(point, chart, theme, placement);
+                Content = (IDrawnElement<SkiaSharpDrawingContext>)layout;
+                size = Measure();
+                y = point.LandCenter.Y;
+            }
+            else if (placement == PopUpPlacement.Bottom && y + size.Height > chart.View.ControlSize.Height)
+            {
+                placement = PopUpPlacement.Top;
+                layout = GetLayout(point, chart, theme, placement);
+                Content = (IDrawnElement<SkiaSharpDrawingContext>)layout;
+                size = Measure();
+                y = point.LandCenter.Y - size.Height;
+            }
+        }
+
+        // Clamp horizontal
+        var controlSize = chart.View.ControlSize;
+        if (x < 0) x = 0;
+        if (x + size.Width > controlSize.Width)
+            x = controlSize.Width - size.Width;
+
+        // Clamp bottom
+        if (y + size.Height > controlSize.Height)
+            y = controlSize.Height - size.Height;
+
+        X = x;
+        Y = y;
+
+        Geometry.Placement = placement;
+        chart.View.CoreCanvas.Invalidate();
+    }
+
+    /// <inheritdoc cref="IGeoMapTooltip.Hide(GeoMapChart)"/>
+    public virtual void Hide(GeoMapChart chart)
+    {
+        if (!_isOpen) return;
+        _isOpen = false;
+
+        Opacity = 0f;
+        ScaleTransform = new LvcPoint(0.85f, 0.85f);
+        chart.View.CoreCanvas.Invalidate();
+    }
+
+    /// <summary>
+    /// Gets the tooltip content layout.
+    /// </summary>
+    protected virtual Layout<SkiaSharpDrawingContext> GetLayout(
+        GeoTooltipPoint point, GeoMapChart chart, Theme theme, PopUpPlacement placement)
+    {
+        var textSize = (float)chart.View.TooltipTextSize;
+        if (textSize <= 0) textSize = theme.TooltipTextSize;
+
+        var fontPaint =
+            chart.View.TooltipTextPaint ??
+            theme.TooltipTextPaint ??
+            new SolidColorPaint(new SKColor(28, 49, 58));
+
+        var lw = (float)LiveCharts.DefaultSettings.MaxTooltipsAndLegendsLabelsWidth;
+
+        // Padding accounts for wedge on the appropriate side
+        var padding = placement == PopUpPlacement.Bottom
+            ? new Padding(Px, Py + Wedge, Px, Py)
+            : new Padding(Px, Py, Px, Py + Wedge);
+
+        var stackLayout = new StackLayout
+        {
+            Orientation = ContainerOrientation.Vertical,
+            HorizontalAlignment = Align.Middle,
+            VerticalAlignment = Align.Middle,
+            Padding = padding
+        };
+
+        // Country name (title-cased since the data stores lowercase names)
+        stackLayout.Children.Add(
+            new LabelGeometry
+            {
+                Text = ToTitleCase(point.Land.Name),
+                Paint = fontPaint,
+                TextSize = textSize,
+                Padding = new Padding(0, 0, 0, 8),
+                MaxWidth = lw,
+                VerticalAlign = Align.Start,
+                HorizontalAlign = Align.Start
+            });
+
+        // Value line
+        if (point.Value != 0)
+        {
+            stackLayout.Children.Add(
+                new LabelGeometry
+                {
+                    Text = point.Value.ToString("N2"),
+                    Paint = fontPaint,
+                    TextSize = textSize,
+                    MaxWidth = lw,
+                    VerticalAlign = Align.Start,
+                    HorizontalAlign = Align.Start
+                });
+        }
+
+        return stackLayout;
+    }
+
+    /// <summary>
+    /// Called to initialize the tooltip.
+    /// </summary>
+    protected virtual void Initialize(GeoMapChart chart, Theme theme)
+    {
+        var backgroundPaint =
+            chart.View.TooltipBackgroundPaint ??
+            theme.TooltipBackgroundPaint ??
+            new SolidColorPaint(new SKColor(235, 235, 235, 230))
+            {
+                ImageFilter = new DropShadow(2, 2, 6, 6, new SKColor(50, 0, 0, 100))
+            };
+
+        Geometry.Fill = backgroundPaint;
+        Geometry.Wedge = Wedge;
+        Geometry.WedgeThickness = 3;
+
+        this.Animate(
+            new Animation(Easing, AnimationsSpeed),
+                OpacityProperty,
+                ScaleTransformProperty,
+                XProperty,
+                YProperty);
+    }
+
+    private static string ToTitleCase(string text) =>
+        CultureInfo.InvariantCulture.TextInfo.ToTitleCase(text);
+}

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/SKCharts/SKDefaultGeoTooltip.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/SKCharts/SKDefaultGeoTooltip.cs
@@ -47,6 +47,8 @@ public class SKDefaultGeoTooltip : Container<PopUpGeometry>, IGeoMapTooltip
     private bool _isInitialized;
     private bool _isOpen;
     private object? _themeId;
+    private Paint? _lastBackgroundPaint;
+    private Paint? _lastTextPaint;
     private DrawnTask? _drawnTask;
     private const int Py = 4;
     private const int Px = 8;
@@ -72,11 +74,17 @@ public class SKDefaultGeoTooltip : Container<PopUpGeometry>, IGeoMapTooltip
         var theme = chart.GetTheme();
         var currentThemeId = theme.ThemeId;
 
-        if (!_isInitialized || _themeId != currentThemeId || chart.View.TooltipBackgroundPaint is not null)
+        var bgPaint = chart.View.TooltipBackgroundPaint;
+        var textPaint = chart.View.TooltipTextPaint;
+
+        if (!_isInitialized || _themeId != currentThemeId ||
+            bgPaint != _lastBackgroundPaint || textPaint != _lastTextPaint)
         {
             Initialize(chart, theme);
             _isInitialized = true;
             _themeId = currentThemeId;
+            _lastBackgroundPaint = bgPaint;
+            _lastTextPaint = textPaint;
         }
 
         if (_drawnTask is null || _drawnTask.IsEmpty)
@@ -207,7 +215,7 @@ public class SKDefaultGeoTooltip : Container<PopUpGeometry>, IGeoMapTooltip
             });
 
         // Value line
-        if (point.Value != 0)
+        if (point.HasValue)
         {
             stackLayout.Children.Add(
                 new LabelGeometry

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Blazor/SourceGenMapChart.blazor.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Blazor/SourceGenMapChart.blazor.cs
@@ -23,10 +23,12 @@
 using LiveChartsCore.Drawing;
 using LiveChartsCore.Geo;
 using LiveChartsCore.Kernel.Sketches;
+using LiveChartsCore.Measure;
 using LiveChartsCore.Motion;
 using LiveChartsCore.SkiaSharpView.Blazor;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.AspNetCore.Components.Web;
 
 namespace LiveChartsGeneratedCode;
 
@@ -67,7 +69,12 @@ public abstract partial class SourceGenMapChart : ComponentBase, IDisposable, IG
     protected override void BuildRenderTree(RenderTreeBuilder builder)
     {
         builder.OpenComponent<MotionCanvas>(0);
-        builder.AddComponentReferenceCapture(1, r => _motionCanvas = (MotionCanvas)r);
+        builder.AddAttribute(1, "OnPointerDownCallback", EventCallback.Factory.Create<PointerEventArgs>(this, OnPointerDown));
+        builder.AddAttribute(2, "OnPointerMoveCallback", EventCallback.Factory.Create<PointerEventArgs>(this, OnPointerMove));
+        builder.AddAttribute(3, "OnPointerUpCallback", EventCallback.Factory.Create<PointerEventArgs>(this, OnPointerUp));
+        builder.AddAttribute(4, "OnPointerOutCallback", EventCallback.Factory.Create<PointerEventArgs>(this, OnPointerOut));
+        builder.AddAttribute(5, "OnWheelCallback", EventCallback.Factory.Create<WheelEventArgs>(this, OnWheel));
+        builder.AddComponentReferenceCapture(7, r => _motionCanvas = (MotionCanvas)r);
         builder.CloseComponent();
     }
 
@@ -90,4 +97,21 @@ public abstract partial class SourceGenMapChart : ComponentBase, IDisposable, IG
 
     void IDisposable.Dispose() =>
         CoreChart.Unload();
+
+    private void OnPointerDown(PointerEventArgs e) =>
+        CoreChart?.InvokePointerDown(new LvcPoint((float)e.OffsetX, (float)e.OffsetY));
+
+    private void OnPointerMove(PointerEventArgs e) =>
+        CoreChart?.InvokePointerMove(new LvcPoint((float)e.OffsetX, (float)e.OffsetY));
+
+    private void OnPointerUp(PointerEventArgs e) =>
+        CoreChart?.InvokePointerUp(new LvcPoint((float)e.OffsetX, (float)e.OffsetY));
+
+    private void OnPointerOut(PointerEventArgs e) =>
+        CoreChart?.InvokePointerLeft();
+
+    private void OnWheel(WheelEventArgs e) =>
+        CoreChart?.InvokePointerWheel(
+            new LvcPoint((float)e.OffsetX, (float)e.OffsetY),
+            e.DeltaY < 0 ? ZoomDirection.ZoomIn : ZoomDirection.ZoomOut);
 }

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Blazor/SourceGenMapChart.blazor.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Blazor/SourceGenMapChart.blazor.cs
@@ -53,6 +53,7 @@ public abstract partial class SourceGenMapChart : ComponentBase, IDisposable, IG
     public CoreMotionCanvas CoreCanvas => _motionCanvas.CanvasCore;
 
     bool IGeoMapView.DesignerMode => false;
+    bool IGeoMapView.IsDarkMode => false;
 
     LvcSize IDrawnView.ControlSize => new()
     {

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Eto/SourceGenMapChart.eto.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Eto/SourceGenMapChart.eto.cs
@@ -58,6 +58,7 @@ public abstract partial class SourceGenMapChart : Panel, IGeoMapView
     public CoreMotionCanvas CoreCanvas => ((MotionCanvas)Content).CanvasCore;
 
     bool IGeoMapView.DesignerMode => false;
+    bool IGeoMapView.IsDarkMode => false;
     LvcSize IDrawnView.ControlSize => new() { Width = Content.Width, Height = Content.Height };
 
     void IGeoMapView.InvokeOnUIThread(Action action) =>

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Eto/SourceGenMapChart.eto.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Eto/SourceGenMapChart.eto.cs
@@ -26,6 +26,7 @@ using Eto.Forms;
 using LiveChartsCore.Drawing;
 using LiveChartsCore.Geo;
 using LiveChartsCore.Kernel.Sketches;
+using LiveChartsCore.Measure;
 using LiveChartsCore.Motion;
 using LiveChartsCore.SkiaSharpView.Eto;
 
@@ -52,6 +53,12 @@ public abstract partial class SourceGenMapChart : Panel, IGeoMapView
 
         Content.SizeChanged += (s, e) =>
             CoreChart.Update();
+
+        Content.MouseWheel += OnMouseWheel;
+        Content.MouseDown += OnMouseDown;
+        Content.MouseMove += OnMouseMove;
+        Content.MouseUp += OnMouseUp;
+        Content.MouseLeave += OnMouseLeave;
     }
 
     /// <inheritdoc cref="IDrawnView.CoreCanvas"/>
@@ -69,5 +76,37 @@ public abstract partial class SourceGenMapChart : Panel, IGeoMapView
     {
         base.OnUnLoad(e);
         CoreChart.Unload();
+    }
+
+    private void OnMouseWheel(object? sender, MouseEventArgs e)
+    {
+        var p = e.Location;
+        CoreChart?.InvokePointerWheel(
+            new LvcPoint(p.X, p.Y),
+            e.Delta.Height > 0 ? ZoomDirection.ZoomIn : ZoomDirection.ZoomOut);
+        e.Handled = true;
+    }
+
+    private void OnMouseDown(object? sender, MouseEventArgs e)
+    {
+        var p = e.Location;
+        CoreChart?.InvokePointerDown(new LvcPoint(p.X, p.Y));
+    }
+
+    private void OnMouseMove(object? sender, MouseEventArgs e)
+    {
+        var p = e.Location;
+        CoreChart?.InvokePointerMove(new LvcPoint(p.X, p.Y));
+    }
+
+    private void OnMouseUp(object? sender, MouseEventArgs e)
+    {
+        var p = e.Location;
+        CoreChart?.InvokePointerUp(new LvcPoint(p.X, p.Y));
+    }
+
+    private void OnMouseLeave(object? sender, MouseEventArgs e)
+    {
+        CoreChart?.InvokePointerLeft();
     }
 }

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/SourceGenMapChart.maui.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/SourceGenMapChart.maui.cs
@@ -24,6 +24,7 @@ using System;
 using LiveChartsCore.Drawing;
 using LiveChartsCore.Geo;
 using LiveChartsCore.Kernel.Sketches;
+using LiveChartsCore.Measure;
 using LiveChartsCore.Motion;
 using LiveChartsCore.SkiaSharpView.Maui;
 using Microsoft.Maui.ApplicationModel;
@@ -66,4 +67,21 @@ public abstract partial class SourceGenMapChart : ChartView, IGeoMapView
 
     void IGeoMapView.InvokeOnUIThread(Action action) =>
         MainThread.BeginInvokeOnMainThread(action);
+
+    internal override void OnPressed(object? sender, Native.Events.PressedEventArgs args) =>
+        CoreChart?.InvokePointerDown(args.Location);
+
+    internal override void OnMoved(object? sender, Native.Events.ScreenEventArgs args) =>
+        CoreChart?.InvokePointerMove(args.Location);
+
+    internal override void OnReleased(object? sender, Native.Events.PressedEventArgs args) =>
+        CoreChart?.InvokePointerUp(args.Location);
+
+    internal override void OnExited(object? sender, Native.Events.EventArgs args) =>
+        CoreChart?.InvokePointerLeft();
+
+    internal override void OnScrolled(object? sender, Native.Events.ScrollEventArgs args) =>
+        CoreChart?.InvokePointerWheel(
+            args.Location,
+            args.ScrollDelta > 0 ? ZoomDirection.ZoomIn : ZoomDirection.ZoomOut);
 }

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/SourceGenMapChart.maui.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/SourceGenMapChart.maui.cs
@@ -58,6 +58,7 @@ public abstract partial class SourceGenMapChart : ChartView, IGeoMapView
     public CoreMotionCanvas CoreCanvas => CanvasView.CanvasCore;
 
     bool IGeoMapView.DesignerMode => false;
+    bool IGeoMapView.IsDarkMode => false;
     LvcSize IDrawnView.ControlSize => new() { Width = (float)Width, Height = (float)Height };
 
     private void OnUnloaded(object? sender, EventArgs e) =>

--- a/src/skiasharp/_Shared.WinUI/SourceGenMapChart.winui.cs
+++ b/src/skiasharp/_Shared.WinUI/SourceGenMapChart.winui.cs
@@ -62,6 +62,7 @@ public abstract partial class SourceGenMapChart : UserControl, IGeoMapView
     public CoreMotionCanvas CoreCanvas => MotionCanvas.CanvasCore;
 
     bool IGeoMapView.DesignerMode => false;
+    bool IGeoMapView.IsDarkMode => false;
     LvcSize IDrawnView.ControlSize => new() { Width = (float)ActualWidth, Height = (float)ActualHeight };
 
     private void OnUnloaded(object sender, RoutedEventArgs e) =>

--- a/src/skiasharp/_Shared.WinUI/SourceGenMapChart.winui.cs
+++ b/src/skiasharp/_Shared.WinUI/SourceGenMapChart.winui.cs
@@ -24,9 +24,11 @@ using System;
 using System.Runtime.InteropServices;
 using LiveChartsCore.Drawing;
 using LiveChartsCore.Kernel.Sketches;
+using LiveChartsCore.Measure;
 using LiveChartsCore.SkiaSharpView.WinUI;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
 using LiveChartsCore.Motion;
 using LiveChartsCore.Geo;
 
@@ -53,6 +55,12 @@ public abstract partial class SourceGenMapChart : UserControl, IGeoMapView
         SizeChanged += (s, e) =>
             CoreChart.Update();
 
+        PointerWheelChanged += OnPointerWheelChanged;
+        PointerPressed += OnPointerPressed;
+        PointerMoved += OnPointerMoved;
+        PointerReleased += OnPointerReleased;
+        PointerExited += OnPointerExited;
+
         Unloaded += OnUnloaded;
     }
 
@@ -78,5 +86,39 @@ public abstract partial class SourceGenMapChart : UserControl, IGeoMapView
 
         _ = DispatcherQueue.TryEnqueue(
             Microsoft.UI.Dispatching.DispatcherQueuePriority.Normal, () => action());
+    }
+
+    private void OnPointerWheelChanged(object sender, PointerRoutedEventArgs e)
+    {
+        var pp = e.GetCurrentPoint(this);
+        var p = pp.Position;
+        var delta = pp.Properties.MouseWheelDelta;
+        CoreChart?.InvokePointerWheel(
+            new LvcPoint((float)p.X, (float)p.Y),
+            delta > 0 ? ZoomDirection.ZoomIn : ZoomDirection.ZoomOut);
+        e.Handled = true;
+    }
+
+    private void OnPointerPressed(object sender, PointerRoutedEventArgs e)
+    {
+        var p = e.GetCurrentPoint(this).Position;
+        CoreChart?.InvokePointerDown(new LvcPoint((float)p.X, (float)p.Y));
+    }
+
+    private void OnPointerMoved(object sender, PointerRoutedEventArgs e)
+    {
+        var p = e.GetCurrentPoint(this).Position;
+        CoreChart?.InvokePointerMove(new LvcPoint((float)p.X, (float)p.Y));
+    }
+
+    private void OnPointerReleased(object sender, PointerRoutedEventArgs e)
+    {
+        var p = e.GetCurrentPoint(this).Position;
+        CoreChart?.InvokePointerUp(new LvcPoint((float)p.X, (float)p.Y));
+    }
+
+    private void OnPointerExited(object sender, PointerRoutedEventArgs e)
+    {
+        CoreChart?.InvokePointerLeft();
     }
 }

--- a/src/skiasharp/_Shared/SourceGenMapChart.sgp.cs
+++ b/src/skiasharp/_Shared/SourceGenMapChart.sgp.cs
@@ -94,6 +94,15 @@ public partial class SourceGenMapChart
     /// <inheritdoc cref="IGeoMapView.TooltipTextSize"/>
     static UIProperty<double>                   tooltipTextSize     = new(defaultValue: 14d);
 
+    /// <inheritdoc cref="IGeoMapView.ZoomingSpeed"/>
+    static UIProperty<double>                   zoomingSpeed        = new(defaultValue: LiveCharts.DefaultSettings.ZoomSpeed);
+
+    /// <inheritdoc cref="IGeoMapView.MinZoomLevel"/>
+    static UIProperty<double>                   minZoomLevel        = new(defaultValue: 1d);
+
+    /// <inheritdoc cref="IGeoMapView.MaxZoomLevel"/>
+    static UIProperty<double>                   maxZoomLevel        = new(defaultValue: 100d);
+
     static void OnSyncContextChanged(SGChart chart, object oldValue, object newValue)
     {
 #if BLAZOR_LVC

--- a/src/skiasharp/_Shared/SourceGenMapChart.sgp.cs
+++ b/src/skiasharp/_Shared/SourceGenMapChart.sgp.cs
@@ -134,6 +134,11 @@ public partial class SourceGenMapChart
             newPaint.PaintStyle = propertyName == nameof(Fill)
                 ? PaintStyle.Fill
                 : PaintStyle.Stroke;
+
+#if BLAZOR_LVC
+            if (chart.CoreChart is null) return;
+#endif
+            chart.CoreChart.Update();
         };
 
     static Paint GetPaint(LvcColor color, PaintStyle style)

--- a/src/skiasharp/_Shared/SourceGenMapChart.sgp.cs
+++ b/src/skiasharp/_Shared/SourceGenMapChart.sgp.cs
@@ -26,6 +26,7 @@
 using LiveChartsCore;
 using LiveChartsCore.Geo;
 using LiveChartsCore.Generators;
+using LiveChartsCore.Measure;
 using System.Windows.Input;
 using System;
 using LiveChartsCore.Painting;
@@ -77,6 +78,21 @@ public partial class SourceGenMapChart
 
     /// <inheritdoc cref="IGeoMapView.Series"/>
     static UIProperty<IEnumerable<IGeoSeries>>  series              = new(onChanged: OnSeriesPropertyChanged);
+
+    /// <inheritdoc cref="IGeoMapView.Tooltip"/>
+    static UIProperty<IGeoMapTooltip>           tooltip;
+
+    /// <inheritdoc cref="IGeoMapView.TooltipPosition"/>
+    static UIProperty<TooltipPosition>          tooltipPosition     = new(defaultValue: TooltipPosition.Auto);
+
+    /// <inheritdoc cref="IGeoMapView.TooltipTextPaint"/>
+    static UIProperty<Paint>                    tooltipTextPaint;
+
+    /// <inheritdoc cref="IGeoMapView.TooltipBackgroundPaint"/>
+    static UIProperty<Paint>                    tooltipBackgroundPaint;
+
+    /// <inheritdoc cref="IGeoMapView.TooltipTextSize"/>
+    static UIProperty<double>                   tooltipTextSize     = new(defaultValue: 14d);
 
     static void OnSyncContextChanged(SGChart chart, object oldValue, object newValue)
     {


### PR DESCRIPTION
## Summary

- **Tooltips**: hover over any country to see its name and heat value, with configurable position and text size
- **Zoom & Pan**: scroll wheel to zoom (GPU-accelerated canvas transforms), click-and-drag to pan, with bounce-back animation to keep the map in view
- **Click events**: `LandClicked` event on `GeoMapChart` fires when a country is clicked (distinguished from drag via 5px threshold)
- **Configurable properties**: `ZoomingSpeed`, `MinZoomLevel`, `MaxZoomLevel` bindable properties; `ResetViewport()` method
- **Performance**: cached `SKPath` per geometry with zero allocations during zoom/pan; explicit `IDrawnElement` reimplementation bypasses per-frame path rebuilding
- **Series clearing fix**: `ClearHeat()` now properly resets `shape.Fill` when series is removed
- **Paint responsiveness**: changing `Stroke` or `Fill` now triggers immediate re-render
- **All 7 platforms**: pointer and scroll handlers added for Avalonia, WPF, WinForms, Blazor, Maui, Eto, WinUI

Fixes #249
Fixes #79
Fixes #1498
Fixes #2000

## Test plan

- [ ] Zoom in/out with scroll wheel — should be smooth, pivot stays under cursor
- [ ] Click and drag to pan — should only start after 5px movement
- [ ] Pan past map edges and release — map bounces back into view
- [ ] Zoom out past 1x and release — bounces back to 1x
- [ ] Click a country — `LandClicked` event fires, sample shows country name
- [ ] Hover countries — tooltip shows name and value
- [ ] Change border width/color via sample controls
- [ ] Clear Series button — heat colors disappear; Restore brings them back
- [ ] Reset Zoom button — returns to default viewport

## Disclaimer
- I have only tested this in AvaloniaSample.Desktop.
- When you zoom or pan quickly, the borders around each country do not render/update fast enough.