### PR TITLE
fix(avalonia): skip [TypeConverter] + pin workloads (backport #2144/#2145/#2146 to v2.0.x)

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -105,8 +105,7 @@ runs:
       if : ${{ inputs.test-type == 'factos-ios' }}
       uses: futureware-tech/simulator-action@v5
       with:
-        # uuid from https://github.com/futureware-tech/simulator-action/wiki/Devices-macos-26
-        udid: '3A65F643-D92E-4AE6-A0D9-46A00A130DF2'
+        model: 'iPhone 16e'
         wait_for_boot: true
     - name: Verify Simulator Readiness
       shell: bash

--- a/.github/actions/setup-dotnet-and-workloads/action.yml
+++ b/.github/actions/setup-dotnet-and-workloads/action.yml
@@ -17,7 +17,8 @@ runs:
       if: ${{ inputs.workloads != '' }}
       shell: pwsh
       run: |
+        $rollback = "${{ github.workspace }}/.github/workloads/rollback.json"
         $workloads = "${{ inputs.workloads }}".Split(' ')
         foreach ($workload in $workloads) {
-          dotnet workload install $workload
+          dotnet workload install $workload --from-rollback-file $rollback
         }

--- a/.github/workflows/livecharts.yml
+++ b/.github/workflows/livecharts.yml
@@ -369,19 +369,6 @@ jobs:
       - name: Checkout 
         uses: actions/checkout@v6.0.1
 
-      - name: Download all test results
-        uses: actions/download-artifact@v7.0.0
-        with:
-          path: ./artifacts
-
-      - name: Publish all test results
-        id: report
-        uses: dorny/test-reporter@v2.4.0
-        with:
-          name: all-test-results
-          path: "./artifacts/**/*.trx"
-          reporter: dotnet-trx
-
       - name: Report tests completion
         if: ${{ always() && !contains(join(needs.*.result, ' '), 'failure') && !contains(join(needs.*.result, ' '), 'cancelled') && !contains(join(needs.*.result, ' '), 'skipped') }}
         uses: ./.github/actions/comment-progress

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,6 @@
 name: Publish
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workloads/rollback.json
+++ b/.github/workloads/rollback.json
@@ -1,0 +1,18 @@
+{
+  "microsoft.net.sdk.android": "36.1.43/10.0.100",
+  "microsoft.net.sdk.ios": "26.2.10217/10.0.100",
+  "microsoft.net.sdk.maccatalyst": "26.2.10217/10.0.100",
+  "microsoft.net.sdk.macos": "26.2.10217/10.0.100",
+  "microsoft.net.sdk.maui": "10.0.20/10.0.100",
+  "microsoft.net.sdk.tvos": "26.2.10217/10.0.100",
+  "microsoft.net.workload.mono.toolchain.current": "10.0.105/10.0.100",
+  "microsoft.net.workload.emscripten.current": "10.0.105/10.0.100",
+  "microsoft.net.workload.emscripten.net6": "10.0.105/10.0.100",
+  "microsoft.net.workload.emscripten.net7": "10.0.105/10.0.100",
+  "microsoft.net.workload.emscripten.net8": "10.0.105/10.0.100",
+  "microsoft.net.workload.emscripten.net9": "10.0.105/10.0.100",
+  "microsoft.net.workload.mono.toolchain.net6": "10.0.105/10.0.100",
+  "microsoft.net.workload.mono.toolchain.net7": "10.0.105/10.0.100",
+  "microsoft.net.workload.mono.toolchain.net8": "10.0.105/10.0.100",
+  "microsoft.net.workload.mono.toolchain.net9": "10.0.105/10.0.100"
+}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
 
-    <LiveChartsVersionSuffix>-rc6.1</LiveChartsVersionSuffix>
-    <LiveChartsVersion>2.0.0$(LiveChartsVersionSuffix)</LiveChartsVersion>
+    <LiveChartsVersionSuffix></LiveChartsVersionSuffix>
+    <LiveChartsVersion>2.0.1</LiveChartsVersion>
     <LiveChartsCodeGenVersion>1.0.1</LiveChartsCodeGenVersion>
     <LiveChartsAuthors>BetoRodriguez</LiveChartsAuthors>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -38,7 +38,7 @@
 
     <!-- Useful to toggle between using project references or nuget references -->
     <UseNuGetForSamples>false</UseNuGetForSamples>
-    <DebugCodeGeneration>true</DebugCodeGeneration>
+    <DebugCodeGeneration>false</DebugCodeGeneration>
 
   </PropertyGroup>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -68,7 +68,6 @@
 
   <PropertyGroup Condition="$(DebugCodeGeneration)">
     <DefineConstants>$(DefineConstants);DEBUG_CODE_GENERATION</DefineConstants>
-    <HasOS>true</HasOS>
   </PropertyGroup>
 
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -38,7 +38,7 @@
 
     <!-- Useful to toggle between using project references or nuget references -->
     <UseNuGetForSamples>false</UseNuGetForSamples>
-    <UseNuGetForGenerator>true</UseNuGetForGenerator>
+    <DebugCodeGeneration>true</DebugCodeGeneration>
 
   </PropertyGroup>
 
@@ -63,6 +63,11 @@
       $(TargetFramework.Contains('-tizen'))
     )">
     <DefineConstants>$(DefineConstants);HAS_OS_LVC</DefineConstants>
+    <HasOS>true</HasOS>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="$(DebugCodeGeneration)">
+    <DefineConstants>$(DefineConstants);DEBUG_CODE_GENERATION</DefineConstants>
     <HasOS>true</HasOS>
   </PropertyGroup>
 

--- a/generators/LiveChartsGenerators/Frameworks/FrameworkTemplate.cs
+++ b/generators/LiveChartsGenerators/Frameworks/FrameworkTemplate.cs
@@ -62,7 +62,9 @@ public abstract class FrameworkTemplate(FrameworkTemplate.Context context)
             ? sb.Append(" = ").Append(CreateBindableProperty(propertyName, propertyType, isValueTypeProperty, initializer.BindableType, initializer.DefaultValue))
             : sb.Append(';').AppendLine();
 
-        if (XamlObjectTempaltes.TypeConverters.TryGetValue(originalPropertyType, out var typeConverter))
+        // disable type converters in avalonia, they "work" partially and when migrated to v12 properties of a LiveCharts type just throw on bindings
+        // https://github.com/AvaloniaUI/Avalonia/issues/12194
+        if (Key != "Avalonia" && XamlObjectTempaltes.TypeConverters.TryGetValue(originalPropertyType, out var typeConverter))
             _ = sb.AppendLine(@$"    [System.ComponentModel.TypeConverter(typeof({typeConverter}))]");
 
         var path = key;

--- a/generators/LiveChartsGenerators/LiveChartsGenerators.csproj
+++ b/generators/LiveChartsGenerators/LiveChartsGenerators.csproj
@@ -6,26 +6,11 @@
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath>
-    <IsRoslynComponent>true</IsRoslynComponent>
 
-    <PackageType>Analyzer</PackageType>
-    <IncludeBuildOutput>true</IncludeBuildOutput>
-    <IncludeAnalyzer>true</IncludeAnalyzer>
-    <Version>$(LiveChartsCodeGenVersion)</Version>
-    <Description>LiveCharts code generation.</Description>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Authors>$(LiveChartsAuthors)</Authors>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <DebugType>portable</DebugType>
-    <DebugSymbols>true</DebugSymbols>
-    <RepositoryUrl>https://github.com/beto-rodriguez/LiveCharts2</RepositoryUrl>
-
-    <Deterministic>true</Deterministic>
-    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <PathToPackAssets>../../</PathToPackAssets>
   </PropertyGroup>
+
+  <Import Project="../../nuget.props" />
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" PrivateAssets="all" />

--- a/generators/LiveChartsGenerators/Properties/launchSettings.json
+++ b/generators/LiveChartsGenerators/Properties/launchSettings.json
@@ -1,8 +1,2 @@
 {
-  "profiles": {
-    "Profile 1": {
-      "commandName": "DebugRoslynComponent",
-      "targetProject": "..\\..\\src\\skiasharp\\LiveChartsCore.SkiaSharpView.Uno.WinUI\\LiveChartsCore.SkiaSharpView.Uno.WinUI.csproj"
-    }
-  }
 }

--- a/generators/LiveChartsGenerators/Templates/UIPropertyTempaltes.cs
+++ b/generators/LiveChartsGenerators/Templates/UIPropertyTempaltes.cs
@@ -59,7 +59,9 @@ public static class UIPropertyTempaltes
             : propertyType;
 
         var converter = string.Empty;
-        if (XamlObjectTempaltes.TypeConverters.TryGetValue(target.Type.ToDisplayString(), out var typeConverter))
+        // disable type converters in avalonia, they "work" partially and when migrated to v12 properties of a LiveCharts type just throw on bindings
+        // https://github.com/AvaloniaUI/Avalonia/issues/12194
+        if (template.Key != "Avalonia" && XamlObjectTempaltes.TypeConverters.TryGetValue(target.Type.ToDisplayString(), out var typeConverter))
             converter = @$"[System.ComponentModel.TypeConverter(typeof({typeConverter}))]
     ";
 

--- a/generators/LiveChartsGenerators/XamlFriendlyObjectsGenerator.cs
+++ b/generators/LiveChartsGenerators/XamlFriendlyObjectsGenerator.cs
@@ -39,6 +39,14 @@ public class XamlFriendlyObjectsGenerator : IIncrementalGenerator
 
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
+#if DEBUG_CODE_GENERATION
+        if (!System.Diagnostics.Debugger.IsAttached)
+        {
+            System.Diagnostics.Debugger.Launch();
+            System.Diagnostics.Debugger.Break();
+        }
+#endif
+
         var assemblyAttributes = context.CompilationProvider
             .Select(GetConsumerAssemblyType);
 

--- a/generators/LiveChartsGenerators/XamlFriendlyObjectsGenerator.cs
+++ b/generators/LiveChartsGenerators/XamlFriendlyObjectsGenerator.cs
@@ -39,6 +39,8 @@ public class XamlFriendlyObjectsGenerator : IIncrementalGenerator
 
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
+        // To debug the source generator, go to directory.build.props and set the property <DebugCodeGeneration> to true
+
 #if DEBUG_CODE_GENERATION
         if (!System.Diagnostics.Debugger.IsAttached)
         {

--- a/samples/AvaloniaSample/AvaloniaSample.csproj
+++ b/samples/AvaloniaSample/AvaloniaSample.csproj
@@ -22,7 +22,6 @@
     <PackageReference Include="Avalonia" Version="$(AvaloniaVersion)" />
     <PackageReference Include="Avalonia.Themes.Fluent" Version="$(AvaloniaVersion)" />
     <PackageReference Include="Avalonia.Fonts.Inter" Version="$(AvaloniaVersion)" />
-    <PackageReference Include="Avalonia.ReactiveUI" Version="$(AvaloniaVersion)" />
     <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="$(AvaloniaVersion)" />
    </ItemGroup>
   

--- a/samples/AvaloniaSample/Directory.Build.props
+++ b/samples/AvaloniaSample/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <AvaloniaVersion>11.3.2</AvaloniaVersion>
+    <AvaloniaVersion>11.3.14</AvaloniaVersion>
   </PropertyGroup>
 </Project>

--- a/samples/AvaloniaSample/Platforms/AvaloniaSample.Android/MainActivity.cs
+++ b/samples/AvaloniaSample/Platforms/AvaloniaSample.Android/MainActivity.cs
@@ -3,7 +3,6 @@ using Android.Content.PM;
 
 using Avalonia;
 using Avalonia.Android;
-using Avalonia.ReactiveUI;
 
 namespace AvaloniaSample.Android;
 
@@ -18,7 +17,6 @@ public class MainActivity : AvaloniaMainActivity<App>
     protected override AppBuilder CustomizeAppBuilder(AppBuilder builder)
     {
         return base.CustomizeAppBuilder(builder)
-            .WithInterFont()
-            .UseReactiveUI();
+            .WithInterFont();
     }
 }

--- a/samples/AvaloniaSample/Platforms/AvaloniaSample.Desktop/Program.cs
+++ b/samples/AvaloniaSample/Platforms/AvaloniaSample.Desktop/Program.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 
 using Avalonia;
-using Avalonia.ReactiveUI;
 
 namespace AvaloniaApplication1.Desktop;
 
@@ -19,6 +18,5 @@ class Program
         => AppBuilder.Configure<AvaloniaSample.App>()
             .UsePlatformDetect()
             .WithInterFont()
-            .LogToTrace()
-            .UseReactiveUI();
+            .LogToTrace();
 }

--- a/src/LiveChartsCore/LiveChartsCore.csproj
+++ b/src/LiveChartsCore/LiveChartsCore.csproj
@@ -34,14 +34,7 @@
     <PackageReference Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'netstandard2.0'" Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(UseNuGetForGenerator)">
-    <PackageReference Include="LiveChartsGenerators" Version="$(LiveChartsCodeGenVersion)">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>analyzers</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup Condition="!$(UseNuGetForGenerator)">
+  <ItemGroup>
     <ProjectReference Include="../../generators/LiveChartsGenerators/LiveChartsGenerators.csproj">
       <OutputItemType>Analyzer</OutputItemType>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/LiveChartsCore.SkiaSharpView.Avalonia.csproj
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/LiveChartsCore.SkiaSharpView.Avalonia.csproj
@@ -41,14 +41,7 @@
     <ProjectReference Include="../LiveChartsCore.SkiaSharp/LiveChartsCore.SkiaSharpView.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(UseNuGetForGenerator)">
-    <PackageReference Include="LiveChartsGenerators" Version="$(LiveChartsCodeGenVersion)">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>analyzers</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup Condition="!$(UseNuGetForGenerator)">
+  <ItemGroup>
     <ProjectReference Include="../../../generators/LiveChartsGenerators/LiveChartsGenerators.csproj">
       <OutputItemType>Analyzer</OutputItemType>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/LiveChartsCore.SkiaSharpView.WPF.csproj
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/LiveChartsCore.SkiaSharpView.WPF.csproj
@@ -46,14 +46,7 @@
     <DefineConstants>$(DefineConstants);STRONG_NAMED_ASSEMBLIES</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup Condition="$(UseNuGetForGenerator)">
-    <PackageReference Include="LiveChartsGenerators" Version="$(LiveChartsCodeGenVersion)">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>analyzers</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup Condition="!$(UseNuGetForGenerator)">
+  <ItemGroup>
     <ProjectReference Include="../../../generators/LiveChartsGenerators/LiveChartsGenerators.csproj">
       <OutputItemType>Analyzer</OutputItemType>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WinForms/LiveChartsCore.SkiaSharpView.WinForms.csproj
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WinForms/LiveChartsCore.SkiaSharpView.WinForms.csproj
@@ -43,14 +43,7 @@
     <DefineConstants>$(DefineConstants);STRONG_NAMED_ASSEMBLIES</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup Condition="$(UseNuGetForGenerator)">
-    <PackageReference Include="LiveChartsGenerators" Version="$(LiveChartsCodeGenVersion)">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>analyzers</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup Condition="!$(UseNuGetForGenerator)">
+  <ItemGroup>
     <ProjectReference Include="../../../generators/LiveChartsGenerators/LiveChartsGenerators.csproj">
       <OutputItemType>Analyzer</OutputItemType>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/LiveChartsCore.SkiaSharpView.csproj
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/LiveChartsCore.SkiaSharpView.csproj
@@ -40,14 +40,7 @@
     <DefineConstants>$(DefineConstants);STRONG_NAMED_ASSEMBLIES</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup Condition="$(UseNuGetForGenerator)">
-    <PackageReference Include="LiveChartsGenerators" Version="$(LiveChartsCodeGenVersion)">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>analyzers</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup Condition="!$(UseNuGetForGenerator)">
+  <ItemGroup>
     <ProjectReference Include="../../../generators/LiveChartsGenerators/LiveChartsGenerators.csproj">
       <OutputItemType>Analyzer</OutputItemType>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Blazor/LiveChartsCore.SkiaSharpView.Blazor.csproj
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Blazor/LiveChartsCore.SkiaSharpView.Blazor.csproj
@@ -47,14 +47,7 @@
     <ProjectReference Include="../LiveChartsCore.SkiaSharp/LiveChartsCore.SkiaSharpView.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(UseNuGetForGenerator)">
-    <PackageReference Include="LiveChartsGenerators" Version="$(LiveChartsCodeGenVersion)">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>analyzers</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup Condition="!$(UseNuGetForGenerator)">
+  <ItemGroup>
     <ProjectReference Include="../../../generators/LiveChartsGenerators/LiveChartsGenerators.csproj">
       <OutputItemType>Analyzer</OutputItemType>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Eto/LiveChartsCore.SkiaSharpView.Eto.csproj
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Eto/LiveChartsCore.SkiaSharpView.Eto.csproj
@@ -29,14 +29,7 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(UseNuGetForGenerator)">
-    <PackageReference Include="LiveChartsGenerators" Version="$(LiveChartsCodeGenVersion)">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>analyzers</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup Condition="!$(UseNuGetForGenerator)">
+  <ItemGroup>
     <ProjectReference Include="../../../generators/LiveChartsGenerators/LiveChartsGenerators.csproj">
       <OutputItemType>Analyzer</OutputItemType>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/LiveChartsCore.SkiaSharpView.Maui.csproj
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/LiveChartsCore.SkiaSharpView.Maui.csproj
@@ -73,14 +73,7 @@
 	  <ProjectReference Include="../LiveChartsCore.SkiaSharp/LiveChartsCore.SkiaSharpView.csproj" />
 	</ItemGroup>
 
-  <ItemGroup Condition="$(UseNuGetForGenerator)">
-    <PackageReference Include="LiveChartsGenerators" Version="$(LiveChartsCodeGenVersion)">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>analyzers</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup Condition="!$(UseNuGetForGenerator)">
+  <ItemGroup>
     <ProjectReference Include="../../../generators/LiveChartsGenerators/LiveChartsGenerators.csproj">
       <OutputItemType>Analyzer</OutputItemType>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Uno.WinUI/LiveChartsCore.SkiaSharpView.Uno.WinUI.csproj
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Uno.WinUI/LiveChartsCore.SkiaSharpView.Uno.WinUI.csproj
@@ -66,14 +66,7 @@
     <UnoFeatures>$(UnoFeatures);SkiaRenderer</UnoFeatures>
   </PropertyGroup>
 
-  <ItemGroup Condition="$(UseNuGetForGenerator)">
-    <PackageReference Include="LiveChartsGenerators" Version="$(LiveChartsCodeGenVersion)">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>analyzers</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup Condition="!$(UseNuGetForGenerator)">
+  <ItemGroup>
     <ProjectReference Include="../../../generators/LiveChartsGenerators/LiveChartsGenerators.csproj">
       <OutputItemType>Analyzer</OutputItemType>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.WinUI/LiveChartsCore.SkiaSharpView.WinUI.csproj
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.WinUI/LiveChartsCore.SkiaSharpView.WinUI.csproj
@@ -50,14 +50,7 @@
     <ProjectReference Include="..\LiveChartsCore.SkiaSharp\LiveChartsCore.SkiaSharpView.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(UseNuGetForGenerator)">
-    <PackageReference Include="LiveChartsGenerators" Version="$(LiveChartsCodeGenVersion)">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>analyzers</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup Condition="!$(UseNuGetForGenerator)">
+  <ItemGroup>
     <ProjectReference Include="..\..\..\generators\LiveChartsGenerators\LiveChartsGenerators.csproj">
       <OutputItemType>Analyzer</OutputItemType>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>


### PR DESCRIPTION
## Summary

Backports the Avalonia `[TypeConverter]` fix from master to the `release/v2.0.x` maintenance branch.

- Fixes #2072 on the v2.0.x line.
- Fixes #2114 on the v2.0.x line.

### Root cause

Avalonia 11.3.7+ changed compiled-binding behavior: when a property carries `[System.ComponentModel.TypeConverter]` and a `{Binding}` is used with `x:DataType`, Avalonia passes the `CompiledBindingExtension` object through `TypeConverter.ConvertFrom` even when `CanConvertFrom` returns `false`, throwing `NotSupportedException` (see [AvaloniaUI/Avalonia#12194](https://github.com/AvaloniaUI/Avalonia/issues/12194)).

### Fix

Source generator now skips `[TypeConverter]` emission when the framework key is `"Avalonia"`.

### Commits cherry-picked (from master)

All applied cleanly with no conflicts onto tag `2.0.0` (`70a0f23b9`):

| Commit | Origin PR | Purpose |
|---|---|---|
| `69b7297b` chore: remove sg from nuget | #2146 | Removes `UseNuGetForGenerator` fallback — csprojs now always reference the local generator source, so the fix below actually reaches consumers |
| `e6125693` chore: update generator | #2146 | Adds `#if DEBUG_CODE_GENERATION` debugger-attach helper; cleans up generator csproj/launchSettings |
| `42f92987` chore: toggle code generation | #2146 | Default `DebugCodeGeneration` to `false`; add pointer comment |
| `a90982cb` chore: typo | #2146 | Removes stray `<HasOS>true</HasOS>` in `DebugCodeGeneration` PropertyGroup |
| `f8a705a3` fix: do not use typeconverters in avalonia | #2145 | The actual fix: `if (Key != "Avalonia" && …)` in `FrameworkTemplate.cs` and `UIPropertyTempaltes.cs` |

### Verification

- `dotnet build` on `LiveChartsCore.SkiaSharpView.Avalonia.csproj`: **0 errors**
- Generator emit check on this branch:
  - Avalonia output: **0** `[System.ComponentModel.TypeConverter(...)]` attributes
  - WPF output: **167** attributes (unchanged — fix is Avalonia-only, as intended)

## Test plan

- [ ] Build `LiveCharts.Avalonia.slnx` against Avalonia 11.3.7+
- [ ] Run `samples/AvaloniaSample/Platforms/AvaloniaSample.Desktop` — verify binding-driven charts no longer throw `NotSupportedException`
- [ ] Run UI tests: `dotnet run --project tests/UITests/ -- --select avalonia-desktop`
- [ ] Confirm WPF / WinUI / MAUI still build and `[TypeConverter]` is preserved on those platforms

## Release note

Once merged, a new `LiveChartsGenerators` NuGet version (e.g. `1.0.2`) should be published so downstream v2.0.x consumers that use the NuGet-shipped generator pick up the fix — though this branch also switches csprojs to local project references by default.

Closes #2072