### PR TITLE
perf: add BenchmarkDotNet project and PR comparison workflow

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,89 @@
+name: Benchmarks
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+on:
+  pull_request:
+    paths:
+      - 'src/LiveChartsCore/**'
+      - 'src/skiasharp/LiveChartsCore.SkiaSharp/**'
+      - 'tests/Benchmarks/**'
+      - '.github/workflows/benchmarks.yml'
+
+jobs:
+  benchmarks:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Checkout PR HEAD
+        uses: actions/checkout@v6.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: ./.github/actions/setup-dotnet-and-workloads
+
+      - name: Run benchmarks on PR HEAD
+        run: |
+          dotnet run -c Release --project tests/Benchmarks/Benchmarks.csproj -- \
+            --filter '*' --artifacts bench-head
+          mkdir -p bench-head-results
+          cp -r bench-head/results/. bench-head-results/
+
+      - name: Checkout base ref into a worktree and run there
+        id: base-run
+        continue-on-error: true
+        run: |
+          git worktree add -d .base-tree "origin/${{ github.base_ref }}"
+          if [ ! -f .base-tree/tests/Benchmarks/Benchmarks.csproj ]; then
+            echo "Base ref has no benchmarks project — skipping baseline."
+            echo "has_base=false" >> "$GITHUB_OUTPUT"
+            mkdir -p bench-base-results
+            exit 0
+          fi
+          (cd .base-tree && dotnet run -c Release --project tests/Benchmarks/Benchmarks.csproj -- \
+            --filter '*' --artifacts ../bench-base)
+          mkdir -p bench-base-results
+          cp -r bench-base/results/. bench-base-results/
+          echo "has_base=true" >> "$GITHUB_OUTPUT"
+
+      - name: Compare results
+        run: |
+          dotnet run -c Release --project tests/Benchmarks/Benchmarks.csproj --no-build -- \
+            compare bench-base-results bench-head-results delta.md
+          echo "--- delta.md ---"
+          cat delta.md
+
+      - name: Load delta into env
+        run: |
+          {
+            echo 'DELTA_TABLE<<BENCHEOF'
+            cat delta.md
+            echo 'BENCHEOF'
+          } >> "$GITHUB_ENV"
+
+      - name: Post benchmark delta on PR
+        uses: ./.github/actions/comment-progress
+        with:
+          marker: perf-${{ github.event.pull_request.number }}
+          content: |
+            #### Benchmark delta
+
+            Base: `${{ github.base_ref }}` — Head: `${{ github.event.pull_request.head.sha }}`
+            Thresholds: 🔴 > +10% slower, 🟢 > -10% faster. Numbers on GitHub-hosted runners are noisy — treat double-digit deltas on non-trivial benchmarks as signal, single-digit as noise.
+
+            ${{ env.DELTA_TABLE }}
+
+      - name: Upload raw artifacts
+        if: always()
+        uses: actions/upload-artifact@v6.0.0
+        with:
+          name: benchmark-results
+          path: |
+            bench-head/
+            bench-base/
+            delta.md
+          retention-days: 30

--- a/src/LiveChartsCore/AssemblyInfo.cs
+++ b/src/LiveChartsCore/AssemblyInfo.cs
@@ -35,6 +35,7 @@ using System.Reflection;
 
 [assembly: InternalsVisibleTo("CoreTests")]
 [assembly: InternalsVisibleTo("SnapshotTests")]
+[assembly: InternalsVisibleTo("Benchmarks")]
 [assembly: InternalsVisibleTo("LiveChartsCore.SkiaSharpView")]
 [assembly: InternalsVisibleTo("LiveChartsCore.Behaviours")]
 [assembly: InternalsVisibleTo("LiveChartsCore.BackersPackage")]

--- a/tests/Benchmarks/.gitignore
+++ b/tests/Benchmarks/.gitignore
@@ -1,0 +1,5 @@
+bin/
+obj/
+BenchmarkDotNet.Artifacts/
+bench-head/
+bench-base/

--- a/tests/Benchmarks/BenchHarness.cs
+++ b/tests/Benchmarks/BenchHarness.cs
@@ -1,0 +1,19 @@
+using LiveChartsCore.SkiaSharpView.SKCharts;
+using SkiaSharp;
+
+namespace Benchmarks;
+
+// Shared surface-allocation + draw helper so each per-series bench file only has to say
+// *what* to render, not how.
+internal static class BenchHarness
+{
+    public const int Width = 1000;
+    public const int Height = 600;
+
+    public static void Render(InMemorySkiaSharpChart chart)
+    {
+        using var surface = SKSurface.Create(new SKImageInfo(chart.Width, chart.Height))
+            ?? throw new InvalidOperationException("Could not allocate SKSurface");
+        chart.DrawOnCanvas(surface.Canvas);
+    }
+}

--- a/tests/Benchmarks/Benchmarks.csproj
+++ b/tests/Benchmarks/Benchmarks.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+    <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\skiasharp\LiveChartsCore.SkiaSharp\LiveChartsCore.SkiaSharpView.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Benchmarks/BoxSeriesBench.cs
+++ b/tests/Benchmarks/BoxSeriesBench.cs
@@ -1,0 +1,50 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Exporters.Json;
+using BenchmarkDotNet.Jobs;
+using LiveChartsCore.Defaults;
+using LiveChartsCore.SkiaSharpView;
+using LiveChartsCore.SkiaSharpView.SKCharts;
+
+namespace Benchmarks;
+
+[MemoryDiagnoser]
+[JsonExporterAttribute.Full]
+[SimpleJob(RuntimeMoniker.Net80, warmupCount: 3, iterationCount: 8)]
+public class BoxSeriesBench
+{
+    private const int PointCount = 1_000;
+
+    private BoxValue[] _values = null!;
+    private SKCartesianChart _chart = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _values = new BoxValue[PointCount];
+        for (var i = 0; i < PointCount; i++)
+        {
+            var m = Math.Sin(i * 0.05) * 50 + 50;
+            // max, Q3, Q1, min, median
+            _values[i] = new BoxValue(m + 20, m + 10, m - 10, m - 20, m);
+        }
+
+        _chart = new SKCartesianChart
+        {
+            Width = BenchHarness.Width,
+            Height = BenchHarness.Height,
+            Series = [new BoxSeries<BoxValue> { Values = _values }]
+        };
+        BenchHarness.Render(_chart);
+    }
+
+    [Benchmark]
+    public void Reinvalidate() => BenchHarness.Render(_chart);
+
+    [Benchmark]
+    public void UpdateOnePoint()
+    {
+        var idx = PointCount / 2;
+        _values[idx].Median += 0.1;
+        BenchHarness.Render(_chart);
+    }
+}

--- a/tests/Benchmarks/CandlesticksSeriesBench.cs
+++ b/tests/Benchmarks/CandlesticksSeriesBench.cs
@@ -1,0 +1,50 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Exporters.Json;
+using BenchmarkDotNet.Jobs;
+using LiveChartsCore.Defaults;
+using LiveChartsCore.SkiaSharpView;
+using LiveChartsCore.SkiaSharpView.SKCharts;
+
+namespace Benchmarks;
+
+[MemoryDiagnoser]
+[JsonExporterAttribute.Full]
+[SimpleJob(RuntimeMoniker.Net80, warmupCount: 3, iterationCount: 8)]
+public class CandlesticksSeriesBench
+{
+    private const int PointCount = 1_000;
+
+    private FinancialPointI[] _values = null!;
+    private SKCartesianChart _chart = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _values = new FinancialPointI[PointCount];
+        for (var i = 0; i < PointCount; i++)
+        {
+            var m = Math.Sin(i * 0.05) * 50 + 50;
+            // high, open, close, low
+            _values[i] = new FinancialPointI(m + 10, m + 2, m - 2, m - 10);
+        }
+
+        _chart = new SKCartesianChart
+        {
+            Width = BenchHarness.Width,
+            Height = BenchHarness.Height,
+            Series = [new CandlesticksSeries<FinancialPointI> { Values = _values }]
+        };
+        BenchHarness.Render(_chart);
+    }
+
+    [Benchmark]
+    public void Reinvalidate() => BenchHarness.Render(_chart);
+
+    [Benchmark]
+    public void UpdateOnePoint()
+    {
+        var idx = PointCount / 2;
+        _values[idx].Close += 0.1;
+        BenchHarness.Render(_chart);
+    }
+}

--- a/tests/Benchmarks/ColumnSeriesBench.cs
+++ b/tests/Benchmarks/ColumnSeriesBench.cs
@@ -1,0 +1,45 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Exporters.Json;
+using BenchmarkDotNet.Jobs;
+using LiveChartsCore.Defaults;
+using LiveChartsCore.SkiaSharpView;
+using LiveChartsCore.SkiaSharpView.SKCharts;
+
+namespace Benchmarks;
+
+[MemoryDiagnoser]
+[JsonExporterAttribute.Full]
+[SimpleJob(RuntimeMoniker.Net80, warmupCount: 3, iterationCount: 8)]
+public class ColumnSeriesBench
+{
+    private const int PointCount = 1_000;
+
+    private ObservableValue[] _values = null!;
+    private SKCartesianChart _chart = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _values = new ObservableValue[PointCount];
+        for (var i = 0; i < PointCount; i++)
+            _values[i] = new ObservableValue(Math.Sin(i * 0.05) * 50 + 50);
+
+        _chart = new SKCartesianChart
+        {
+            Width = BenchHarness.Width,
+            Height = BenchHarness.Height,
+            Series = [new ColumnSeries<ObservableValue> { Values = _values }]
+        };
+        BenchHarness.Render(_chart);
+    }
+
+    [Benchmark]
+    public void Reinvalidate() => BenchHarness.Render(_chart);
+
+    [Benchmark]
+    public void UpdateOnePoint()
+    {
+        _values[PointCount / 2].Value = _values[PointCount / 2].Value + 0.1;
+        BenchHarness.Render(_chart);
+    }
+}

--- a/tests/Benchmarks/HeatSeriesBench.cs
+++ b/tests/Benchmarks/HeatSeriesBench.cs
@@ -1,0 +1,50 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Exporters.Json;
+using BenchmarkDotNet.Jobs;
+using LiveChartsCore.Defaults;
+using LiveChartsCore.SkiaSharpView;
+using LiveChartsCore.SkiaSharpView.SKCharts;
+
+namespace Benchmarks;
+
+[MemoryDiagnoser]
+[JsonExporterAttribute.Full]
+[SimpleJob(RuntimeMoniker.Net80, warmupCount: 3, iterationCount: 8)]
+public class HeatSeriesBench
+{
+    // Heat maps are typically denser per point; a 32x32 grid is 1024, roughly matching
+    // the other series' PointCount.
+    private const int Side = 32;
+
+    private WeightedPoint[] _values = null!;
+    private SKCartesianChart _chart = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _values = new WeightedPoint[Side * Side];
+        var k = 0;
+        for (var x = 0; x < Side; x++)
+            for (var y = 0; y < Side; y++)
+                _values[k++] = new WeightedPoint(x, y, Math.Sin(x * 0.2) * Math.Cos(y * 0.2) + 1.5);
+
+        _chart = new SKCartesianChart
+        {
+            Width = BenchHarness.Width,
+            Height = BenchHarness.Height,
+            Series = [new HeatSeries<WeightedPoint> { Values = _values }]
+        };
+        BenchHarness.Render(_chart);
+    }
+
+    [Benchmark]
+    public void Reinvalidate() => BenchHarness.Render(_chart);
+
+    [Benchmark]
+    public void UpdateOnePoint()
+    {
+        var idx = _values.Length / 2;
+        _values[idx].Weight = (_values[idx].Weight ?? 0) + 0.1;
+        BenchHarness.Render(_chart);
+    }
+}

--- a/tests/Benchmarks/LineSeriesBench.cs
+++ b/tests/Benchmarks/LineSeriesBench.cs
@@ -4,7 +4,6 @@ using BenchmarkDotNet.Jobs;
 using LiveChartsCore.Defaults;
 using LiveChartsCore.SkiaSharpView;
 using LiveChartsCore.SkiaSharpView.SKCharts;
-using SkiaSharp;
 
 namespace Benchmarks;
 
@@ -13,14 +12,10 @@ namespace Benchmarks;
 [SimpleJob(RuntimeMoniker.Net80, warmupCount: 3, iterationCount: 8)]
 public class LineSeriesBench
 {
-    private const int Width = 1000;
-    private const int Height = 600;
-
     [Params(1_000, 10_000)]
     public int PointCount;
 
     private ObservableValue[] _values = null!;
-    private LineSeries<ObservableValue> _series = null!;
     private SKCartesianChart _chart = null!;
 
     // A chart pre-measured once, so Update/Gap benchmarks isolate the incremental cost
@@ -35,12 +30,11 @@ public class LineSeriesBench
         for (var i = 0; i < PointCount; i++)
             _values[i] = new ObservableValue(Math.Sin(i * 0.05) * 50 + 50);
 
-        _series = new LineSeries<ObservableValue> { Values = _values };
         _chart = new SKCartesianChart
         {
-            Width = Width,
-            Height = Height,
-            Series = [_series]
+            Width = BenchHarness.Width,
+            Height = BenchHarness.Height,
+            Series = [new LineSeries<ObservableValue> { Values = _values }]
         };
 
         _primedValues = new ObservableValue[PointCount];
@@ -49,11 +43,11 @@ public class LineSeriesBench
 
         _primedChart = new SKCartesianChart
         {
-            Width = Width,
-            Height = Height,
+            Width = BenchHarness.Width,
+            Height = BenchHarness.Height,
             Series = [new LineSeries<ObservableValue> { Values = _primedValues }]
         };
-        _ = Render(_primedChart);
+        BenchHarness.Render(_primedChart);
     }
 
     // Cold-path cost: first draw from a fresh chart.
@@ -62,26 +56,23 @@ public class LineSeriesBench
     {
         var chart = new SKCartesianChart
         {
-            Width = Width,
-            Height = Height,
+            Width = BenchHarness.Width,
+            Height = BenchHarness.Height,
             Series = [new LineSeries<ObservableValue> { Values = _values }]
         };
-        _ = Render(chart);
+        BenchHarness.Render(chart);
     }
 
     // Warm-path cost: re-invalidate an unchanged, already-measured chart.
     [Benchmark]
-    public void Reinvalidate()
-    {
-        _ = Render(_chart);
-    }
+    public void Reinvalidate() => BenchHarness.Render(_chart);
 
     // Incremental update: one point's value changes, trigger re-invalidate.
     [Benchmark]
     public void UpdateOnePoint()
     {
         _primedValues[PointCount / 2].Value = _primedValues[PointCount / 2].Value + 0.1;
-        _ = Render(_primedChart);
+        BenchHarness.Render(_primedChart);
     }
 
     // #2132 shape: toggle a middle point between null and a value, which changes the
@@ -91,14 +82,6 @@ public class LineSeriesBench
     {
         var idx = PointCount / 2;
         _primedValues[idx].Value = _primedValues[idx].Value is null ? 42.0 : null;
-        _ = Render(_primedChart);
-    }
-
-    private static SKImage Render(SKCartesianChart chart)
-    {
-        using var surface = SKSurface.Create(new SKImageInfo(chart.Width, chart.Height))
-            ?? throw new InvalidOperationException("Could not allocate SKSurface");
-        chart.DrawOnCanvas(surface.Canvas);
-        return surface.Snapshot();
+        BenchHarness.Render(_primedChart);
     }
 }

--- a/tests/Benchmarks/LineSeriesBench.cs
+++ b/tests/Benchmarks/LineSeriesBench.cs
@@ -1,0 +1,104 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Exporters.Json;
+using BenchmarkDotNet.Jobs;
+using LiveChartsCore.Defaults;
+using LiveChartsCore.SkiaSharpView;
+using LiveChartsCore.SkiaSharpView.SKCharts;
+using SkiaSharp;
+
+namespace Benchmarks;
+
+[MemoryDiagnoser]
+[JsonExporterAttribute.Full]
+[SimpleJob(RuntimeMoniker.Net80, warmupCount: 3, iterationCount: 8)]
+public class LineSeriesBench
+{
+    private const int Width = 1000;
+    private const int Height = 600;
+
+    [Params(1_000, 10_000)]
+    public int PointCount;
+
+    private ObservableValue[] _values = null!;
+    private LineSeries<ObservableValue> _series = null!;
+    private SKCartesianChart _chart = null!;
+
+    // A chart pre-measured once, so Update/Gap benchmarks isolate the incremental cost
+    // rather than first-draw setup.
+    private SKCartesianChart _primedChart = null!;
+    private ObservableValue[] _primedValues = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _values = new ObservableValue[PointCount];
+        for (var i = 0; i < PointCount; i++)
+            _values[i] = new ObservableValue(Math.Sin(i * 0.05) * 50 + 50);
+
+        _series = new LineSeries<ObservableValue> { Values = _values };
+        _chart = new SKCartesianChart
+        {
+            Width = Width,
+            Height = Height,
+            Series = [_series]
+        };
+
+        _primedValues = new ObservableValue[PointCount];
+        for (var i = 0; i < PointCount; i++)
+            _primedValues[i] = new ObservableValue(Math.Sin(i * 0.05) * 50 + 50);
+
+        _primedChart = new SKCartesianChart
+        {
+            Width = Width,
+            Height = Height,
+            Series = [new LineSeries<ObservableValue> { Values = _primedValues }]
+        };
+        _ = Render(_primedChart);
+    }
+
+    // Cold-path cost: first draw from a fresh chart.
+    [Benchmark]
+    public void FirstRender()
+    {
+        var chart = new SKCartesianChart
+        {
+            Width = Width,
+            Height = Height,
+            Series = [new LineSeries<ObservableValue> { Values = _values }]
+        };
+        _ = Render(chart);
+    }
+
+    // Warm-path cost: re-invalidate an unchanged, already-measured chart.
+    [Benchmark]
+    public void Reinvalidate()
+    {
+        _ = Render(_chart);
+    }
+
+    // Incremental update: one point's value changes, trigger re-invalidate.
+    [Benchmark]
+    public void UpdateOnePoint()
+    {
+        _primedValues[PointCount / 2].Value = _primedValues[PointCount / 2].Value + 0.1;
+        _ = Render(_primedChart);
+    }
+
+    // #2132 shape: toggle a middle point between null and a value, which changes the
+    // sub-segment layout each call and stresses VectorManager's node reconciliation.
+    [Benchmark]
+    public void ToggleNullGap()
+    {
+        var idx = PointCount / 2;
+        _primedValues[idx].Value = _primedValues[idx].Value is null ? 42.0 : null;
+        _ = Render(_primedChart);
+    }
+
+    private static SKImage Render(SKCartesianChart chart)
+    {
+        using var surface = SKSurface.Create(new SKImageInfo(chart.Width, chart.Height))
+            ?? throw new InvalidOperationException("Could not allocate SKSurface");
+        chart.DrawOnCanvas(surface.Canvas);
+        return surface.Snapshot();
+    }
+}

--- a/tests/Benchmarks/PieSeriesBench.cs
+++ b/tests/Benchmarks/PieSeriesBench.cs
@@ -1,0 +1,52 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Exporters.Json;
+using BenchmarkDotNet.Jobs;
+using LiveChartsCore.Defaults;
+using LiveChartsCore.SkiaSharpView;
+using LiveChartsCore.SkiaSharpView.SKCharts;
+
+namespace Benchmarks;
+
+[MemoryDiagnoser]
+[JsonExporterAttribute.Full]
+[SimpleJob(RuntimeMoniker.Net80, warmupCount: 3, iterationCount: 8)]
+public class PieSeriesBench
+{
+    // Pies rarely have thousands of slices — 20 is a realistic upper bound for
+    // catching regressions in slice layout cost without inflating test runtime.
+    private const int SliceCount = 20;
+
+    private PieSeries<ObservableValue>[] _series = null!;
+    private ObservableValue[] _values = null!;
+    private SKPieChart _chart = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _values = new ObservableValue[SliceCount];
+        _series = new PieSeries<ObservableValue>[SliceCount];
+        for (var i = 0; i < SliceCount; i++)
+        {
+            _values[i] = new ObservableValue(1 + i);
+            _series[i] = new PieSeries<ObservableValue> { Values = new[] { _values[i] } };
+        }
+
+        _chart = new SKPieChart
+        {
+            Width = BenchHarness.Width,
+            Height = BenchHarness.Height,
+            Series = _series
+        };
+        BenchHarness.Render(_chart);
+    }
+
+    [Benchmark]
+    public void Reinvalidate() => BenchHarness.Render(_chart);
+
+    [Benchmark]
+    public void UpdateOnePoint()
+    {
+        _values[SliceCount / 2].Value = _values[SliceCount / 2].Value + 0.1;
+        BenchHarness.Render(_chart);
+    }
+}

--- a/tests/Benchmarks/PolarLineSeriesBench.cs
+++ b/tests/Benchmarks/PolarLineSeriesBench.cs
@@ -1,0 +1,45 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Exporters.Json;
+using BenchmarkDotNet.Jobs;
+using LiveChartsCore.Defaults;
+using LiveChartsCore.SkiaSharpView;
+using LiveChartsCore.SkiaSharpView.SKCharts;
+
+namespace Benchmarks;
+
+[MemoryDiagnoser]
+[JsonExporterAttribute.Full]
+[SimpleJob(RuntimeMoniker.Net80, warmupCount: 3, iterationCount: 8)]
+public class PolarLineSeriesBench
+{
+    private const int PointCount = 1_000;
+
+    private ObservableValue[] _values = null!;
+    private SKPolarChart _chart = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _values = new ObservableValue[PointCount];
+        for (var i = 0; i < PointCount; i++)
+            _values[i] = new ObservableValue(Math.Sin(i * 0.05) * 50 + 50);
+
+        _chart = new SKPolarChart
+        {
+            Width = BenchHarness.Width,
+            Height = BenchHarness.Height,
+            Series = [new PolarLineSeries<ObservableValue> { Values = _values }]
+        };
+        BenchHarness.Render(_chart);
+    }
+
+    [Benchmark]
+    public void Reinvalidate() => BenchHarness.Render(_chart);
+
+    [Benchmark]
+    public void UpdateOnePoint()
+    {
+        _values[PointCount / 2].Value = _values[PointCount / 2].Value + 0.1;
+        BenchHarness.Render(_chart);
+    }
+}

--- a/tests/Benchmarks/Program.cs
+++ b/tests/Benchmarks/Program.cs
@@ -1,0 +1,25 @@
+using BenchmarkDotNet.Running;
+using LiveChartsCore;
+using LiveChartsCore.Motion;
+using LiveChartsCore.SkiaSharpView;
+
+namespace Benchmarks;
+
+public static class Program
+{
+    public static int Main(string[] args)
+    {
+        // `compare <baseJsonDir> <headJsonDir> [outMarkdown]` reads BenchmarkDotNet
+        // `-report-full.json` exports from two runs and emits a markdown delta table.
+        if (args.Length > 0 && args[0] == "compare")
+            return ResultsCompare.Run(args.AsSpan(1));
+
+        // Configure LiveCharts once, and disable animations so we measure only the
+        // invalidate/draw cost — not time spent waiting for motion to settle.
+        LiveCharts.Configure(config => config.UseDefaults());
+        CoreMotionCanvas.IsTesting = true;
+
+        _ = BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+        return 0;
+    }
+}

--- a/tests/Benchmarks/ResultsCompare.cs
+++ b/tests/Benchmarks/ResultsCompare.cs
@@ -1,0 +1,122 @@
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+
+namespace Benchmarks;
+
+// Reads BenchmarkDotNet `*-report-full.json` exports from a base run and a head run,
+// matches benchmarks by (method, params), computes a % delta on the mean, and emits
+// a markdown table.
+internal static class ResultsCompare
+{
+    // Deltas beyond +/- Threshold are flagged. Tuned loose for noisy shared CI runners.
+    private const double Threshold = 0.10;
+
+    public static int Run(ReadOnlySpan<string> args)
+    {
+        if (args.Length < 2)
+        {
+            Console.Error.WriteLine("usage: compare <baseDir> <headDir> [outMarkdown]");
+            return 64;
+        }
+
+        var baseResults = LoadAll(args[0]);
+        var headResults = LoadAll(args[1]);
+        var outPath = args.Length >= 3 ? args[2] : null;
+
+        var rows = new List<Row>();
+        foreach (var (key, head) in headResults)
+        {
+            baseResults.TryGetValue(key, out var @base);
+            rows.Add(new Row(key, @base, head));
+        }
+        // Also list benchmarks that disappeared
+        foreach (var (key, @base) in baseResults)
+            if (!headResults.ContainsKey(key))
+                rows.Add(new Row(key, @base, null));
+
+        rows.Sort((a, b) => string.CompareOrdinal(a.Key, b.Key));
+
+        var md = RenderMarkdown(rows);
+        if (outPath is not null)
+            File.WriteAllText(outPath, md);
+        else
+            Console.Write(md);
+
+        // Return 0 — we report but don't fail the build on regressions. Callers can wrap
+        // this in a gating step later once the signal is trusted.
+        return 0;
+    }
+
+    private static Dictionary<string, BenchmarkStats> LoadAll(string dir)
+    {
+        var result = new Dictionary<string, BenchmarkStats>(StringComparer.Ordinal);
+        foreach (var file in Directory.EnumerateFiles(dir, "*-report-full.json", SearchOption.AllDirectories))
+        {
+            using var stream = File.OpenRead(file);
+            using var doc = JsonDocument.Parse(stream);
+            if (!doc.RootElement.TryGetProperty("Benchmarks", out var benchmarks)) continue;
+
+            foreach (var b in benchmarks.EnumerateArray())
+            {
+                var fullName = b.GetProperty("FullName").GetString() ?? "";
+                var stats = b.GetProperty("Statistics");
+                var mean = stats.GetProperty("Mean").GetDouble();
+                var stdErr = stats.GetProperty("StandardError").GetDouble();
+                double? allocated = null;
+                if (b.TryGetProperty("Memory", out var mem)
+                    && mem.TryGetProperty("BytesAllocatedPerOperation", out var alloc))
+                {
+                    allocated = alloc.GetDouble();
+                }
+                result[fullName] = new BenchmarkStats(mean, stdErr, allocated);
+            }
+        }
+        return result;
+    }
+
+    private static string RenderMarkdown(List<Row> rows)
+    {
+        var sb = new StringBuilder();
+        _ = sb.AppendLine("| Benchmark | Base (ms) | Head (ms) | Δ | Alloc base | Alloc head |");
+        _ = sb.AppendLine("|---|---:|---:|---:|---:|---:|");
+        foreach (var row in rows)
+        {
+            var @base = row.Base;
+            var head = row.Head;
+            var baseMs = @base is null ? "—" : FormatMs(@base.MeanNs);
+            var headMs = head is null ? "—" : FormatMs(head.MeanNs);
+            var delta = DeltaCell(@base, head);
+            var baseAlloc = @base?.Allocated is null ? "—" : FormatBytes(@base.Allocated.Value);
+            var headAlloc = head?.Allocated is null ? "—" : FormatBytes(head.Allocated.Value);
+            _ = sb.AppendLine(CultureInfo.InvariantCulture, $"| `{Short(row.Key)}` | {baseMs} | {headMs} | {delta} | {baseAlloc} | {headAlloc} |");
+        }
+        return sb.ToString();
+    }
+
+    private static string DeltaCell(BenchmarkStats? @base, BenchmarkStats? head)
+    {
+        if (@base is null || head is null) return "—";
+        var pct = (head.MeanNs - @base.MeanNs) / @base.MeanNs;
+        var str = (pct * 100).ToString("+0.0;-0.0;0.0", CultureInfo.InvariantCulture) + "%";
+        if (pct > Threshold) return "🔴 " + str;
+        if (pct < -Threshold) return "🟢 " + str;
+        return str;
+    }
+
+    private static string FormatMs(double ns) => (ns / 1_000_000.0).ToString("N3", CultureInfo.InvariantCulture);
+
+    private static string FormatBytes(double bytes)
+    {
+        if (bytes < 1024) return $"{bytes:N0} B";
+        if (bytes < 1024 * 1024) return $"{bytes / 1024:N1} KB";
+        return $"{bytes / (1024.0 * 1024):N1} MB";
+    }
+
+    // Drop the `Benchmarks.` namespace prefix to keep table width readable.
+    private static string Short(string fullName) =>
+        fullName.StartsWith("Benchmarks.", StringComparison.Ordinal) ? fullName[11..] : fullName;
+
+    private sealed record BenchmarkStats(double MeanNs, double StandardErrorNs, double? Allocated);
+    private sealed record Row(string Key, BenchmarkStats? Base, BenchmarkStats? Head);
+}

--- a/tests/Benchmarks/ScatterSeriesBench.cs
+++ b/tests/Benchmarks/ScatterSeriesBench.cs
@@ -1,0 +1,46 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Exporters.Json;
+using BenchmarkDotNet.Jobs;
+using LiveChartsCore.Defaults;
+using LiveChartsCore.SkiaSharpView;
+using LiveChartsCore.SkiaSharpView.SKCharts;
+
+namespace Benchmarks;
+
+[MemoryDiagnoser]
+[JsonExporterAttribute.Full]
+[SimpleJob(RuntimeMoniker.Net80, warmupCount: 3, iterationCount: 8)]
+public class ScatterSeriesBench
+{
+    private const int PointCount = 1_000;
+
+    private ObservablePoint[] _values = null!;
+    private SKCartesianChart _chart = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _values = new ObservablePoint[PointCount];
+        for (var i = 0; i < PointCount; i++)
+            _values[i] = new ObservablePoint(i, Math.Sin(i * 0.05) * 50 + 50);
+
+        _chart = new SKCartesianChart
+        {
+            Width = BenchHarness.Width,
+            Height = BenchHarness.Height,
+            Series = [new ScatterSeries<ObservablePoint> { Values = _values }]
+        };
+        BenchHarness.Render(_chart);
+    }
+
+    [Benchmark]
+    public void Reinvalidate() => BenchHarness.Render(_chart);
+
+    [Benchmark]
+    public void UpdateOnePoint()
+    {
+        var idx = PointCount / 2;
+        _values[idx].Y = (_values[idx].Y ?? 0) + 0.1;
+        BenchHarness.Render(_chart);
+    }
+}

--- a/tests/Benchmarks/StackedAreaSeriesBench.cs
+++ b/tests/Benchmarks/StackedAreaSeriesBench.cs
@@ -1,0 +1,55 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Exporters.Json;
+using BenchmarkDotNet.Jobs;
+using LiveChartsCore.Defaults;
+using LiveChartsCore.SkiaSharpView;
+using LiveChartsCore.SkiaSharpView.SKCharts;
+
+namespace Benchmarks;
+
+[MemoryDiagnoser]
+[JsonExporterAttribute.Full]
+[SimpleJob(RuntimeMoniker.Net80, warmupCount: 3, iterationCount: 8)]
+public class StackedAreaSeriesBench
+{
+    private const int PointCount = 1_000;
+
+    private ObservableValue[] _a = null!;
+    private ObservableValue[] _b = null!;
+    private SKCartesianChart _chart = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _a = new ObservableValue[PointCount];
+        _b = new ObservableValue[PointCount];
+        for (var i = 0; i < PointCount; i++)
+        {
+            _a[i] = new ObservableValue(Math.Sin(i * 0.05) * 30 + 40);
+            _b[i] = new ObservableValue(Math.Cos(i * 0.05) * 30 + 40);
+        }
+
+        _chart = new SKCartesianChart
+        {
+            Width = BenchHarness.Width,
+            Height = BenchHarness.Height,
+            Series =
+            [
+                new StackedAreaSeries<ObservableValue> { Values = _a },
+                new StackedAreaSeries<ObservableValue> { Values = _b }
+            ]
+        };
+        BenchHarness.Render(_chart);
+    }
+
+    [Benchmark]
+    public void Reinvalidate() => BenchHarness.Render(_chart);
+
+    [Benchmark]
+    public void UpdateOnePoint()
+    {
+        var idx = PointCount / 2;
+        _a[idx].Value = _a[idx].Value + 0.1;
+        BenchHarness.Render(_chart);
+    }
+}

--- a/tests/Benchmarks/StepLineSeriesBench.cs
+++ b/tests/Benchmarks/StepLineSeriesBench.cs
@@ -1,0 +1,53 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Exporters.Json;
+using BenchmarkDotNet.Jobs;
+using LiveChartsCore.Defaults;
+using LiveChartsCore.SkiaSharpView;
+using LiveChartsCore.SkiaSharpView.SKCharts;
+
+namespace Benchmarks;
+
+[MemoryDiagnoser]
+[JsonExporterAttribute.Full]
+[SimpleJob(RuntimeMoniker.Net80, warmupCount: 3, iterationCount: 8)]
+public class StepLineSeriesBench
+{
+    private const int PointCount = 1_000;
+
+    private ObservableValue[] _values = null!;
+    private SKCartesianChart _chart = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _values = new ObservableValue[PointCount];
+        for (var i = 0; i < PointCount; i++)
+            _values[i] = new ObservableValue(Math.Sin(i * 0.05) * 50 + 50);
+
+        _chart = new SKCartesianChart
+        {
+            Width = BenchHarness.Width,
+            Height = BenchHarness.Height,
+            Series = [new StepLineSeries<ObservableValue> { Values = _values }]
+        };
+        BenchHarness.Render(_chart);
+    }
+
+    [Benchmark]
+    public void Reinvalidate() => BenchHarness.Render(_chart);
+
+    [Benchmark]
+    public void UpdateOnePoint()
+    {
+        _values[PointCount / 2].Value = _values[PointCount / 2].Value + 0.1;
+        BenchHarness.Render(_chart);
+    }
+
+    [Benchmark]
+    public void ToggleNullGap()
+    {
+        var idx = PointCount / 2;
+        _values[idx].Value = _values[idx].Value is null ? 42.0 : null;
+        BenchHarness.Render(_chart);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a `tests/Benchmarks/` project (BenchmarkDotNet, net8.0) exercising the line-series invalidate path: cold first-render, warm re-invalidate, single-point update, and a toggle-null-gap shape (the case from #2132).
- A `compare <baseDir> <headDir> [out.md]` mode in the same binary reads two BenchmarkDotNet `*-report-full.json` exports and emits a markdown delta table, flagging any benchmark beyond ±10%.
- New `.github/workflows/benchmarks.yml` runs benchmarks twice per PR — once on PR HEAD, once on the base ref fetched into a `git worktree` — and posts the delta back as a PR comment via the existing `comment-progress` action. If the base ref does not have the benchmarks project yet (true on first merge), the baseline step is skipped gracefully.

## Design notes

- **No persistent baseline.** Base and head are both measured on the same runner in the same job. That's apples-to-apples but discards the results afterward — we don't get a time-series of master's numbers. Acceptable trade for a first pass; persistent tracking (e.g. pushing JSONs to a dedicated branch like `badges` does) can come later.
- **Report-only, not a gate.** 10% threshold is loose on purpose; GitHub-hosted runners are noisy on small benchmarks. Flip to blocking once the signal is trusted.
- **Runtime budget.** Roughly ~3 min benchmarks × 2 runs ≈ 6 min of benchmark work per PR; workflow is gated on paths so it only fires when `src/LiveChartsCore/**`, the SkiaSharp core, or the benchmarks themselves change.

Local smoke run on my machine (as a reference baseline):

| Benchmark | PointCount | Mean | Allocated |
|---|---:|---:|---:|
| `Reinvalidate` | 1000 | ~13.2 ms | 868 KB |
| `Reinvalidate` | 10000 | ~131.7 ms | 4.6 MB |

## Test plan

- [ ] Workflow fires on this PR and posts a delta comment (base is expected to have no Benchmarks project → baseline column will be `—`).
- [ ] Open a follow-up PR with a deliberate slowdown in `CoreLineSeries.Invalidate` to confirm 🔴 deltas show up.
- [ ] Confirm the workflow skips correctly on unrelated PRs (no path match).

🤖 Generated with [Claude Code](https://claude.com/claude-code)