### PR TITLE
ci(benchmarks): followup fixes to the PR-perf workflow

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -56,6 +56,7 @@ jobs:
           echo "has_base=true" >> "$GITHUB_OUTPUT"
 
       - name: Compare results
+        id: compare
         run: |
           dotnet run -c Release --project tests/Benchmarks/Benchmarks.csproj --no-build -- \
             compare bench-base-results bench-head-results delta.md
@@ -63,6 +64,7 @@ jobs:
           cat delta.md
 
       - name: Load delta into env
+        if: steps.compare.outputs.has_interesting == 'true'
         run: |
           {
             echo 'DELTA_TABLE<<BENCHEOF'
@@ -71,6 +73,7 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Post benchmark delta on PR
+        if: steps.compare.outputs.has_interesting == 'true'
         uses: ./.github/actions/comment-progress
         with:
           marker: perf-${{ github.event.pull_request.number }}
@@ -92,3 +95,9 @@ jobs:
             bench-base/
             delta.md
           retention-days: 30
+
+      - name: Fail job if a benchmark regressed by more than 10%
+        if: steps.compare.outputs.has_regression == 'true'
+        run: |
+          echo "::error::One or more benchmarks regressed by more than 10%. See the PR comment for details."
+          exit 1

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -77,7 +77,7 @@ jobs:
           content: |
             #### Benchmark delta
 
-            Base: `${{ github.base_ref }}` — Head: `${{ github.event.pull_request.head.sha }}`
+            Base: **${{ github.base_ref }}** — Head: **${{ github.event.pull_request.head.sha }}**
             Thresholds: 🔴 > +10% slower, 🟢 > -10% faster. Numbers on GitHub-hosted runners are noisy — treat double-digit deltas on non-trivial benchmarks as signal, single-digit as noise.
 
             ${{ env.DELTA_TABLE }}

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -15,8 +15,13 @@ on:
 
 jobs:
   benchmarks:
-    runs-on: ubuntu-24.04
+    # Windows to match the rest of the repo's SkiaSharp testing (test-core, test-snapshot)
+    # and avoid the libSkiaSharp native-dependency minefield on Linux.
+    runs-on: windows-2025
     timeout-minutes: 30
+    defaults:
+      run:
+        shell: bash
     steps:
       - name: Checkout PR HEAD
         uses: actions/checkout@v6.0.1

--- a/tests/Benchmarks/ResultsCompare.cs
+++ b/tests/Benchmarks/ResultsCompare.cs
@@ -99,7 +99,9 @@ internal static class ResultsCompare
             var delta = DeltaCell(@base, head);
             var baseAlloc = @base?.Allocated is null ? "—" : FormatBytes(@base.Allocated.Value);
             var headAlloc = head?.Allocated is null ? "—" : FormatBytes(head.Allocated.Value);
-            _ = sb.AppendLine(CultureInfo.InvariantCulture, $"| `{Short(row.Key)}` | {baseMs} | {headMs} | {delta} | {baseAlloc} | {headAlloc} |");
+            // No backticks around the name — comment-progress injects this table into a JS
+            // template literal and backticks would close it, producing a syntax error.
+            _ = sb.AppendLine(CultureInfo.InvariantCulture, $"| {Short(row.Key)} | {baseMs} | {headMs} | {delta} | {baseAlloc} | {headAlloc} |");
         }
         return sb.ToString();
     }

--- a/tests/Benchmarks/ResultsCompare.cs
+++ b/tests/Benchmarks/ResultsCompare.cs
@@ -37,15 +37,52 @@ internal static class ResultsCompare
 
         rows.Sort((a, b) => string.CompareOrdinal(a.Key, b.Key));
 
+        var (hasInteresting, hasRegression) = Classify(rows);
+
         var md = RenderMarkdown(rows);
         if (outPath is not null)
             File.WriteAllText(outPath, md);
         else
             Console.Write(md);
 
-        // Return 0 — we report but don't fail the build on regressions. Callers can wrap
-        // this in a gating step later once the signal is trusted.
+        // Expose flags to the workflow so it can decide whether to post a comment
+        // (any row outside ±Threshold) and whether to fail (any row slower by more
+        // than Threshold).
+        var githubOutput = Environment.GetEnvironmentVariable("GITHUB_OUTPUT");
+        if (!string.IsNullOrEmpty(githubOutput))
+        {
+            File.AppendAllLines(githubOutput,
+            [
+                "has_interesting=" + (hasInteresting ? "true" : "false"),
+                "has_regression=" + (hasRegression ? "true" : "false"),
+            ]);
+        }
+
+        Console.WriteLine($"has_interesting={hasInteresting}");
+        Console.WriteLine($"has_regression={hasRegression}");
+
         return 0;
+    }
+
+    private static (bool hasInteresting, bool hasRegression) Classify(List<Row> rows)
+    {
+        var interesting = false;
+        var regression = false;
+        foreach (var row in rows)
+        {
+            if (row.Base is null || row.Head is null) continue;
+            var pct = (row.Head.MeanNs - row.Base.MeanNs) / row.Base.MeanNs;
+            if (pct > Threshold)
+            {
+                regression = true;
+                interesting = true;
+            }
+            else if (pct < -Threshold)
+            {
+                interesting = true;
+            }
+        }
+        return (interesting, regression);
     }
 
     private static Dictionary<string, BenchmarkStats> LoadAll(string dir)

--- a/tests/Benchmarks/ResultsCompare.cs
+++ b/tests/Benchmarks/ResultsCompare.cs
@@ -60,11 +60,21 @@ internal static class ResultsCompare
             foreach (var b in benchmarks.EnumerateArray())
             {
                 var fullName = b.GetProperty("FullName").GetString() ?? "";
-                var stats = b.GetProperty("Statistics");
+
+                // If the benchmark errored out (worker crash, no results), Statistics
+                // is serialised as null. Skip it so one bad row doesn't kill the diff.
+                if (!b.TryGetProperty("Statistics", out var stats)
+                    || stats.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined)
+                {
+                    Console.Error.WriteLine($"warn: no statistics for '{fullName}', skipping.");
+                    continue;
+                }
+
                 var mean = stats.GetProperty("Mean").GetDouble();
                 var stdErr = stats.GetProperty("StandardError").GetDouble();
                 double? allocated = null;
                 if (b.TryGetProperty("Memory", out var mem)
+                    && mem.ValueKind is JsonValueKind.Object
                     && mem.TryGetProperty("BytesAllocatedPerOperation", out var alloc))
                 {
                     allocated = alloc.GetDouble();


### PR DESCRIPTION
## Summary

Three small followups to the benchmarks workflow from #2160. Each lands a fix that surfaced while getting the workflow green on a live PR.

- **Run on `windows-2025`, tolerate failed benchmarks in diff** — the Linux runner hit libSkiaSharp native-dep issues (workers exited 255). Switching to windows-2025 matches the rest of the repo's SkiaSharp test setup, and `ResultsCompare` now skips benchmarks with null `Statistics` instead of crashing.
- **Stop breaking `comment-progress` with backticks** — the composite action injects content into a JS template literal. Backticks in the delta table or the workflow body closed the literal and blew up with "Unexpected identifier 'master'". Removed both sources.
- **Gate the comment on signal, fail on regression** — `ResultsCompare` now emits `has_interesting` and `has_regression` to `\$GITHUB_OUTPUT`. The PR comment only posts when at least one row is outside ±10%, and the job fails when any row is >+10% slower — turning the workflow from report-only into a blocking gate.

No changes to series code; these all live in `.github/workflows/benchmarks.yml` and `tests/Benchmarks/ResultsCompare.cs`.

## Test plan

- [ ] PR builds cleanly on CI.
- [ ] Benchmarks workflow runs end-to-end on this PR.
- [ ] With no interesting deltas, no comment is posted (silent success).
- [ ] With deltas > ±10%, the comment is posted and — if any row is slower by >10% — the job fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)