### PR TITLE
ci: route benchmark comments through pr-comment, fix PR lookup

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -2,8 +2,6 @@ name: Benchmarks
 
 permissions:
   contents: read
-  pull-requests: write
-  issues: write
 
 on:
   pull_request:
@@ -63,27 +61,13 @@ jobs:
           echo "--- delta.md ---"
           cat delta.md
 
-      - name: Load delta into env
+      - name: Upload delta for PR comment
         if: steps.compare.outputs.has_interesting == 'true'
-        run: |
-          {
-            echo 'DELTA_TABLE<<BENCHEOF'
-            cat delta.md
-            echo 'BENCHEOF'
-          } >> "$GITHUB_ENV"
-
-      - name: Post benchmark delta on PR
-        if: steps.compare.outputs.has_interesting == 'true'
-        uses: ./.github/actions/comment-progress
+        uses: actions/upload-artifact@v6.0.0
         with:
-          marker: perf-${{ github.event.pull_request.number }}
-          content: |
-            #### Benchmark delta
-
-            Base: **${{ github.base_ref }}** — Head: **${{ github.event.pull_request.head.sha }}**
-            Thresholds: 🔴 > +10% slower, 🟢 > -10% faster. Numbers on GitHub-hosted runners are noisy — treat double-digit deltas on non-trivial benchmarks as signal, single-digit as noise.
-
-            ${{ env.DELTA_TABLE }}
+          name: benchmark-delta
+          path: delta.md
+          retention-days: 7
 
       - name: Upload raw artifacts
         if: always()

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -143,11 +143,11 @@ jobs:
               ``,
               packBlock,
               ``,
-              `#### Section 1: Core & Snapshot Tests ${emoji(sec1Ok ? 'success' : 'failure')}`,
+              `#### Core & Snapshot Tests ${emoji(sec1Ok ? 'success' : 'failure')}`,
               ``,
               `Core ${emoji(sec.testCore)} | Snapshot ${emoji(sec.testSnapshot)}`,
               ``,
-              `#### Section 2: UI Tests ${emoji(sec2Ok ? 'success' : 'failure')}`,
+              `#### UI Tests ${emoji(sec2Ok ? 'success' : 'failure')}`,
               ``,
               `Windows ${emoji(sec.testWindows)} | Linux ${emoji(sec.testLinux)} | Mac ${emoji(sec.testMac)} | Browser ${emoji(sec.testBrowser)} | Android ${emoji(sec.testAndroid)} | iOS ${emoji(sec.testIos)}`,
               coverageBlock,
@@ -216,15 +216,29 @@ jobs:
             }
 
             const delta = fs.readFileSync('benchmark-delta/delta.md', 'utf8');
+            // Each table row in delta.md carries a 🔴 / 🟢 prefix in the Δ column when
+            // the benchmark moved past the ±10% threshold. Count them for the summary.
+            const regressions = (delta.match(/🔴/g) || []).length;
+            const improvements = (delta.match(/🟢/g) || []).length;
+            const summary = regressions > 0
+              ? `❌ ${regressions} regression${regressions === 1 ? '' : 's'}, ${improvements} improvement${improvements === 1 ? '' : 's'}`
+              : improvements > 0
+                ? `✅ ${improvements} improvement${improvements === 1 ? '' : 's'}, no regressions`
+                : `➖ No significant changes`;
+
             const tag = `<!-- livecharts-bot:perf-pr-${prNumber} -->`;
             const body = [
               tag,
-              `#### Benchmark delta`,
+              `#### Benchmark delta — ${summary}`,
+              ``,
+              `<details><summary>Show details</summary>`,
               ``,
               `Base: **${baseRef || 'master'}** — Head: **${headSha}**`,
               `Thresholds: 🔴 > +10% slower, 🟢 > -10% faster. Numbers on GitHub-hosted runners are noisy — treat double-digit deltas on non-trivial benchmarks as signal, single-digit as noise.`,
               ``,
               delta,
+              ``,
+              `</details>`,
             ].join('\n');
 
             const comments = await github.paginate(github.rest.issues.listComments, {

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -1,12 +1,12 @@
 name: PR Comment
 
-# Posts a single consolidated comment to the PR after the LiveCharts workflow finishes.
+# Posts consolidated comments to the PR after upstream workflows finish.
 # This runs in the base repo's context (not the fork's), so the GITHUB_TOKEN has the
-# write permissions that the LiveCharts workflow itself does not get on fork PRs.
+# write permissions that the triggering workflows do not get on fork PRs.
 
 on:
   workflow_run:
-    workflows: [LiveCharts]
+    workflows: [LiveCharts, Benchmarks]
     types: [completed]
 
 permissions:
@@ -16,8 +16,10 @@ permissions:
   issues: write
 
 jobs:
-  comment:
-    if: github.event.workflow_run.event == 'pull_request'
+  livecharts:
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.name == 'LiveCharts'
     runs-on: ubuntu-24.04
     steps:
       - name: Download coverage summary
@@ -35,7 +37,8 @@ jobs:
         env:
           RUN_ID: ${{ github.event.workflow_run.id }}
           RUN_NUMBER: ${{ github.event.workflow_run.run_number }}
-          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          HEAD_OWNER: ${{ github.event.workflow_run.head_repository.owner.login }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         with:
           script: |
             const fs = require('fs');
@@ -43,19 +46,25 @@ jobs:
             const repo = context.repo.repo;
             const runId = Number(process.env.RUN_ID);
             const runNumber = process.env.RUN_NUMBER;
-            const headSha = process.env.HEAD_SHA;
+            const headOwner = process.env.HEAD_OWNER;
+            const headBranch = process.env.HEAD_BRANCH;
 
-            // Resolve the PR number from the head SHA. Works for both same-repo and
-            // fork PRs (workflow_run.pull_requests is empty for forks).
-            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-              owner, repo, commit_sha: headSha,
-            });
-            const pr = prs.find(p => p.state === 'open') || prs[0];
-            if (!pr) {
-              core.warning(`No PR found for head_sha ${headSha}; nothing to comment on.`);
+            // Resolve the PR by head ref. Reliable for both same-repo and fork PRs;
+            // listPullRequestsAssociatedWithCommit is not (it only indexes commits
+            // reachable from the default branch / merge commits).
+            const wrPrs = context.payload.workflow_run.pull_requests || [];
+            let prNumber = wrPrs.find(p => p.number)?.number;
+            if (!prNumber) {
+              const { data: prs } = await github.rest.pulls.list({
+                owner, repo, state: 'open',
+                head: `${headOwner}:${headBranch}`,
+              });
+              prNumber = prs[0]?.number;
+            }
+            if (!prNumber) {
+              core.warning(`No open PR found for ${headOwner}:${headBranch}; nothing to comment on.`);
               return;
             }
-            const prNumber = pr.number;
 
             // Pull all jobs of the upstream run and aggregate by base name. Matrix
             // jobs render as "name (matrix, values)" so we match the literal name
@@ -145,6 +154,79 @@ jobs:
             ].join('\n');
 
             // Find existing comment by marker; create or update.
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number: prNumber, per_page: 100,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(tag));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number: prNumber, body });
+            }
+
+  benchmarks:
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.name == 'Benchmarks'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Download benchmark delta
+        id: delta
+        continue-on-error: true
+        uses: actions/download-artifact@v7.0.0
+        with:
+          name: benchmark-delta
+          path: benchmark-delta
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and post comment
+        if: steps.delta.outcome == 'success'
+        uses: actions/github-script@v8
+        env:
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          HEAD_OWNER: ${{ github.event.workflow_run.head_repository.owner.login }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          BASE_REF: ${{ github.event.workflow_run.pull_requests[0].base.ref }}
+        with:
+          script: |
+            const fs = require('fs');
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const runId = Number(process.env.RUN_ID);
+            const headSha = process.env.HEAD_SHA;
+            const headOwner = process.env.HEAD_OWNER;
+            const headBranch = process.env.HEAD_BRANCH;
+
+            const wrPrs = context.payload.workflow_run.pull_requests || [];
+            let prNumber = wrPrs.find(p => p.number)?.number;
+            let baseRef = process.env.BASE_REF;
+            if (!prNumber) {
+              const { data: prs } = await github.rest.pulls.list({
+                owner, repo, state: 'open',
+                head: `${headOwner}:${headBranch}`,
+              });
+              prNumber = prs[0]?.number;
+              baseRef = baseRef || prs[0]?.base?.ref;
+            }
+            if (!prNumber) {
+              core.warning(`No open PR found for ${headOwner}:${headBranch}; nothing to comment on.`);
+              return;
+            }
+
+            const delta = fs.readFileSync('benchmark-delta/delta.md', 'utf8');
+            const tag = `<!-- livecharts-bot:perf-pr-${prNumber} -->`;
+            const body = [
+              tag,
+              `#### Benchmark delta`,
+              ``,
+              `Base: **${baseRef || 'master'}** — Head: **${headSha}**`,
+              `Thresholds: 🔴 > +10% slower, 🟢 > -10% faster. Numbers on GitHub-hosted runners are noisy — treat double-digit deltas on non-trivial benchmarks as signal, single-digit as noise.`,
+              ``,
+              delta,
+            ].join('\n');
+
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner, repo, issue_number: prNumber, per_page: 100,
             });


### PR DESCRIPTION
## Summary

- Move benchmark PR comment posting out of `benchmarks.yml` (which tried to use the removed `.github/actions/comment-progress` action — this is what was failing PR #2166 with `Can't find 'action.yml'`) into `pr-comment.yml`. The benchmarks job now just uploads `delta.md` as an artifact; `pr-comment.yml` listens to the `Benchmarks` workflow_run and posts/updates the comment from the base-repo context (so fork PRs work).
- Fix PR resolution in `pr-comment.yml`: replace `listPullRequestsAssociatedWithCommit` (which only indexes commits reachable from the default branch / merge commits and returned `[]` for PR #2166's open head SHA, silently no-op'ing the comment) with `pulls.list({ head: 'owner:branch', state: 'open' })`, keyed on `workflow_run.head_repository.owner.login` and `head_branch`. Falls back to `workflow_run.pull_requests` when present.
- Tighten `benchmarks.yml` permissions to `contents: read` since it no longer comments.

## Test plan

- [ ] Land this PR, then close/reopen #2166 to re-run LiveCharts and confirm the consolidated comment posts.
- [ ] On the next PR that touches `src/LiveChartsCore/**` or `tests/Benchmarks/**`, confirm `Benchmarks` runs to completion (no `action.yml` error) and the perf-delta comment appears with marker `<!-- livecharts-bot:perf-pr-N -->`.
- [ ] Confirm fork PRs get both comments (LiveCharts summary + benchmark delta when applicable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)