### PR TITLE
ci: pin workload manifests via rollback file

### DIFF
--- a/.github/actions/setup-dotnet-and-workloads/action.yml
+++ b/.github/actions/setup-dotnet-and-workloads/action.yml
@@ -17,7 +17,8 @@ runs:
       if: ${{ inputs.workloads != '' }}
       shell: pwsh
       run: |
+        $rollback = "${{ github.workspace }}/.github/workloads/rollback.json"
         $workloads = "${{ inputs.workloads }}".Split(' ')
         foreach ($workload in $workloads) {
-          dotnet workload install $workload
+          dotnet workload install $workload --from-rollback-file $rollback
         }

--- a/.github/workloads/rollback.json
+++ b/.github/workloads/rollback.json
@@ -1,0 +1,18 @@
+{
+  "microsoft.net.sdk.android": "36.1.43/10.0.100",
+  "microsoft.net.sdk.ios": "26.2.10217/10.0.100",
+  "microsoft.net.sdk.maccatalyst": "26.2.10217/10.0.100",
+  "microsoft.net.sdk.macos": "26.2.10217/10.0.100",
+  "microsoft.net.sdk.maui": "10.0.20/10.0.100",
+  "microsoft.net.sdk.tvos": "26.2.10217/10.0.100",
+  "microsoft.net.workload.mono.toolchain.current": "10.0.105/10.0.100",
+  "microsoft.net.workload.emscripten.current": "10.0.105/10.0.100",
+  "microsoft.net.workload.emscripten.net6": "10.0.105/10.0.100",
+  "microsoft.net.workload.emscripten.net7": "10.0.105/10.0.100",
+  "microsoft.net.workload.emscripten.net8": "10.0.105/10.0.100",
+  "microsoft.net.workload.emscripten.net9": "10.0.105/10.0.100",
+  "microsoft.net.workload.mono.toolchain.net6": "10.0.105/10.0.100",
+  "microsoft.net.workload.mono.toolchain.net7": "10.0.105/10.0.100",
+  "microsoft.net.workload.mono.toolchain.net8": "10.0.105/10.0.100",
+  "microsoft.net.workload.mono.toolchain.net9": "10.0.105/10.0.100"
+}


### PR DESCRIPTION
## Summary
- Pins .NET workload manifests (maui, ios, maccatalyst, etc.) via `.github/workloads/rollback.json` so CI is no longer broken the moment Microsoft publishes a new manifest that raises the required Xcode version.
- `setup-dotnet-and-workloads` now installs workloads with `--from-rollback-file` instead of always pulling the latest advertising manifest.
- Current pin uses `26.2.10217` for ios/maccatalyst/macos — the last set that works with the runner's Xcode 26.2. Bump intentionally when switching to a newer Xcode.

## Test plan
- [ ] CI run on this PR completes the `pack`, `test-mac`, and `test-ios` jobs without the `requires Xcode 26.3` error
- [ ] `maui-skiasharp` pack job logs show maccatalyst manifest resolving to `26.2.10217/10.0.100`

🤖 Generated with [Claude Code](https://claude.com/claude-code)