### PR TITLE
fix: derive DPI scale from surface size for correct RDP and per-monitor rendering

### DIFF
--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/Rendering/CPURenderMode.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/Rendering/CPURenderMode.cs
@@ -55,23 +55,18 @@ internal class CPURenderMode : SKElement, IRenderMode
 
     private void OnPaintSurface(object? sender, SKPaintSurfaceEventArgs args)
     {
-        var density = GetPixelDensity();
-        if (density.dpix != 1 || density.dpiy != 1)
-            args.Surface.Canvas.Scale(density.dpix, density.dpiy);
+        // Derive scale from actual surface vs logical size so that RDP and per-monitor
+        // DPI changes are always reflected correctly, regardless of what system APIs report.
+        if (ActualWidth > 0 && ActualHeight > 0)
+        {
+            var scaleX = args.Info.Width / (float)ActualWidth;
+            var scaleY = args.Info.Height / (float)ActualHeight;
+            if (scaleX != 1f || scaleY != 1f)
+                args.Surface.Canvas.Scale(scaleX, scaleY);
+        }
 
         FrameRequest?.Invoke(
             new SkiaSharpDrawingContext(_canvas, args.Surface.Canvas, GetBackground()));
-    }
-
-    private ResolutionHelper GetPixelDensity()
-    {
-        var presentationSource = PresentationSource.FromVisual(this);
-        if (presentationSource is null) return new(1f, 1f);
-        var compositionTarget = presentationSource.CompositionTarget;
-        if (compositionTarget is null) return new(1f, 1f);
-
-        var matrix = compositionTarget.TransformToDevice;
-        return new((float)matrix.M11, (float)matrix.M22);
     }
 
     private SKColor GetBackground() =>

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/Rendering/GPURenderMode.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/Rendering/GPURenderMode.cs
@@ -56,23 +56,18 @@ internal class GPURenderMode : SKGLElement, IRenderMode
 
     private void OnPaintSurface(object? sender, SKPaintGLSurfaceEventArgs args)
     {
-        var density = GetPixelDensity();
-        if (density.dpix != 1 || density.dpiy != 1)
-            args.Surface.Canvas.Scale(density.dpix, density.dpiy);
+        // Derive scale from actual surface vs logical size so that RDP and per-monitor
+        // DPI changes are always reflected correctly, regardless of what system APIs report.
+        if (ActualWidth > 0 && ActualHeight > 0)
+        {
+            var scaleX = args.BackendRenderTarget.Width / (float)ActualWidth;
+            var scaleY = args.BackendRenderTarget.Height / (float)ActualHeight;
+            if (scaleX != 1f || scaleY != 1f)
+                args.Surface.Canvas.Scale(scaleX, scaleY);
+        }
 
         FrameRequest?.Invoke(
             new SkiaSharpDrawingContext(_canvas, args.Surface.Canvas, GetBackground()));
-    }
-
-    private ResolutionHelper GetPixelDensity()
-    {
-        var presentationSource = PresentationSource.FromVisual(this);
-        if (presentationSource is null) return new(1f, 1f);
-        var compositionTarget = presentationSource.CompositionTarget;
-        if (compositionTarget is null) return new(1f, 1f);
-
-        var matrix = compositionTarget.TransformToDevice;
-        return new((float)matrix.M11, (float)matrix.M22);
     }
 
     private SKColor GetBackground() =>

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/Rendering/CPURenderMode.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/Rendering/CPURenderMode.cs
@@ -20,11 +20,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System;
 using LiveChartsCore.Kernel.Sketches;
 using LiveChartsCore.Motion;
 using LiveChartsCore.SkiaSharpView.Drawing;
-using Microsoft.Maui.Devices;
 using SkiaSharp;
 using SkiaSharp.Views.Maui;
 using SkiaSharp.Views.Maui.Controls;
@@ -34,7 +32,6 @@ namespace LiveChartsCore.SkiaSharpView.Maui.Rendering;
 internal class CPURenderMode : SKCanvasView, IRenderMode
 {
     private CoreMotionCanvas _canvas = null!;
-    private float _pixelDensity = 1;
 
     public event CoreMotionCanvas.FrameRequestHandler? FrameRequest;
 
@@ -43,9 +40,6 @@ internal class CPURenderMode : SKCanvasView, IRenderMode
         _canvas = canvas;
         PaintSurface += OnPaintSurface;
 
-        _pixelDensity = (float)DeviceDisplay.MainDisplayInfo.Density;
-        DeviceDisplay.MainDisplayInfoChanged += MainDisplayInfoChanged;
-
         CoreMotionCanvas.s_rendererName = $"{nameof(CPURenderMode)} and {nameof(SKCanvasView)}";
     }
 
@@ -53,7 +47,6 @@ internal class CPURenderMode : SKCanvasView, IRenderMode
     {
         _canvas = null!;
         PaintSurface -= OnPaintSurface;
-        DeviceDisplay.MainDisplayInfoChanged -= MainDisplayInfoChanged;
     }
 
     public void InvalidateRenderer() =>
@@ -61,15 +54,19 @@ internal class CPURenderMode : SKCanvasView, IRenderMode
 
     private void OnPaintSurface(object? sender, SKPaintSurfaceEventArgs args)
     {
-        if (_pixelDensity != 1)
-            args.Surface.Canvas.Scale(_pixelDensity, _pixelDensity);
+        // Derive scale from actual surface vs logical size so that per-display DPI
+        // changes are always reflected correctly, regardless of what system APIs report.
+        if (Width > 0 && Height > 0)
+        {
+            var scaleX = args.Info.Width / (float)Width;
+            var scaleY = args.Info.Height / (float)Height;
+            if (scaleX != 1f || scaleY != 1f)
+                args.Surface.Canvas.Scale(scaleX, scaleY);
+        }
 
         FrameRequest?.Invoke(
             new SkiaSharpDrawingContext(_canvas, args.Surface.Canvas, GetBackground()));
     }
-
-    private void MainDisplayInfoChanged(object? sender, EventArgs e) =>
-        _pixelDensity = (float)DeviceDisplay.MainDisplayInfo.Density;
 
     private SKColor GetBackground() =>
         (Parent?.Parent as IChartView)?.BackColor.AsSKColor() ?? SKColor.Empty;

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/Rendering/GPURenderMode.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/Rendering/GPURenderMode.cs
@@ -20,11 +20,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System;
 using LiveChartsCore.Kernel.Sketches;
 using LiveChartsCore.Motion;
 using LiveChartsCore.SkiaSharpView.Drawing;
-using Microsoft.Maui.Devices;
 using SkiaSharp;
 using SkiaSharp.Views.Maui;
 using SkiaSharp.Views.Maui.Controls;
@@ -34,7 +32,6 @@ namespace LiveChartsCore.SkiaSharpView.Maui.Rendering;
 internal class GPURenderMode : SKGLView, IRenderMode
 {
     private CoreMotionCanvas _canvas = null!;
-    private float _pixelDensity = 1;
 
     public event CoreMotionCanvas.FrameRequestHandler? FrameRequest;
 
@@ -43,9 +40,6 @@ internal class GPURenderMode : SKGLView, IRenderMode
         _canvas = canvas;
         PaintSurface += OnPaintSurface;
 
-        _pixelDensity = (float)DeviceDisplay.MainDisplayInfo.Density;
-        DeviceDisplay.MainDisplayInfoChanged += MainDisplayInfoChanged;
-
         CoreMotionCanvas.s_rendererName = $"{nameof(GPURenderMode)} and {nameof(SKGLView)}";
     }
 
@@ -53,7 +47,6 @@ internal class GPURenderMode : SKGLView, IRenderMode
     {
         _canvas = null!;
         PaintSurface -= OnPaintSurface;
-        DeviceDisplay.MainDisplayInfoChanged -= MainDisplayInfoChanged;
     }
 
     public void InvalidateRenderer() =>
@@ -61,15 +54,19 @@ internal class GPURenderMode : SKGLView, IRenderMode
 
     private void OnPaintSurface(object? sender, SKPaintGLSurfaceEventArgs e)
     {
-        if (_pixelDensity != 1)
-            e.Surface.Canvas.Scale(_pixelDensity, _pixelDensity);
+        // Derive scale from actual surface vs logical size so that per-display DPI
+        // changes are always reflected correctly, regardless of what system APIs report.
+        if (Width > 0 && Height > 0)
+        {
+            var scaleX = e.BackendRenderTarget.Width / (float)Width;
+            var scaleY = e.BackendRenderTarget.Height / (float)Height;
+            if (scaleX != 1f || scaleY != 1f)
+                e.Surface.Canvas.Scale(scaleX, scaleY);
+        }
 
         FrameRequest?.Invoke(
             new SkiaSharpDrawingContext(_canvas, e.Surface.Canvas, GetBackground()));
     }
-
-    private void MainDisplayInfoChanged(object? sender, EventArgs e) =>
-        _pixelDensity = (float)DeviceDisplay.MainDisplayInfo.Density;
 
     private SKColor GetBackground() =>
         (Parent?.Parent as IChartView)?.BackColor.AsSKColor() ?? SKColor.Empty;

--- a/src/skiasharp/_Shared.WinUI/Rendering/CPURenderMode.cs
+++ b/src/skiasharp/_Shared.WinUI/Rendering/CPURenderMode.cs
@@ -51,9 +51,15 @@ internal partial class CPURenderMode : SKXamlCanvas, IRenderMode
 
     private void OnPaintSurface(object? sender, SKPaintSurfaceEventArgs e)
     {
-        var density = GetPixelDensity();
-        if (density.DpiX != 1 || density.DpiY != 1)
-            e.Surface.Canvas.Scale(density.DpiX, density.DpiY);
+        // Derive scale from actual surface vs logical size so that RDP and per-monitor
+        // DPI changes are always reflected correctly, regardless of what system APIs report.
+        if (ActualWidth > 0 && ActualHeight > 0)
+        {
+            var scaleX = e.Info.Width / (float)ActualWidth;
+            var scaleY = e.Info.Height / (float)ActualHeight;
+            if (scaleX != 1f || scaleY != 1f)
+                e.Surface.Canvas.Scale(scaleX, scaleY);
+        }
 
         FrameRequest?.Invoke(new SkiaSharpDrawingContext(
             _canvas, e.Surface.Canvas, GetBackground()));
@@ -61,23 +67,6 @@ internal partial class CPURenderMode : SKXamlCanvas, IRenderMode
 
     public void InvalidateRenderer() =>
         Invalidate();
-
-    private PixelDensity GetPixelDensity()
-    {
-#if HAS_UNO_WINUI
-        var d = Windows.Graphics.Display.DisplayInformation.GetForCurrentView().LogicalDpi / 96.0f;
-        return new(d, d);
-#else
-        var scaleFactor = (float)XamlRoot.RasterizationScale;
-        return new(scaleFactor, scaleFactor);
-#endif
-    }
-
-    private readonly struct PixelDensity(float dpiX, float dpiY)
-    {
-        public float DpiX { get; } = dpiX;
-        public float DpiY { get; } = dpiY;
-    }
 
     private SKColor GetBackground() =>
         ((Parent as FrameworkElement)?.Parent as IChartView)?.BackColor.AsSKColor() ?? SKColor.Empty;

--- a/src/skiasharp/_Shared.WinUI/Rendering/GPURenderMode.cs
+++ b/src/skiasharp/_Shared.WinUI/Rendering/GPURenderMode.cs
@@ -51,9 +51,15 @@ internal partial class GPURenderMode : SKSwapChainPanel, IRenderMode
 
     private void OnPaintSurface(object? sender, SKPaintGLSurfaceEventArgs e)
     {
-        var density = GetPixelDensity();
-        if (density.DpiX != 1 || density.DpiY != 1)
-            e.Surface.Canvas.Scale(density.DpiX, density.DpiY);
+        // Derive scale from actual surface vs logical size so that RDP and per-monitor
+        // DPI changes are always reflected correctly, regardless of what system APIs report.
+        if (ActualWidth > 0 && ActualHeight > 0)
+        {
+            var scaleX = e.BackendRenderTarget.Width / (float)ActualWidth;
+            var scaleY = e.BackendRenderTarget.Height / (float)ActualHeight;
+            if (scaleX != 1f || scaleY != 1f)
+                e.Surface.Canvas.Scale(scaleX, scaleY);
+        }
 
         FrameRequest?.Invoke(new SkiaSharpDrawingContext(
             _canvas, e.Surface.Canvas, GetBackground()));
@@ -61,23 +67,6 @@ internal partial class GPURenderMode : SKSwapChainPanel, IRenderMode
 
     public void InvalidateRenderer() =>
         Invalidate();
-
-    private PixelDensity GetPixelDensity()
-    {
-#if HAS_UNO_WINUI
-        var d = Windows.Graphics.Display.DisplayInformation.GetForCurrentView().LogicalDpi / 96.0f;
-        return new(d, d);
-#else
-        var scaleFactor = (float)XamlRoot.RasterizationScale;
-        return new(scaleFactor, scaleFactor);
-#endif
-    }
-
-    private readonly struct PixelDensity(float dpiX, float dpiY)
-    {
-        public float DpiX { get; } = dpiX;
-        public float DpiY { get; } = dpiY;
-    }
 
     private SKColor GetBackground() =>
         ((Parent as FrameworkElement)?.Parent as IChartView)?.BackColor.AsSKColor() ?? SKColor.Empty;


### PR DESCRIPTION
Fixes incorrect chart rendering when using Remote Desktop (RDP) or when moving between monitors with different DPI settings.

Previously, DPI was read from system metadata APIs that can return stale or incorrect values in RDP sessions. The fix computes the scale factor directly from the ratio of the rendering surface's physical pixel dimensions to the control's logical size on every frame.

Fixed frameworks: WPF (CPU+GPU), MAUI (CPU+GPU), WinUI/UNO (CPU+GPU).

Closes #2137

Generated with [Claude Code](https://claude.ai/code)